### PR TITLE
Draft: Upgrading MLIR/LLVM and adapting our code to their breaking changes

### DIFF
--- a/src/compiler/lowering/RewriteToCallKernelOpPass.cpp
+++ b/src/compiler/lowering/RewriteToCallKernelOpPass.cpp
@@ -212,14 +212,14 @@ namespace
                                         rewriter.getContext(),
                                         op->getOperand(idx).getType()
                                 ),
-                                rewriter.getIndexAttr(len)
+                                rewriter.getI64IntegerAttr(len)
                         );
                         for(size_t k = 0; k < len; k++)
                             rewriter.create<daphne::StoreVariadicPackOp>(
                                     loc,
                                     cvpOp,
                                     op->getOperand(idx + k),
-                                    rewriter.getIndexAttr(k)
+                                    rewriter.getI64IntegerAttr(k)
                             );
                         newOperands.push_back(cvpOp);
                         newOperands.push_back(rewriter.create<daphne::ConstantOp>(

--- a/src/ir/daphneir/DaphneDialect.cpp
+++ b/src/ir/daphneir/DaphneDialect.cpp
@@ -19,6 +19,7 @@
 #include <ir/daphneir/DaphneOps.cpp.inc>
 #define GET_TYPEDEF_CLASSES
 #include <ir/daphneir/DaphneOpsTypes.cpp.inc>
+#include <ir/daphneir/DaphneOpsDialect.cpp.inc>
 
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"

--- a/src/ir/daphneir/DaphneOps.td
+++ b/src/ir/daphneir/DaphneOps.td
@@ -804,12 +804,12 @@ def Daphne_DestroyDaphneContextOp : Daphne_Op<"destroyDaphneContext"> {
 // ****************************************************************************
 
 def Daphne_CreateVariadicPackOp : Daphne_Op<"createVariadicPack"> {
-    let arguments = (ins IndexAttr:$numElements);
+    let arguments = (ins I64Attr:$numElements);
     let results = (outs VariadicPack:$res);
 }
 
 def Daphne_StoreVariadicPackOp : Daphne_Op<"storeVariadicPack"> {
-    let arguments = (ins VariadicPack:$pack, AnyType:$item, IndexAttr:$pos);
+    let arguments = (ins VariadicPack:$pack, AnyType:$item, I64Attr:$pos);
     let results = (outs); // no results
 }
 


### PR DESCRIPTION
In GitLab by @pdamme on Jul 31, 2021, 23:03

- I64IntegerAttr instead of IndexAttr in several places.
- Lowering to LLVM dialect: function calls must not have llvm.void as return type, otherwise it complains at runtime.
- Including the tablegen'erated DaphneOpsDialect.cpp.inc.
- Open problem: In the test cases for distributed operations (DistributedTest.cpp and WorkerTest.cpp), the LowerToLLVMPass fails (see details in the PR).