### PR TITLE
[DAPHNE-#79] Parse Matrix and Frame types

### DIFF
--- a/src/ir/daphneir/DaphneDialect.cpp
+++ b/src/ir/daphneir/DaphneDialect.cpp
@@ -59,8 +59,41 @@ mlir::Operation *mlir::daphne::DaphneDialect::materializeConstant(OpBuilder &bui
 
 mlir::Type mlir::daphne::DaphneDialect::parseType(mlir::DialectAsmParser &parser) const
 {
-    return mlir::IntegerType();
-};
+    llvm::StringRef keyword;
+    parser.parseKeyword(&keyword);
+    if (keyword == "Matrix") {
+        mlir::Type elementType;
+        llvm::SMLoc locElementType;
+        if (parser.parseLess() || parser.getCurrentLocation(&locElementType) || parser.parseType(elementType)
+            || parser.parseGreater()) {
+            return nullptr;
+        }
+
+        // TODO: check valid element types
+        return MatrixType::get(parser.getBuilder().getContext(), elementType);
+    }
+    else if (keyword == "Frame") {
+        if (parser.parseLess() || parser.parseLSquare()) {
+            return nullptr;
+        }
+        std::vector<mlir::Type> cts;
+        mlir::Type type;
+        do {
+            if (parser.parseType(type))
+                return nullptr;
+            cts.push_back(type);
+        }
+        while (succeeded(parser.parseOptionalComma()));
+        if (parser.parseRSquare() || parser.parseGreater()) {
+            return nullptr;
+        }
+        return FrameType::get(parser.getBuilder().getContext(), cts);
+    }
+    else {
+        parser.emitError(parser.getCurrentLocation()) << "Parsing failed, keyword `" << keyword << "` not recognized!";
+        return nullptr;
+    }
+}
 
 void mlir::daphne::DaphneDialect::printType(mlir::Type type,
                                             mlir::DialectAsmPrinter &os) const

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(run_tests
         run_tests.cpp
 
         api/cli/controlflow/ControlFlowTest.cpp
+		api/cli/parser/ParserTest.cpp
         api/cli/scoping/ScopingTest.cpp
         api/cli/Utils.cpp
         
@@ -45,7 +46,12 @@ add_executable(run_tests
 	runtime/local/kernels/SeqTest.cpp
 )
 add_dependencies(run_tests daphnec)
+
+get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 target_link_libraries(run_tests PRIVATE
+	${dialect_libs}
     DataStructures
+	DaphneDSLParser
+	MLIRDaphne
     ${OPENBLAS_LIBRARIES}
 )

--- a/test/api/cli/parser/ParserTest.cpp
+++ b/test/api/cli/parser/ParserTest.cpp
@@ -1,0 +1,81 @@
+/*
+ *  Copyright 2021 The DAPHNE Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <tags.h>
+
+#include <catch.hpp>
+
+#include <parser/daphnedsl/DaphneDSLParser.h>
+#include "ir/daphneir/Daphne.h"
+
+#include "mlir/Dialect/SCF/SCF.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/ExecutionEngine/OptUtils.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include <mlir/IR/MLIRContext.h>
+#include <mlir/InitAllDialects.h>
+#include <mlir/ExecutionEngine/ExecutionEngine.h>
+#include <mlir/IR/AsmState.h>
+#include <mlir/Parser.h>
+#include <mlir/Pass/PassManager.h>
+#include <mlir/Transforms/Passes.h>
+
+#include <iostream>
+#include <memory>
+
+#include <cstring>
+
+const std::string dirPath = "test/api/cli/parser/";
+
+/// This testcase tests both parsing of a simple DML file, while also checking if the printing and parsing of
+/// dialect operations and types is compatible.
+TEST_CASE("Parse file in DML, write and re-read as DaphneIR", TAG_PARSER)
+{
+    std::string daphneIrCode;
+    {
+        mlir::MLIRContext context;
+        context.getOrLoadDialect<mlir::daphne::DaphneDialect>();
+        context.getOrLoadDialect<mlir::StandardOpsDialect>();
+        context.getOrLoadDialect<mlir::scf::SCFDialect>();
+
+        mlir::OpBuilder builder(&context);
+        auto moduleOp = mlir::ModuleOp::create(builder.getUnknownLoc());
+        auto *body = moduleOp.getBody();
+        builder.setInsertionPoint(body, body->begin());
+
+        DaphneDSLParser parser;
+        parser.parseFile(builder, dirPath + "simple.daphne");
+
+        llvm::raw_string_ostream stream(daphneIrCode);
+        moduleOp.print(stream);
+    }
+
+    mlir::MLIRContext context;
+    context.getOrLoadDialect<mlir::daphne::DaphneDialect>();
+    context.getOrLoadDialect<mlir::StandardOpsDialect>();
+    context.getOrLoadDialect<mlir::scf::SCFDialect>();
+
+    mlir::OwningModuleRef module(mlir::parseSourceString(daphneIrCode, &context));
+    REQUIRE(module);
+
+    std::string newCode;
+    llvm::raw_string_ostream stream(newCode);
+    module->print(stream);
+
+    REQUIRE(daphneIrCode == newCode);
+}
+

--- a/test/api/cli/parser/simple.daphne
+++ b/test/api/cli/parser/simple.daphne
@@ -1,0 +1,8 @@
+x = 1;
+y = 2;
+print(x + y);
+
+m = rand(2, 3, 100.0, 200.0, 1.0, -1);
+print(m);
+print(m + m);
+print(t(m));

--- a/test/tags.h
+++ b/test/tags.h
@@ -26,6 +26,7 @@
 #define TAG_DATASTRUCTURES "[datastructures]"
 #define TAG_KERNELS "[kernels]"
 #define TAG_SCOPING "[scoping]"
+#define TAG_PARSER "[parser]"
 
 #endif //TEST_TAGS_H
 


### PR DESCRIPTION
In GitLab by @kev-inn on Jun 15, 2021, 15:30

Adds behaviour for parsing the daphne IR representation of matrix and frames in MLIR.

Closes #79.