### PR TITLE
[DAPHNE-#216] ANTLR not found while building

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -77,6 +77,9 @@ initPwd=$(pwd)
 thirdpartyPath=$initPwd/thirdparty
 llvmCommitFilePath=$thirdpartyPath/llvm-last-built-commit.txt
 
+# a hotfix, to solve issue #216 @todo investigate possible side effects
+installLibDir=lib
+
 #******************************************************************************
 # Parse arguments
 #******************************************************************************
@@ -153,7 +156,7 @@ then
     mkdir -p build
     mkdir -p run
     cd build
-    cmake .. -G Ninja  -DANTLR_JAR_LOCATION=../$antlrJarName -DANTLR4_INSTALL=ON -DCMAKE_INSTALL_PREFIX=../run/usr/local
+    cmake .. -G Ninja  -DANTLR_JAR_LOCATION=../$antlrJarName -DANTLR4_INSTALL=ON -DCMAKE_INSTALL_PREFIX=../run/usr/local -DCMAKE_INSTALL_LIBDIR=$installLibDir
     cmake --build . --target install
 fi
 cd $pwdBeforeAntlr
@@ -287,7 +290,8 @@ cmake -G Ninja .. \
     -DANTLR4_RUNTIME_DIR=$thirdpartyPath/$antlrDirName/$antlrCppRuntimeDirName \
     -DANTLR4_JAR_LOCATION=$thirdpartyPath/$antlrDirName/$antlrJarName \
     -DOPENBLAS_INST_DIR=$thirdpartyPath/$openBlasDirName/$openBlasInstDirName \
-    -DCMAKE_PREFIX_PATH="$grpcInstDir"
+    -DCMAKE_PREFIX_PATH="$grpcInstDir" \
+    -DCMAKE_INSTALL_LIBDIR=$installLibDir
 # optional cmake flags (to be added to the command above):
 # -DUSE_CUDA=ON
 # -DCMAKE_BUILD_TYPE=Debug


### PR DESCRIPTION
In GitLab by @EricMier on Mar 10, 2022, 08:46

- Fixed incorrect path generation through manually setting CMAKE_INSTALL_LIBDIR for ANTLR and Daphne build
- Closes #216