### PR TITLE
Improved tree-based broadcast

### DIFF
--- a/src/runtime/distributed/proto/worker.proto
+++ b/src/runtime/distributed/proto/worker.proto
@@ -24,9 +24,19 @@ import "data.proto";
 
 service Worker {
   rpc Store (Matrix) returns (StoredData) {}
+  rpc Broadcast (BroadcastedData) returns (BroadcastedStored) {}
   rpc Compute (Task) returns (ComputeResult) {}
   rpc Transfer (StoredData) returns (Matrix) {}
   rpc FreeMem (StoredData) returns (Empty) {}
+}
+
+message BroadcastedData {
+  Matrix matrix = 1;  
+  repeated string addresses = 2;
+}
+
+message BroadcastedStored {
+  repeated StoredData stored = 1;
 }
 
 message WorkData {

--- a/src/runtime/distributed/worker/CallData.h
+++ b/src/runtime/distributed/worker/CallData.h
@@ -61,6 +61,42 @@ private:
     };
     CallStatus status_; // The current serving state.
 };
+
+class BroadcastCallData final : public CallData
+{
+public:
+    BroadcastCallData(WorkerImpl *worker_, grpc::ServerCompletionQueue *cq)
+        : worker(worker_), service_(&worker_->service_), cq_(cq), responder_(&ctx_), status_(CREATE)
+    {
+        // Invoke the serving logic right away.
+        Proceed();
+    }
+
+    void Proceed() override;
+
+private:
+    WorkerImpl *worker;
+    distributed::Worker::AsyncService *service_;
+    grpc::ServerCompletionQueue *cq_;
+    grpc::ServerContext ctx_;
+
+    distributed::BroadcastedData data;
+
+    distributed::BroadcastedStored broadcastedStoredData;
+
+    grpc::ServerAsyncResponseWriter<distributed::BroadcastedStored> responder_;
+
+    // Let's implement a tiny state machine with the following states.
+    enum CallStatus
+    {
+        CREATE,
+        PROCESS,
+        FINISH
+    };
+    CallStatus status_; // The current serving state.
+};
+
+
 class ComputeCallData final : public CallData
 {
 public:

--- a/src/runtime/distributed/worker/WorkerImpl.h
+++ b/src/runtime/distributed/worker/WorkerImpl.h
@@ -40,6 +40,9 @@ public:
     grpc::Status Store(::grpc::ServerContext *context,
                          const ::distributed::Matrix *request,
                          ::distributed::StoredData *response) ;
+    grpc::Status Broadcast(::grpc::ServerContext *context,
+                         const ::distributed::BroadcastedData *request,
+                         ::distributed::BroadcastedStored *response) ;
     grpc::Status Compute(::grpc::ServerContext *context,
                          const ::distributed::Task *request,
                          ::distributed::ComputeResult *response) ;

--- a/src/runtime/local/kernels/DistributedCaller.h
+++ b/src/runtime/local/kernels/DistributedCaller.h
@@ -94,6 +94,40 @@ public:
         auto channel = GetOrCreateChannel(workerAddr);
         asyncStoreCall(channel, storedInfo, arg);
     }
+    
+     /**
+    * @brief Enqueues an asynchronous Broadcast call to be executed.     
+    * 
+    * @param  workerAddr An address (or channel) to make the call
+    * @param  StoredInfo An StoredInfo type returned when call response is ready
+    * @param  arg Argument passed to the asynchronous call
+    */
+    void asyncBroadcastCall(
+        std::shared_ptr<grpc::Channel> channel,
+        StoredInfo storedInfo,
+        const distributed::BroadcastedData arg
+        )
+    {        
+        AsyncClientCall *call = new AsyncClientCall;
+        call->storedInfo = storedInfo;
+
+        auto stub = distributed::Worker::NewStub(channel);
+        auto response_reader = stub->AsyncBroadcast(&call->context_, arg, &cq_);
+        
+        response_reader->Finish(&call->result, &call->status, (void*)call);
+        callCounter++;
+    }
+    void asyncBroadcastCall(
+        std::string workerAddr,
+        StoredInfo storedInfo,
+        const distributed::BroadcastedData arg
+        )
+    {
+        auto channel = GetOrCreateChannel(workerAddr);
+        asyncBroadcastCall(channel, storedInfo, arg);
+    }
+
+
     /**
     * @brief Enqueues an asynchronous Compute call to be executed.     
     * 


### PR DESCRIPTION
In GitLab by @aristotelis96 on Feb 11, 2022, 15:14

Improved broadcast from sequential to a tree-based approach.
- Coordinator/Local runtime sends a message to two child workers along with a list of additional workers
- Child workers use the received list of workers to further broadcast the message to their "child" workers