### PR TITLE
[DAPHNE-#216] ANTLR not found while building

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -149,6 +149,9 @@ then
     mkdir --parents $antlrCppRuntimeDirName
     unzip $antlrCppRuntimeZipName -d $antlrCppRuntimeDirName
     cd $antlrCppRuntimeDirName
+    # Github disabled the unauthenticated git:// protocol, patch antlr4 to use https://
+    # until we upgrade to antlr4-4.9.3+
+    sed -i 's#git://github.com#https://github.com#' runtime/CMakeLists.txt
     rm -rf ./build
     mkdir -p build
     mkdir -p run


### PR DESCRIPTION
In GitLab by @psomas on Mar 31, 2022, 10:50

antlr4-4.9.2 uses the unauthenticated git:// protocol to clone a Github repo for a dependency. Unauthenticated git:// isn't supported by Github anymore. This leads to an antlr4 (and subsequently daphne) build failure. Patch antlr4 to use https:// until we upgrade to antlr4-4.9.3+, which has switched to https://.

Closes #216