### PR TITLE
[DAPHNE-191] Refactor CUDA buffer mgmt (aka introducing Object Meta D…

### DIFF
--- a/src/api/cli/DaphneUserConfig.h
+++ b/src/api/cli/DaphneUserConfig.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <runtime/local/vectorized/LoadPartitioning.h>
+#include <runtime/local/vectorized/LoadPartitioningDefs.h>
 
 #include <vector>
 #include <string>

--- a/src/runtime/local/context/CUDAContext.cpp
+++ b/src/runtime/local/context/CUDAContext.cpp
@@ -16,6 +16,8 @@
 
 #include "runtime/local/context/CUDAContext.h"
 
+size_t CUDAContext::alloc_count = 0;
+
 void CUDAContext::destroy() {
 #ifndef NDEBUG
     std::cerr << "Destroying CUDA context..." << std::endl;
@@ -48,7 +50,7 @@ void CUDAContext::init() {
     float mem_usage = 0.9f;
     mem_budget = total * mem_usage;
 #ifndef NDEBUG
-    std::cout << "Using CUDA device " << device_id << ": " << device_properties.name  << "\nAvailable mem: "
+    std::cerr << "Using CUDA device " << device_id << ": " << device_properties.name  << "\nAvailable mem: "
             << available << " Total mem: " << total << " using " << mem_usage * 100 << "% thereof -> " << mem_budget
             << std::endl;
 #endif
@@ -110,9 +112,7 @@ void* CUDAContext::getCUDNNWorkspace(size_t size) {
 }
 
 std::unique_ptr<IContext> CUDAContext::createCudaContext(int device_id) {
-    //#ifndef NDEBUG
-//    std::cout << "creating CUDA context..." << std::endl;
-//#endif
+
     int device_count = -1;
     CHECK_CUDART(cudaGetDeviceCount(&device_count));
 
@@ -129,5 +129,22 @@ std::unique_ptr<IContext> CUDAContext::createCudaContext(int device_id) {
     auto ctx = std::unique_ptr<CUDAContext>(new CUDAContext(device_id));
     ctx->init();
     return ctx;
+}
+
+std::shared_ptr<std::byte> CUDAContext::malloc(size_t size, bool zero, size_t& id) {
+    id = alloc_count++;
+    std::byte* dev_ptr;
+    CHECK_CUDART(cudaMalloc(reinterpret_cast<void **>(&dev_ptr), size));
+    allocations.emplace(id, std::shared_ptr<std::byte>(dev_ptr, CudaDeleter<std::byte>()));
+
+    if(zero)
+        CHECK_CUDART(cudaMemset(dev_ptr, 0, size));
+    return allocations.at(id);
+}
+
+void CUDAContext::free(size_t id) {
+    // ToDo: handle reuse
+    CHECK_CUDART(cudaFree(allocations.at(id).get()));
+    allocations.erase(id);
 }
 

--- a/src/runtime/local/context/DaphneContext.h
+++ b/src/runtime/local/context/DaphneContext.h
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 
-#ifndef SRC_RUNTIME_LOCAL_CONTEXT_DAPHNECONTEXT_H
-#define SRC_RUNTIME_LOCAL_CONTEXT_DAPHNECONTEXT_H
-
 #pragma once
 
 #include <api/cli/DaphneUserConfig.h>
@@ -26,10 +23,6 @@
 #include <memory>
 
 #include "IContext.h"
-
-#ifdef USE_CUDA
-    #include "CUDAContext.h"
-#endif
 
 // This macro is intended to be used in kernel function signatures, such that
 // we can change the ubiquitous DaphneContext parameter in a single place, if
@@ -77,8 +70,8 @@ struct DaphneContext {
 
 #ifdef USE_CUDA
     // ToDo: in a multi device setting this should use a find call instead of a direct [] access
-    [[nodiscard]] CUDAContext* getCUDAContext(int dev_id) const {
-        return dynamic_cast<CUDAContext*>(cuda_contexts[dev_id].get());
+    [[nodiscard]] IContext* getCUDAContext(size_t dev_id) const {
+        return cuda_contexts[dev_id].get();
     }
 #endif
 
@@ -86,5 +79,3 @@ struct DaphneContext {
     
     [[maybe_unused]] [[nodiscard]] DaphneUserConfig getUserConfig() const { return config; }
 };
-
-#endif //SRC_RUNTIME_LOCAL_CONTEXT_DAPHNECONTEXT_H

--- a/src/runtime/local/context/IContext.h
+++ b/src/runtime/local/context/IContext.h
@@ -1,11 +1,6 @@
-#ifndef DAPHNE_PROTOTYPE_ICONTEXT_H
-#define DAPHNE_PROTOTYPE_ICONTEXT_H
-
 #pragma once
 
 class IContext {
 public:
     virtual void destroy() = 0;
 };
-
-#endif //DAPHNE_PROTOTYPE_ICONTEXT_H

--- a/src/runtime/local/datastructures/AllocationDescriptorCUDA.h
+++ b/src/runtime/local/datastructures/AllocationDescriptorCUDA.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2022 The DAPHNE Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include "DataPlacement.h"
+#include "runtime/local/context/CUDAContext.h"
+
+class AllocationDescriptorCUDA : public IAllocationDescriptor {
+    ALLOCATION_TYPE type = ALLOCATION_TYPE::GPU_CUDA;
+    uint32_t device_id{};
+    DaphneContext* dctx{};
+    std::shared_ptr<std::byte> data{};
+    size_t alloc_id{};
+
+public:
+    AllocationDescriptorCUDA() = delete;
+
+    AllocationDescriptorCUDA(DaphneContext* ctx, uint32_t device_id) : device_id(device_id), dctx(ctx) { }
+
+    ~AllocationDescriptorCUDA() override {
+        // ToDo: for now we free if this is the last context-external ref to the buffer
+        if(data.use_count() == 2) {
+            CUDAContext::get(dctx, device_id)->free(alloc_id);
+        }
+    }
+
+    [[nodiscard]] ALLOCATION_TYPE getType() const override { return type; }
+
+    [[nodiscard]] uint32_t getLocation() const { return device_id; }
+
+    void createAllocation(size_t size, bool zero) override {
+        auto ctx = CUDAContext::get(dctx, device_id);
+        data = ctx->malloc(size, zero, alloc_id);
+    }
+
+    std::shared_ptr<std::byte> getData() override { return data; }
+
+    [[nodiscard]] std::unique_ptr<IAllocationDescriptor> clone() const override {
+        return std::make_unique<AllocationDescriptorCUDA>(*this);
+    }
+
+    void transferTo(std::byte* src, size_t size) override {
+        CHECK_CUDART(cudaMemcpy(data.get(), src, size, cudaMemcpyHostToDevice));
+    }
+    void transferFrom(std::byte* dst, size_t size) override {
+        CHECK_CUDART(cudaMemcpy(dst, data.get(), size, cudaMemcpyDeviceToHost));
+    };
+
+    bool operator==(const IAllocationDescriptor* other) const override {
+        if(getType() == other->getType())
+            return(getLocation() == dynamic_cast<const AllocationDescriptorCUDA *>(other)->getLocation());
+        return false;
+    }
+};

--- a/src/runtime/local/datastructures/AllocationDescriptorHost.h
+++ b/src/runtime/local/datastructures/AllocationDescriptorHost.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 The DAPHNE Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "DataPlacement.h"
+#include <memory>
+
+class AllocationDescriptorHost : public IAllocationDescriptor {
+    ALLOCATION_TYPE type = ALLOCATION_TYPE::HOST;
+    std::shared_ptr<std::byte> data{};
+
+public:
+    ~AllocationDescriptorHost() override = default;
+    [[nodiscard]] ALLOCATION_TYPE getType() const override { return type; }
+    void createAllocation(size_t size, bool zero) override { }
+    std::shared_ptr<std::byte> getData() override { return data; }
+    void transferTo(std::byte* src, size_t size) override { }
+    void transferFrom(std::byte* dst, size_t size) override {}
+    [[nodiscard]] std::unique_ptr<IAllocationDescriptor> clone() const override {
+        return std::make_unique<AllocationDescriptorHost>(*this);
+    }
+    bool operator==(const IAllocationDescriptor* other) const override { return (getType() == other->getType()); }
+};

--- a/src/runtime/local/datastructures/CMakeLists.txt
+++ b/src/runtime/local/datastructures/CMakeLists.txt
@@ -13,9 +13,16 @@
 # limitations under the License.
 
 add_library(DataStructures
+        AllocationDescriptorHost.h
+        AllocationDescriptorCUDA.h
+        DataPlacement.h
+        DataPlacement.cpp
+        DenseMatrix.cpp
         Frame.cpp
-        ValueTypeUtils.cpp
-        DenseMatrix.cpp)
+        IAllocationDescriptor.h
+        MetaDataObject.h
+        MetaDataObject.cpp
+        ValueTypeUtils.cpp)
 
 if(USE_CUDA AND CMAKE_CUDA_COMPILER)
     target_include_directories(DataStructures PUBLIC ${CUDAToolkit_INCLUDE_DIRS})

--- a/src/runtime/local/datastructures/DataPlacement.cpp
+++ b/src/runtime/local/datastructures/DataPlacement.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The DAPHNE Consortium
+ * Copyright 2022 The DAPHNE Consortium
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,15 +14,6 @@
  * limitations under the License.
  */
 
-#pragma once
+#include "DataPlacement.h"
 
-#include "runtime/local/context/DaphneContext.h"
-#include "runtime/local/datastructures/DataObjectFactory.h"
-#include "runtime/local/datastructures/DenseMatrix.h"
-
-namespace CUDA::Affine {
-    template<typename DTRes, typename DTArg>
-    struct Forward {
-        static void apply(DTRes *&res, const DTArg *data, const DTArg *weights, const DTArg *bias, DCTX(dctx));
-    };
-}
+std::atomic_size_t DataPlacement::instance_count = 0;

--- a/src/runtime/local/datastructures/DataPlacement.h
+++ b/src/runtime/local/datastructures/DataPlacement.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 The DAPHNE Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "IAllocationDescriptor.h"
+#include "Range.h"
+#include <runtime/local/context/DaphneContext.h>
+
+#include <atomic>
+
+/**
+ * The DataPlacement struct binds an allocation descriptor to a range description and stores an ID of
+ * an instantiated object.
+ */
+struct DataPlacement {
+    size_t dp_id;
+
+    // used to generate object IDs
+    static std::atomic_size_t instance_count;
+    
+    std::unique_ptr<IAllocationDescriptor> allocation{};
+
+    std::unique_ptr<Range> range{};
+
+    DataPlacement() = delete;
+    DataPlacement(std::unique_ptr<IAllocationDescriptor> _a, std::unique_ptr<Range> _r) : dp_id(instance_count++),
+            allocation(std::move(_a)), range(std::move(_r)) { }
+};

--- a/src/runtime/local/datastructures/DenseMatrix.cpp
+++ b/src/runtime/local/datastructures/DenseMatrix.cpp
@@ -195,13 +195,7 @@ size_t DenseMatrix<ValueType>::bufferSize() {
     return this->getNumItems() * sizeof(ValueType);
 }
 
-template<typename ValueType>
-DenseMatrix<ValueType>* DenseMatrix<ValueType>::vectorTranspose() const {
-    assert((this->numRows == 1 || this->numCols == 1) && "no-op transpose for vectors only");
-    auto transposed = DataObjectFactory::create<DenseMatrix<ValueType>>(this, 0, this->getNumRows(), 0, this->getNumCols());
-    std::swap(transposed->numRows, transposed->numCols);
-    return transposed;
-}
+
 
 
 
@@ -281,14 +275,6 @@ void DenseMatrix<const char*>::alloc_shared_strings(std::shared_ptr<CharBuf> src
 
 size_t DenseMatrix<const char*>::bufferSize() {
     return this->getNumItems() * sizeof(const char*);
-}
-
-DenseMatrix<const char*>* DenseMatrix<const char*>::vectorTranspose() const {
-    assert((this->numRows == 1 || this->numCols == 1) && "no-op transpose for vectors only");
-
-    auto transposed = DataObjectFactory::create<DenseMatrix<const char*>>(this->getNumCols(), this->getNumRows(),
-                                                                        this->getValuesSharedPtr());
-    return transposed;
 }
 
 // explicitly instantiate to satisfy linker

--- a/src/runtime/local/datastructures/DenseMatrix.h
+++ b/src/runtime/local/datastructures/DenseMatrix.h
@@ -268,8 +268,6 @@ public:
     size_t bufferSize();
 
     [[nodiscard]] size_t bufferSize() const { return const_cast<DenseMatrix*>(this)->bufferSize(); }
-    
-    DenseMatrix<ValueType>* vectorTranspose() const;
 };
 
 template <typename ValueType>
@@ -547,8 +545,6 @@ public:
     size_t bufferSize() const { return const_cast<DenseMatrix*>(this)->bufferSize(); }
 
     float printBufferSize() const { return static_cast<float>(bufferSize()) / (1048576); }
-
-    DenseMatrix<const char*>* vectorTranspose() const;
 
     bool operator==(const DenseMatrix<const char*> &M) const {
         assert(getNumRows() != 0 && getNumCols() != 0 && strBuf && values && "Invalid matrix");

--- a/src/runtime/local/datastructures/DenseMatrix.h
+++ b/src/runtime/local/datastructures/DenseMatrix.h
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#ifndef SRC_RUNTIME_LOCAL_DATASTRUCTURES_DENSEMATRIX_H
-#define SRC_RUNTIME_LOCAL_DATASTRUCTURES_DENSEMATRIX_H
+#pragma once
 
+#include <runtime/local/datastructures/AllocationDescriptorHost.h>
 #include <runtime/local/datastructures/DataObjectFactory.h>
 #include <runtime/local/datastructures/Matrix.h>
 #include <runtime/local/datastructures/ValueTypeUtils.h>
@@ -27,8 +27,6 @@
 #include <cassert>
 #include <cstddef>
 #include <cstring>
-#include <stdexcept>
-// TODO DenseMatrix should not be concerned about CUDA.
 
 /**
  * @brief A dense matrix implementation.
@@ -52,14 +50,7 @@ class DenseMatrix : public Matrix<ValueType>
     
     size_t rowSkip;
     std::shared_ptr<ValueType[]> values{};
-    std::shared_ptr<ValueType> cuda_ptr{};
-    uint32_t deleted = 0;
-
-    mutable bool cuda_dirty = false;
-    mutable bool host_dirty = false;
-    mutable bool cuda_buffer_current = false;
-    mutable bool host_buffer_current = false;
-
+    
     size_t lastAppendedRowIdx;
     size_t lastAppendedColIdx;
     
@@ -71,32 +62,26 @@ class DenseMatrix : public Matrix<ValueType>
     friend void DataObjectFactory::destroy(const DataType * obj);
 
     /**
-     * @brief Creates a `DenseMatrix` and allocate
-     * s enough memory for the
-     * specified maximum size in the `values` array.
+     * @brief Creates a `DenseMatrix` and allocates enough memory for the specified maximum size in the `values` array.
      *
      * @param maxNumRows The maximum number of rows.
      * @param numCols The exact number of columns.
-     * @param zero Whether the allocated memory of the `values` array shall be
-     * initialized to zeros (`true`), or be left uninitialized (`false`).
+     * @param zero Whether the allocated memory of the `values` array shall be initialized to zeros (`true`), or be left
+     * uninitialized (`false`).
      */
-    DenseMatrix(size_t maxNumRows, size_t numCols, bool zero, ALLOCATION_TYPE type = ALLOCATION_TYPE::HOST_ALLOC);
-    
+    DenseMatrix(size_t maxNumRows, size_t numCols, bool zero, IAllocationDescriptor* allocInfo = nullptr);
+
     /**
-     * @brief Creates a `DenseMatrix` around an existing array of values
-     * without copying the data.
+     * @brief Creates a `DenseMatrix` around an existing array of values without copying the data.
      *
      * @param numRows The exact number of rows.
      * @param numCols The exact number of columns.
      * @param values A `std::shared_ptr` to an existing array of values.
      */
-    DenseMatrix(size_t numRows, size_t numCols, std::shared_ptr<ValueType[]>& values
-                , std::shared_ptr<ValueType> cuda_ptr_ = nullptr) : Matrix<ValueType>(numRows, numCols),
-                rowSkip(numCols), values(values), cuda_ptr(cuda_ptr_), lastAppendedRowIdx(0), lastAppendedColIdx(0) { }
+    DenseMatrix(size_t numRows, size_t numCols, std::shared_ptr<ValueType[]>& values);
 
     /**
-     * @brief Creates a `DenseMatrix` around a sub-matrix of another
-     * `DenseMatrix` without copying the data.
+     * @brief Creates a `DenseMatrix` around a sub-matrix of another `DenseMatrix` without copying the data.
      *
      * @param src The other dense matrix.
      * @param rowLowerIncl Inclusive lower bound for the range of rows to extract.
@@ -104,7 +89,8 @@ class DenseMatrix : public Matrix<ValueType>
      * @param colLowerIncl Inclusive lower bound for the range of columns to extract.
      * @param colUpperExcl Exclusive upper bound for the range of columns to extract.
      */
-    DenseMatrix(const DenseMatrix<ValueType> * src, size_t rowLowerIncl, size_t rowUpperExcl, size_t colLowerIncl, size_t colUpperExcl);
+    DenseMatrix(const DenseMatrix<ValueType> * src, size_t rowLowerIncl, size_t rowUpperExcl, size_t colLowerIncl,
+            size_t colUpperExcl);
 
     ~DenseMatrix() override = default;
 
@@ -140,7 +126,32 @@ class DenseMatrix : public Matrix<ValueType>
 
     void alloc_shared_values(std::shared_ptr<ValueType[]> src = nullptr, size_t offset = 0);
 
-    void alloc_shared_cuda_buffer(std::shared_ptr<ValueType> src = nullptr, size_t offset = 0);
+
+    /**
+     * @brief The getValuesInternal method fetches a pointer to an allocation of values. Optionally a sub range
+     * can be specified.
+     *
+     * This method is called by the public getValues() methods either in const or non-const fashion. The const version
+     * returns a data pointer that is meant to be read-only. Read only access updates the list of up-to-date
+     * allocations (the latest_versions "list"). This way several copies of the data in various allocations can be
+     * kept without invalidating their copy. If the read write version of getValues() is used, the latest_versions
+     * list is cleared because a write to an allocation is assumed, which renders the other allocations of the
+     * same data out of sync.
+     *
+     * @param alloc_desc An instance of an IAllocationDescriptor derived class that is used to specify what type of
+     * allocation is requested. If no allocation descriptor is provided, a host allocation (plain main memory) is
+     * assumed by default.
+     *
+     * @param range An optional range describing which rows and columns of a matrix-like structure are requested.
+     * By default this is null and means all rows and columns.
+     * @return A tuple of three values is returned:
+     *         1: bool - is the returend allocation in the latest_versions list
+     *         2: size_t - the ID of the data placement (a structure relating an allocation to a range)
+     *         3: ValueType* - the pointer to the actual data
+     */
+
+    auto getValuesInternal(const IAllocationDescriptor* alloc_desc = nullptr, const Range* range = nullptr)
+    -> std::tuple<bool, size_t, ValueType*>;
 
 public:
 
@@ -154,37 +165,45 @@ public:
         return rowSkip;
     }
 
-    const ValueType * getValues() const
+    /**
+     * @brief Fetch a pointer to the data held by this structure meant for read-only access.
+     *
+     * A difference is made between read-only and read-write access because with read-only access, the data
+     * can be cached in several memory spaces at the same time.
+     *
+     * @param alloc_desc An allocation descriptor describing which type of memory is requested (e.g. main memory in
+     * the current system, memory in an accelerator card or memory in another host)
+     *
+     * @param range A Range object describing optionally requesting a sub range of a data structure.
+     * @return A pointer to the data in the requested memory space
+     */
+    const ValueType* getValues(const IAllocationDescriptor* alloc_desc = nullptr, const Range* range = nullptr) const
     {
-        if(!values)
-            const_cast<DenseMatrix*>(this)->alloc_shared_values();
-#ifdef USE_CUDA
-        if (cuda_dirty || (!host_buffer_current && cuda_buffer_current)) {
-            cuda2host();
-        }
-        host_buffer_current = true;
-#endif
-        return values.get();
+        auto[isLatest, id, ptr] = const_cast<DenseMatrix<ValueType> *>(this)->getValuesInternal(alloc_desc, range);
+        if(!isLatest)
+            this->mdo.addLatest(id);
+        return ptr;
     }
 
-    ValueType * getValues()
-    {
-        if(!values)
-            alloc_shared_values();
-
-#ifdef USE_CUDA
-        if (cuda_dirty || (!host_buffer_current && cuda_buffer_current)) {
-            cuda2host();
-        }
-        cuda_buffer_current = false;
-        host_buffer_current = true;
-        host_dirty = true;
-#endif
-        return values.get();
+    /**
+     * @brief Fetch a pointer to the data held by this structure meant for read-write access.
+     *
+     * A difference is made between read-only and read-write access. With read-write access, all copies in various
+     * memory spaces will be invalidated because data is assumed to change.
+     *
+     * @param alloc_desc An allocation descriptor describing which type of memory is requested (e.g. main memory in
+     * the current system, memory in an accelerator card or memory in another host)
+     *
+     * @param range A Range object describing optionally requesting a sub range of a data structure.
+     * @return A pointer to the data in the requested memory space
+     */
+    ValueType* getValues(IAllocationDescriptor* alloc_desc = nullptr, const Range* range = nullptr) {
+        auto [isLatest, id, ptr] = const_cast<DenseMatrix<ValueType>*>(this)->getValuesInternal(alloc_desc, range);
+        if(!isLatest)
+            this->mdo.setLatest(id);
+        return ptr;
     }
-
-
-
+    
     std::shared_ptr<ValueType[]> getValuesSharedPtr() const {
         return values;
     }
@@ -220,13 +239,9 @@ public:
     }
 
     void print(std::ostream & os) const override {
-        os << "DenseMatrix(" << numRows << 'x' << numCols << ", "
-                << ValueTypeUtils::cppNameFor<ValueType> << ')' << std::endl;
-#ifdef USE_CUDA
-        if ((cuda_ptr && cuda_dirty) || !values) {
-              cuda2host();
-        }
-#endif
+        os << "DenseMatrix(" << numRows << 'x' << numCols << ", " << ValueTypeUtils::cppNameFor<ValueType> << ')'
+                << std::endl;
+
         for (size_t r = 0; r < numRows; r++) {
             for (size_t c = 0; c < numCols; c++) {
                 printValue(os, get(r, c));
@@ -249,85 +264,12 @@ public:
         return DataObjectFactory::create<DenseMatrix<ValueType>>(this, rl, ru, cl, cu);
     }
 
+    // convenience functions
     size_t bufferSize();
 
-    size_t bufferSize() const { return const_cast<DenseMatrix*>(this)->bufferSize(); }
-
-    float printBufferSize() const { return static_cast<float>(bufferSize()) / (1048576); }
-
+    [[nodiscard]] size_t bufferSize() const { return const_cast<DenseMatrix*>(this)->bufferSize(); }
+    
     DenseMatrix<ValueType>* vectorTranspose() const;
-
-
-#ifdef USE_CUDA
-    const ValueType* getValuesCUDA() const {
-        if(!cuda_ptr)
-            const_cast<DenseMatrix*>(this)->alloc_shared_cuda_buffer();
-
-        if(host_dirty || (!cuda_buffer_current && host_buffer_current)) {
-            host2cuda();
-        }
-        cuda_buffer_current = true;
-        return cuda_ptr.get();
-    }
-
-    ValueType* getValuesCUDA() {
-        if(!cuda_ptr)
-            alloc_shared_cuda_buffer();
-
-        if(host_dirty || (!cuda_buffer_current && host_buffer_current)) {
-            host2cuda();
-        }
-        cuda_dirty = true;
-        cuda_buffer_current = true;
-        host_buffer_current = false;
-        return cuda_ptr.get();
-    }
-
-    [[maybe_unused]] bool isBufferDirty(ALLOCATION_TYPE type) const {
-        switch(type) {
-            case ALLOCATION_TYPE::CUDA_ALLOC:
-                return cuda_dirty;
-            case ALLOCATION_TYPE::HOST_ALLOC:
-            default:
-                return host_dirty;
-        }
-    }
-
-    [[maybe_unused]] bool isBufferCurrent(ALLOCATION_TYPE type) const {
-        switch(type) {
-            case ALLOCATION_TYPE::CUDA_ALLOC:
-                return cuda_buffer_current;
-            case ALLOCATION_TYPE::HOST_ALLOC:
-            default:
-                return host_buffer_current;
-        }
-    }
-
-    std::shared_ptr<ValueType> getCUDAValuesSharedPtr() const {
-        return cuda_ptr;
-    }
-
-    [[maybe_unused]] void printCUDAValuesSharedPtrUseCount() const {
-        std::ios state(nullptr);
-        state.copyfmt(std::cout);
-        std::cout << "CudaPtr " << cuda_ptr.get() << " use_count: " << cuda_ptr.use_count() << std::endl;
-        std::cout.copyfmt(state);
-    }
-
-    void host2cuda();
-    void cuda2host();
-
-    void host2cuda() const {
-        const_cast<DenseMatrix*>(this)->host2cuda();
-    }
-    void cuda2host() const {
-        const_cast<DenseMatrix*>(this)->cuda2host();
-    }
-#else
-    std::shared_ptr<ValueType> getCUDAValuesSharedPtr() const {
-        return nullptr;
-    }
-#endif
 };
 
 template <typename ValueType>
@@ -410,7 +352,7 @@ class DenseMatrix<const char*> : public Matrix<const char*>
     template<class DataType>
     friend void DataObjectFactory::destroy(const DataType * obj);
 
-    DenseMatrix(size_t maxNumRows, size_t numCols, bool zero, size_t strBufCapacity = 1024, ALLOCATION_TYPE type = ALLOCATION_TYPE::HOST_ALLOC);
+    DenseMatrix(size_t maxNumRows, size_t numCols, bool zero, size_t strBufCapacity = 1024, ALLOCATION_TYPE type = ALLOCATION_TYPE::HOST);
     
     DenseMatrix(size_t numRows, size_t numCols, std::shared_ptr<const char*[]>& strings, size_t strBufCapacity = 1024, std::shared_ptr<const char*> cuda_ptr_ = nullptr);
 
@@ -537,7 +479,7 @@ public:
 
         if(diff){
             for(size_t offset = currentPos + 1; offset < getStrBuf()->numCells; offset++)
-                vals[offset] += diff; 
+                vals[offset] += diff;
         }
 
         strBuf->currentTop += diff;
@@ -617,4 +559,3 @@ public:
         return true;
   }
 };
-#endif //SRC_RUNTIME_LOCAL_DATASTRUCTURES_DENSEMATRIX_H

--- a/src/runtime/local/datastructures/IAllocationDescriptor.h
+++ b/src/runtime/local/datastructures/IAllocationDescriptor.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 The DAPHNE Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+
+// An alphabetically sorted wishlist of supported allocation types ;-)
+// Supporting all of that is probably unmaintainable :-/
+enum class ALLOCATION_TYPE {
+    DIST_GRPC,
+    DIST_OPENMPI,
+    DIST_SPARK,
+    GPU_CUDA,
+    GPU_HIP,
+    HOST,
+    HOST_PINNED_CUDA,
+    FPGA_INT, // Intel
+    FPGA_XLX, // Xilinx
+    ONEAPI, // probably need separate ones for CPU/GPU/FPGA
+    NUM_ALLOC_TYPES
+};
+
+/**
+ * @brief The IAllocationDescriptor interface class describes an abstract interface to handle memory allocations
+ *
+ * To decouple specifics of a certain API for managing memory (e.g, hardware accelerators, distributed libraries)
+ * the allocation descriptor interface provides a set of methods that need to be implemented by the concrete API
+ * specific derivations.
+ * These allocation descriptors are used to request a certain type of memory when using the getValues() method of
+ * a matrix/frame. They are also responsible for transferring to and from the special memory that is handled by
+ * the allocator.
+ */
+class IAllocationDescriptor {
+public:
+    virtual ~IAllocationDescriptor() = default;
+    [[nodiscard]] virtual ALLOCATION_TYPE getType() const = 0;
+    virtual void createAllocation(size_t size, bool zero) = 0;
+    virtual std::shared_ptr<std::byte> getData() = 0;
+    virtual void transferTo(std::byte* src, size_t size) = 0;
+    virtual void transferFrom(std::byte* dst, size_t size) = 0;
+    [[nodiscard]] virtual std::unique_ptr<IAllocationDescriptor> clone() const = 0;
+    virtual bool operator==(const IAllocationDescriptor* other) const { return (getType() == other->getType()); }
+};

--- a/src/runtime/local/datastructures/MetaDataObject.cpp
+++ b/src/runtime/local/datastructures/MetaDataObject.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2022 The DAPHNE Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "MetaDataObject.h"
+
+DataPlacement* MetaDataObject::addDataPlacement(const IAllocationDescriptor *allocInfo, Range *r) {
+    data_placements[static_cast<size_t>(allocInfo->getType())].emplace_back(std::make_unique<DataPlacement>(
+            allocInfo->clone(), r == nullptr ? nullptr : r->clone()));
+    return data_placements[static_cast<size_t>(allocInfo->getType())].back().get();
+}
+
+auto MetaDataObject::getDataPlacementByType(ALLOCATION_TYPE type) const
+        -> const std::vector<std::unique_ptr<DataPlacement>>* {
+    return &(data_placements[static_cast<size_t>(type)]);
+}
+
+DataPlacement *MetaDataObject::getDataPlacementByID(size_t id) const {
+    for (const auto &_omdType: data_placements) {
+        for (auto &_omd: _omdType) {
+            if(_omd->dp_id == id)
+                return const_cast<DataPlacement *>(_omd.get());
+        }
+    }
+    return nullptr;
+}
+
+const DataPlacement* MetaDataObject::findDataPlacementByType(const IAllocationDescriptor *alloc_desc, const Range *range) const {
+    auto res = getDataPlacementByType(alloc_desc->getType());
+    if(res->empty())
+        return nullptr;
+    else {
+        for (size_t i = 0; i < res->size(); ++i) {
+            if((*res)[i]->allocation->operator==(alloc_desc)) {
+                if(((*res)[i]->range == nullptr && range == nullptr) ||
+                   ((*res)[i]->range != nullptr && (*res)[i]->range->operator==(range))) {
+                    return (*res)[i].get();
+                }
+            }
+        }
+        return nullptr;
+    }
+}
+
+bool MetaDataObject::isLatestVersion(size_t placement) const {
+    return (std::find(latest_version.begin(), latest_version.end(), placement) != latest_version.end());
+}
+
+void MetaDataObject::addLatest(size_t id) {
+    latest_version.push_back(id);
+}
+
+void MetaDataObject::setLatest(size_t id) {
+    latest_version.clear();
+    latest_version.push_back(id);
+}
+
+auto MetaDataObject::getLatest() const -> std::vector<size_t> {
+    return latest_version;
+}

--- a/src/runtime/local/datastructures/MetaDataObject.h
+++ b/src/runtime/local/datastructures/MetaDataObject.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 The DAPHNE Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "DataPlacement.h"
+#include "Range.h"
+
+#include <algorithm>
+#include <memory>
+#include <array>
+
+/**
+ * @brief The MetaDataObject class contains meta data of a data structure (Frame, Matrix)
+ *
+ * The MetaDataObject holds a vector of data placements (separated by type) and a vector of IDs of
+ * data placements that all hold the current/latest version of the contained data.
+ * Additionaly, this class contains methods to access/manipulate the contained information.
+ */
+class MetaDataObject {
+    std::array<std::vector<std::unique_ptr<DataPlacement>>,
+            static_cast<size_t>(ALLOCATION_TYPE::NUM_ALLOC_TYPES)> data_placements;
+    std::vector<size_t> latest_version;
+
+public:
+    DataPlacement *addDataPlacement(const IAllocationDescriptor *allocInfo, Range *r = nullptr);
+    const DataPlacement *findDataPlacementByType(const IAllocationDescriptor *alloc_desc, const Range *range) const;
+    [[nodiscard]] DataPlacement *getDataPlacementByID(size_t id) const;
+    [[nodiscard]] auto getDataPlacementByType(ALLOCATION_TYPE type) const ->
+            const std::vector<std::unique_ptr<DataPlacement>>*;
+
+    [[nodiscard]] bool isLatestVersion(size_t placement) const;
+    void addLatest(size_t id);
+    void setLatest(size_t id);
+    [[nodiscard]] auto getLatest() const -> std::vector<size_t>;
+
+};

--- a/src/runtime/local/datastructures/Range.h
+++ b/src/runtime/local/datastructures/Range.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 The DAPHNE Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+
+// Unused for now. This can be used to track sub allocations of matrices
+struct Range {
+    size_t r_start;
+    size_t c_start;
+    size_t r_len;
+    size_t c_len;
+
+    explicit Range(size_t r1, size_t c1, size_t r2, size_t c2) : r_start(r1), c_start(c1), r_len(r2), c_len(c2) { }
+
+    bool operator==(const Range* other) const {
+        return((other != nullptr) && (r_start == other->r_start && c_start == other->c_start && r_len == other->r_len &&
+                                      c_len == other->c_len));
+    }
+
+    bool operator==(const Range other) const {
+        return(r_start == other.r_start && c_start == other.c_start && r_len == other.r_len &&
+                                      c_len == other.c_len);
+    }
+
+    [[nodiscard]] std::unique_ptr<Range> clone() const { return std::make_unique<Range>(*this); }
+};

--- a/src/runtime/local/datastructures/Structure.h
+++ b/src/runtime/local/datastructures/Structure.h
@@ -14,14 +14,15 @@
  * limitations under the License.
  */
 
-#ifndef SRC_RUNTIME_LOCAL_DATASTRUCTURES_STRUCTURE_H
-#define SRC_RUNTIME_LOCAL_DATASTRUCTURES_STRUCTURE_H
+#pragma once
 
 #include <runtime/local/datastructures/DataObjectFactory.h>
-
-#include <mutex>
+#include <runtime/local/datastructures/MetaDataObject.h>
 
 #include <cstddef>
+#include <map>
+#include <mutex>
+#include <array>
 
 /**
  * @brief The base class of all data structure implementations.
@@ -34,20 +35,26 @@ private:
     
     template<class DataType>
     friend void DataObjectFactory::destroy(const DataType * obj);
-    
+
 protected:
     size_t numRows;
     size_t numCols;
 
-    Structure(size_t numRows, size_t numCols) :
-            refCounter(1), numRows(numRows), numCols(numCols)
-    {
-        // nothing to do
-    };
+    Structure(size_t numRows, size_t numCols) : refCounter(1), numRows(numRows), numCols(numCols) { };
+
+    mutable MetaDataObject mdo;
 
 public:
     virtual ~Structure() = default;
-    
+
+    explicit operator std::unique_ptr<Range>() const {
+        return std::make_unique<Range>(Range(0ul, 0ul, this->getNumRows(), this->getNumCols()));
+    }
+
+     explicit operator Range() const {
+        return Range(0, 0, this->getNumRows(), this->getNumCols());
+    }
+
     size_t getRefCounter() const {
         return refCounter;
     }
@@ -131,5 +138,3 @@ public:
      */
     virtual Structure* slice(size_t rl, size_t ru, size_t cl, size_t cu) const = 0;
 };
-
-#endif //SRC_RUNTIME_LOCAL_DATASTRUCTURES_STRUCTURE_H

--- a/src/runtime/local/datastructures/ValueTypeUtils.h
+++ b/src/runtime/local/datastructures/ValueTypeUtils.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef SRC_RUNTIME_LOCAL_DATASTRUCTURES_VALUETYPEUTILS_H
-#define SRC_RUNTIME_LOCAL_DATASTRUCTURES_VALUETYPEUTILS_H
+#pragma once
 
 #include <runtime/local/datastructures/ValueTypeCode.h>
 
@@ -80,14 +79,4 @@ template<> const std::string ValueTypeUtils::irNameFor<uint32_t>;
 template<> const std::string ValueTypeUtils::irNameFor<uint64_t>;
 template<> const std::string ValueTypeUtils::irNameFor<float>;
 template<> const std::string ValueTypeUtils::irNameFor<double>;
-
-// TODO This does not belong here. This header is concerned with handling value
-// types. Allocation-related things should be handled somewhere else.
-enum class ALLOCATION_TYPE {
-    HOST_ALLOC,
-    CUDA_ALLOC,
-    NUM_ALLOC_TYPES
-};
-
-#endif //SRC_RUNTIME_LOCAL_DATASTRUCTURES_VALUETYPEUTILS_H
 

--- a/src/runtime/local/kernels/CUDA/Activation.cpp
+++ b/src/runtime/local/kernels/CUDA/Activation.cpp
@@ -15,22 +15,25 @@
  */
 
 #include "Activation.h"
+#include <runtime/local/datastructures/AllocationDescriptorCUDA.h>
 
 namespace CUDA::Activation {
     template<typename OP, typename DTRes, typename DTArg>
     void Forward<OP, DTRes, DTArg>::apply(DTRes *&res, const DTArg *data, DCTX(dctx)) {
-        auto ctx = dynamic_cast<CUDAContext*>(dctx->getCUDAContext(0));
+        const size_t deviceID = 0; //ToDo: multi device support
+        auto ctx = CUDAContext::get(dctx, deviceID);
+        AllocationDescriptorCUDA alloc_desc(dctx, deviceID);
         using VT = typename DTRes::VT;
         const size_t nr1 = data->getNumRows();
         const size_t nc1 = data->getNumCols();
         const VT blend_alpha = 1;
         const VT blend_beta = 0;
-        const VT* d_input = data->getValuesCUDA();
-
+        const VT* d_input = data->getValues(&alloc_desc);
+    
         if (res == nullptr) {
-            res = DataObjectFactory::create<DTRes>(nr1, nc1, false, ALLOCATION_TYPE::CUDA_ALLOC);
+            res = DataObjectFactory::create<DTRes>(nr1, nc1, false, &alloc_desc);
         }
-        VT* d_res = res->getValuesCUDA();
+        VT* d_res = res->getValues(&alloc_desc);
 
         CHECK_CUDNN(cudnnSetTensor4dDescriptor(ctx->src_tensor_desc, ctx->tensor_format, ctx->getCUDNNDataType<VT>(), 1, 1, nr1, nc1));
         CHECK_CUDNN(cudnnSetTensor4dDescriptor(ctx->dst_tensor_desc, ctx->tensor_format, ctx->getCUDNNDataType<VT>(), 1, 1, nr1, nc1));

--- a/src/runtime/local/kernels/CUDA/Activation.h
+++ b/src/runtime/local/kernels/CUDA/Activation.h
@@ -19,7 +19,6 @@
 
 #pragma once
 
-#include "runtime/local/context/CUDAContext.h"
 #include "runtime/local/context/DaphneContext.h"
 #include "runtime/local/datastructures/DataObjectFactory.h"
 #include "runtime/local/datastructures/DenseMatrix.h"

--- a/src/runtime/local/kernels/CUDA/Affine.cpp
+++ b/src/runtime/local/kernels/CUDA/Affine.cpp
@@ -15,6 +15,8 @@
  */
 
 #include "Affine.h"
+#include "HostUtils.h"
+#include <runtime/local/datastructures/AllocationDescriptorCUDA.h>
 
 template<typename T>
 static void launch_cublas_gemm(const CUDAContext& ctx, size_t nr1, size_t nc1, size_t nc2, const T* alpha, const T* beta,
@@ -37,28 +39,30 @@ template<>
 namespace CUDA::Affine {
     template<typename DTRes, typename DTArg>
     void Forward<DTRes, DTArg>::apply(DTRes *&res, const DTArg *data, const DTArg *weights, const DTArg *bias, DCTX(dctx)) {
-        auto ctx = dctx->getCUDAContext(0);
+        const size_t deviceID = 0; //ToDo: multi device support
+        auto ctx = CUDAContext::get(dctx, deviceID);
+        AllocationDescriptorCUDA alloc_desc(dctx, deviceID);
         using VT = typename DTRes::VT;
         const size_t nr1 = data->getNumRows();
         const size_t nc1 = data->getNumCols();
         const size_t nc2 = weights->getNumCols();
         const VT blend_alpha = 1;
         VT blend_beta = 0;
-        const VT* d_input = data->getValuesCUDA();
-        const VT* d_weights = weights->getValuesCUDA();
+        const VT* d_input = data->getValues(&alloc_desc);
+        const VT* d_weights = weights->getValues(&alloc_desc);
 
         assert((nc1 == weights->getNumRows()) && "#cols of lhs and #rows of rhs must be the same");
-
+        
         if(res == nullptr)
-            res = DataObjectFactory::create<DenseMatrix<VT>>(nr1, nc2, false, ALLOCATION_TYPE::CUDA_ALLOC);
-        VT* d_res = res->getValuesCUDA();
+            res = DataObjectFactory::create<DenseMatrix<VT>>(nr1, nc2, false, &alloc_desc);
+        VT* d_res = res->getValues(&alloc_desc);
 
         // reverse order to accommodate cublas' col major format (-> res = rhs * lhs)
         launch_cublas_gemm<VT>(*ctx, nr1, nc1, nc2, &blend_alpha, &blend_beta, d_input, d_weights, d_res);
 
         if(bias) {
             assert((bias->getNumRows() == 1) && "bias dimensions not matching up with weights matrix (W[MxN] -> b[1xN]");
-            const VT* d_bias = bias->getValuesCUDA();
+            const VT* d_bias = bias->getValues(&alloc_desc);
             CHECK_CUDNN(cudnnSetTensor4dDescriptor(ctx->src_tensor_desc, ctx->tensor_format, ctx->getCUDNNDataType<VT>(),
                     1, bias->getNumCols(), 1, 1));
             CHECK_CUDNN(cudnnSetTensor4dDescriptor(ctx->dst_tensor_desc, ctx->tensor_format, ctx->template getCUDNNDataType<VT>(),

--- a/src/runtime/local/kernels/CUDA/BatchNorm.cpp
+++ b/src/runtime/local/kernels/CUDA/BatchNorm.cpp
@@ -15,23 +15,26 @@
  */
 
 #include "BatchNorm.h"
+#include <runtime/local/datastructures/AllocationDescriptorCUDA.h>
 
 namespace CUDA::BatchNorm {
     template<typename DTRes, typename DTArg>
     void Forward<DTRes, DTArg>::apply(DTRes *&res, const DTArg *data, const DTArg *gamma, const DTArg *beta,
                                       const DTArg *ema_mean, const DTArg *ema_var, const typename DTArg::VT eps, DCTX(dctx))
     {
-        auto ctx = dctx->getCUDAContext(0);
+        const size_t deviceID = 0; //ToDo: multi device support
+        auto ctx = CUDAContext::get(dctx, deviceID);
+        AllocationDescriptorCUDA alloc_desc(dctx, deviceID);
         using VT = typename DTRes::VT;
         const size_t nr1 = data->getNumRows();
         const size_t nc1 = data->getNumCols();
         VT blend_alpha = 1.0;
         VT blend_beta = 0.0;
-        const VT* d_input = data->getValuesCUDA();
-        const VT* d_gamma = gamma->getValuesCUDA();
-        const VT* d_beta = beta->getValuesCUDA();
-        const VT* d_ema_mean = ema_mean->getValuesCUDA();
-        const VT* d_ema_var = ema_var->getValuesCUDA();
+        const VT* d_input = data->getValues(&alloc_desc);
+        const VT* d_gamma = gamma->getValues(&alloc_desc);
+        const VT* d_beta = beta->getValues(&alloc_desc);
+        const VT* d_ema_mean = ema_mean->getValues(&alloc_desc);
+        const VT* d_ema_var = ema_var->getValues(&alloc_desc);
         size_t num_channels = gamma->getNumRows();
 
         size_t HW = nc1 / num_channels;
@@ -40,9 +43,9 @@ namespace CUDA::BatchNorm {
         CHECK_CUDNN(cudnnSetTensor4dDescriptor(ctx->dst_tensor_desc, ctx->tensor_format, ctx->getCUDNNDataType<VT>(), nr1, num_channels, H, H));
 
         if (res == nullptr) {
-            res = DataObjectFactory::create<DTRes>(nr1, nc1, false, ALLOCATION_TYPE::CUDA_ALLOC);
+            res = DataObjectFactory::create<DTRes>(nr1, nc1, false, &alloc_desc);
         }
-        VT* d_res = res->getValuesCUDA();
+        VT* d_res = res->getValues(&alloc_desc);
         CHECK_CUDNN(cudnnDeriveBNTensorDescriptor(ctx->bn_tensor_desc, ctx->src_tensor_desc, ctx->bn_mode));
         CHECK_CUDNN(cudnnBatchNormalizationForwardInference(ctx->getCUDNNHandle(), ctx->bn_mode, &blend_alpha,
                 &blend_beta, ctx->src_tensor_desc, d_input, ctx->dst_tensor_desc, d_res, ctx->bn_tensor_desc,

--- a/src/runtime/local/kernels/CUDA/BiasAdd.cpp
+++ b/src/runtime/local/kernels/CUDA/BiasAdd.cpp
@@ -15,19 +15,22 @@
  */
 
 #include "BiasAdd.h"
+#include <runtime/local/datastructures/AllocationDescriptorCUDA.h>
 
 namespace CUDA::BiasAdd {
     template<typename DTRes, typename DTArg>
     void Forward<DTRes, DTArg>::apply(DTRes *&res, const DTArg *data, const DTArg *bias, DCTX(dctx)) {
-        auto ctx = dctx->getCUDAContext(0);
-
+        const size_t deviceID = 0; //ToDo: multi device support
+        auto ctx = CUDAContext::get(dctx, deviceID);
+        AllocationDescriptorCUDA alloc_desc(dctx, deviceID);
+        
         using VT = typename DTRes::VT;
         const size_t nr1 = data->getNumRows();
         const size_t nc1 = data->getNumCols();
         const VT blend_alpha = 1;
         const VT blend_beta = 1;
-        const VT* d_input = data->getValuesCUDA();
-        const VT* d_bias = bias->getValuesCUDA();
+        const VT* d_input = data->getValues(&alloc_desc);
+        const VT* d_bias = bias->getValues(&alloc_desc);
         res = const_cast<DTArg*>(data);
         VT* d_res = const_cast<VT*>(d_input);
 

--- a/src/runtime/local/kernels/CUDA/BiasAdd.h
+++ b/src/runtime/local/kernels/CUDA/BiasAdd.h
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include "runtime/local/context/CUDAContext.h"
 #include "runtime/local/context/DaphneContext.h"
 #include "runtime/local/datastructures/DataObjectFactory.h"
 #include "runtime/local/datastructures/DenseMatrix.h"

--- a/src/runtime/local/kernels/CUDA/ColBind.cu
+++ b/src/runtime/local/kernels/CUDA/ColBind.cu
@@ -15,6 +15,8 @@
  */
 
 #include "ColBind.h"
+#include <runtime/local/datastructures/AllocationDescriptorCUDA.h>
+
 #include <cstdint>
 
 namespace CUDA {
@@ -47,6 +49,9 @@ namespace CUDA {
     template<typename VTres, typename VTlhs, typename VTrhs>
     void ColBind<DenseMatrix<VTres>, DenseMatrix<VTlhs>, DenseMatrix<VTrhs>>::apply(DenseMatrix<VTres> *& res,
             const DenseMatrix<VTlhs> * lhs, const DenseMatrix<VTrhs> * rhs, DCTX(dctx)) {
+        const size_t deviceID = 0; //ToDo: multi device support
+        AllocationDescriptorCUDA alloc_desc(dctx, deviceID);
+
         const size_t numRowsLhs = lhs->getNumRows();
         const size_t numColsLhs = lhs->getNumCols();
         const size_t numRowsRhs = rhs->getNumRows();
@@ -54,7 +59,7 @@ namespace CUDA {
 
         if(res == nullptr) {
             res = DataObjectFactory::create<DenseMatrix<VTres>>(numRowsLhs, numColsLhs + numColsRhs, false,
-                    ALLOCATION_TYPE::CUDA_ALLOC);
+                    &alloc_desc);
         }
         auto N = res->getNumItems();
         int blockSize;
@@ -64,12 +69,12 @@ namespace CUDA {
         gridSize = (N + blockSize - 1) / blockSize;
 
 #ifndef NDEBUG
-        std::cout << " ColBind: " << gridSize << " blocks x " << blockSize << " threads = " << gridSize*blockSize <<
+        std::cerr << " ColBind: " << gridSize << " blocks x " << blockSize << " threads = " << gridSize*blockSize <<
                 " total threads for " << N << " items" << std::endl;
 #endif
 
-        cbind<<<gridSize, blockSize>>>(lhs->getValuesCUDA(), rhs->getValuesCUDA(), res->getValuesCUDA(), numRowsLhs,
-                numColsLhs, numRowsRhs, numColsRhs);
+        cbind<<<gridSize, blockSize>>>(lhs->getValues(&alloc_desc), rhs->getValues(&alloc_desc), res->getValues(&alloc_desc),
+                numRowsLhs, numColsLhs, numRowsRhs, numColsRhs);
     }
     template struct ColBind<DenseMatrix<int64_t>, DenseMatrix<int64_t>, DenseMatrix<int64_t>>;
     template struct ColBind<DenseMatrix<float>, DenseMatrix<float>, DenseMatrix<float>>;

--- a/src/runtime/local/kernels/CUDA/Convolution.h
+++ b/src/runtime/local/kernels/CUDA/Convolution.h
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include "runtime/local/context/CUDAContext.h"
 #include "runtime/local/context/DaphneContext.h"
 #include "runtime/local/datastructures/DataObjectFactory.h"
 #include "runtime/local/datastructures/DenseMatrix.h"

--- a/src/runtime/local/kernels/CUDA/EwBinaryMat.cu
+++ b/src/runtime/local/kernels/CUDA/EwBinaryMat.cu
@@ -15,6 +15,8 @@
  */
 
 #include "EwBinaryMat.h"
+#include "HostUtils.h"
+#include "runtime/local/datastructures/AllocationDescriptorCUDA.h"
 #include "runtime/local/kernels/CUDA/bin_ops.cuh"
 #include <cstdint>
 
@@ -84,10 +86,11 @@ namespace CUDA {
 // ----------------------------------------------------------------------------
     template<typename VTres, typename VTlhs, typename VTrhs>
     void EwBinaryMat<DenseMatrix<VTres>, DenseMatrix<VTlhs>, DenseMatrix<VTrhs>>::apply(BinaryOpCode opCode,
-                                                                                        DenseMatrix<VTres> *&res,
-                                                                                        const DenseMatrix<VTlhs> *lhs,
-                                                                                        const DenseMatrix<VTrhs> *rhs,
-                                                                                        DCTX(dctx)) {
+            DenseMatrix<VTres> *&res, const DenseMatrix<VTlhs> *lhs, const DenseMatrix<VTrhs> *rhs, DCTX(dctx)) {
+        const size_t deviceID = 0; //ToDo: multi device support
+        auto ctx = CUDAContext::get(dctx, deviceID);
+        AllocationDescriptorCUDA alloc_desc(dctx, deviceID);
+
         const size_t numRowsLhs = lhs->getNumRows();
         const size_t numColsLhs = lhs->getNumCols();
         const size_t numRowsRhs = rhs->getNumRows();
@@ -96,11 +99,9 @@ namespace CUDA {
         int blockSize;
         int minGridSize; // The minimum grid size needed to achieve the maximum occupancy for a full device launch
         size_t gridSize;
-//    const VTres alpha = 1;
 
         if(res == nullptr)
-            res = DataObjectFactory::create<DenseMatrix<VTres>>(numRowsLhs, numColsLhs, false,
-                                                                ALLOCATION_TYPE::CUDA_ALLOC);
+            res = DataObjectFactory::create<DenseMatrix<VTres>>(numRowsLhs, numColsLhs, false, &alloc_desc);
 
         auto N = res->getNumItems();
         bool err = false;
@@ -114,7 +115,7 @@ namespace CUDA {
                         cudaOccupancyMaxPotentialBlockSize(&minGridSize, &blockSize, ewBinMat<VTres, SumOp<VTres>>, 0,
                                                            0));
                 gridSize = (N + blockSize - 1) / blockSize;
-                ewBinMat<<<gridSize, blockSize>>>(res->getValuesCUDA(), lhs->getValuesCUDA(), rhs->getValuesCUDA(), N,
+                ewBinMat<<<gridSize, blockSize>>>(res->getValues(&alloc_desc), lhs->getValues(&alloc_desc), rhs->getValues(&alloc_desc), N,
                                                   op);
             }
             else if(numColsLhs == numColsRhs && (numRowsRhs == 1 || numRowsLhs == 1)) {
@@ -123,7 +124,7 @@ namespace CUDA {
                                                            0,
                                                            0));
                 gridSize = (N + blockSize - 1) / blockSize;
-                ewBinMatRVec<<<gridSize, blockSize>>>(res->getValuesCUDA(), lhs->getValuesCUDA(), rhs->getValuesCUDA(),
+                ewBinMatRVec<<<gridSize, blockSize>>>(res->getValues(&alloc_desc), lhs->getValues(&alloc_desc), rhs->getValues(&alloc_desc),
                                                       numColsRhs, N, op);
             }
             else if(numRowsLhs == numRowsRhs && (numColsRhs == 1 || numColsLhs == 1)) {
@@ -132,7 +133,7 @@ namespace CUDA {
                                                            0,
                                                            0));
                 gridSize = (N + blockSize - 1) / blockSize;
-                ewBinMatCVec<<<gridSize, blockSize>>>(res->getValuesCUDA(), lhs->getValuesCUDA(), rhs->getValuesCUDA(),
+                ewBinMatCVec<<<gridSize, blockSize>>>(res->getValues(&alloc_desc), lhs->getValues(&alloc_desc), rhs->getValues(&alloc_desc),
                                                       numRowsRhs, N, op);
             }
             else {
@@ -146,7 +147,7 @@ namespace CUDA {
                         cudaOccupancyMaxPotentialBlockSize(&minGridSize, &blockSize, ewBinMat<VTres, decltype(op)>, 0,
                                                            0));
                 gridSize = (N + blockSize - 1) / blockSize;
-                ewBinMat<<<gridSize, blockSize>>>(res->getValuesCUDA(), lhs->getValuesCUDA(), rhs->getValuesCUDA(), N,
+                ewBinMat<<<gridSize, blockSize>>>(res->getValues(&alloc_desc), lhs->getValues(&alloc_desc), rhs->getValues(&alloc_desc), N,
                                                   op);
             }
             else if(numColsLhs == numColsRhs && (numRowsRhs == 1 || numRowsLhs == 1)) {
@@ -155,7 +156,7 @@ namespace CUDA {
                                                            0,
                                                            0));
                 gridSize = (N + blockSize - 1) / blockSize;
-                ewBinMatRVec<<<gridSize, blockSize>>>(res->getValuesCUDA(), lhs->getValuesCUDA(), rhs->getValuesCUDA(),
+                ewBinMatRVec<<<gridSize, blockSize>>>(res->getValues(&alloc_desc), lhs->getValues(&alloc_desc), rhs->getValues(&alloc_desc),
                                                       numColsRhs, N, op);
             }
             else if(numRowsLhs == numRowsRhs && (numColsRhs == 1 || numColsLhs == 1)) {
@@ -164,7 +165,7 @@ namespace CUDA {
                                                            0,
                                                            0));
                 gridSize = (N + blockSize - 1) / blockSize;
-                ewBinMatCVec<<<gridSize, blockSize>>>(res->getValuesCUDA(), lhs->getValuesCUDA(), rhs->getValuesCUDA(),
+                ewBinMatCVec<<<gridSize, blockSize>>>(res->getValues(&alloc_desc), lhs->getValues(&alloc_desc), rhs->getValues(&alloc_desc),
                                                       numRowsRhs, N, op);
             }
             else {
@@ -177,24 +178,24 @@ namespace CUDA {
                 CHECK_CUDART(cudaOccupancyMaxPotentialBlockSize(&minGridSize, &blockSize, ewBinMat<VTres, decltype(op)>,
                                                                 0, 0));
                 gridSize = (N + blockSize - 1) / blockSize;
-                ewBinMat<<<gridSize, blockSize>>>(res->getValuesCUDA(), lhs->getValuesCUDA(),
-                                                  rhs->getValuesCUDA(), N, op);
+                ewBinMat<<<gridSize, blockSize>>>(res->getValues(&alloc_desc), lhs->getValues(&alloc_desc),
+                                                  rhs->getValues(&alloc_desc), N, op);
             }
             else if(numColsLhs == numColsRhs && (numRowsRhs == 1 || numRowsLhs == 1)) {
                 CHECK_CUDART(cudaOccupancyMaxPotentialBlockSize(&minGridSize, &blockSize, ewBinMatRVec<VTres,
                         decltype(op)>, 0, 0));
                 gridSize = (N + blockSize - 1) / blockSize;
 
-                ewBinMatRVec<<<gridSize, blockSize>>>(res->getValuesCUDA(), lhs->getValuesCUDA(),
-                                                      rhs->getValuesCUDA(), numColsRhs, N, op);
+                ewBinMatRVec<<<gridSize, blockSize>>>(res->getValues(&alloc_desc), lhs->getValues(&alloc_desc),
+                                                      rhs->getValues(&alloc_desc), numColsRhs, N, op);
             }
             else if(numRowsLhs == numRowsRhs && (numColsRhs == 1 || numColsLhs == 1)) {
                 CHECK_CUDART(
                         cudaOccupancyMaxPotentialBlockSize(&minGridSize, &blockSize, ewBinMatCVec<VTres, decltype(op)>,
                                                            0, 0));
                 gridSize = (N + blockSize - 1) / blockSize;
-                ewBinMatRVec<<<gridSize, blockSize>>>(res->getValuesCUDA(), lhs->getValuesCUDA(),
-                                                      rhs->getValuesCUDA(), numColsRhs, N, op);
+                ewBinMatRVec<<<gridSize, blockSize>>>(res->getValues(&alloc_desc), lhs->getValues(&alloc_desc),
+                                                      rhs->getValues(&alloc_desc), numColsRhs, N, op);
             }
             else {
                 err = true;
@@ -212,7 +213,7 @@ namespace CUDA {
             );
         }
 #ifndef NDEBUG
-        std::cout << " EwBinMat[" << static_cast<int>(opCode) << "]: " << gridSize << " blocks x " << blockSize
+        std::cerr << " EwBinMat[" << static_cast<int>(opCode) << "]: " << gridSize << " blocks x " << blockSize
                   << " threads = " << gridSize * blockSize
                   << " total threads for " << N << " items" << std::endl;
 #endif

--- a/src/runtime/local/kernels/CUDA/ExtractCol.cu
+++ b/src/runtime/local/kernels/CUDA/ExtractCol.cu
@@ -15,6 +15,9 @@
  */
 
 #include "ExtractCol.h"
+
+#include <runtime/local/datastructures/AllocationDescriptorCUDA.h>
+
 #include <cstdint>
 
 namespace CUDA {
@@ -33,12 +36,14 @@ namespace CUDA {
     // ----------------------------------------------------------------------------
     template<class DTRes, class DTArg, class DTSel>
     void ExtractCol<DenseMatrix<DTRes>, DenseMatrix<DTArg>, DenseMatrix<DTSel>>::apply(DenseMatrix<DTRes>*& res,
-            const DenseMatrix<DTArg>* arg, const DenseMatrix<DTSel>* sel, DCTX(ctx)) {
-
+            const DenseMatrix<DTArg>* arg, const DenseMatrix<DTSel>* sel, DCTX(dctx)) {
+        const size_t deviceID = 0; //ToDo: multi device support
+        AllocationDescriptorCUDA alloc_desc(dctx, deviceID);
         if(res == nullptr) {
             res = DataObjectFactory::create<DenseMatrix<DTRes>>(arg->getNumRows(), sel->getNumRows(), false,
-                    ALLOCATION_TYPE::CUDA_ALLOC);
+                    &alloc_desc);
         }
+        
         auto N = res->getNumItems();
         int blockSize;
         int minGridSize; // The minimum grid size needed to achieve the maximum occupancy for a full device launch
@@ -47,19 +52,12 @@ namespace CUDA {
         gridSize = (N + blockSize - 1) / blockSize;
 
 #ifndef NDEBUG
-        std::cout << " ExtractCol: " << gridSize << " blocks x " << blockSize << " threads = " << gridSize*blockSize
+        std::cerr << " ExtractCol: " << gridSize << " blocks x " << blockSize << " threads = " << gridSize*blockSize
                 << " total threads for " << N << " items" << std::endl;
 #endif
 
-        extract_col<<<gridSize, blockSize>>>(res->getValuesCUDA(), arg->getValuesCUDA(), sel->getValuesCUDA(),
-                sel->getNumRows(), arg->getNumCols(), N);
-
-
-//        std::vector<DTRes> res_host(res->getNumItems());
-//        CHECK_CUDART(cudaMemcpy(res_host.data(), res->getValuesCUDA(), res->bufferSize(), cudaMemcpyDeviceToHost));
-//        for(auto j=0; j < res->getNumItems(); j++)
-//            std::cout << res_host[j] << " ";
-//        std::cout << std::endl;
+        extract_col<<<gridSize, blockSize>>>(res->getValues(&alloc_desc), arg->getValues(&alloc_desc),
+                sel->getValues(&alloc_desc), sel->getNumRows(), arg->getNumCols(), N);
     }
     template struct ExtractCol<DenseMatrix<int64_t>, DenseMatrix<int64_t>, DenseMatrix<int64_t>>;
     template struct ExtractCol<DenseMatrix<float>, DenseMatrix<float>, DenseMatrix<int64_t>>;

--- a/src/runtime/local/kernels/CUDA/Gemv.h
+++ b/src/runtime/local/kernels/CUDA/Gemv.h
@@ -19,7 +19,7 @@
 #include <runtime/local/datastructures/DataObjectFactory.h>
 #include <runtime/local/datastructures/DenseMatrix.h>
 #include <runtime/local/kernels/CUDA/HostUtils.h>
-#include <runtime/local/context/DaphneContext.h>
+#include <runtime/local/context/CUDAContext.h>
 
 namespace CUDA {
 

--- a/src/runtime/local/kernels/CUDA/HostUtils.h
+++ b/src/runtime/local/kernels/CUDA/HostUtils.h
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 
-#ifndef DAPHNE_PROTOTYPE_CUDAHOSTUTILS_H
-#define DAPHNE_PROTOTYPE_CUDAHOSTUTILS_H
-
 #pragma once
 
 #include <cuda.h>
@@ -127,6 +124,16 @@ template<typename T>
 void cuda_deleter(T* dev_ptr) { CudaDeleter<T>::del(dev_ptr); }
 
 template<typename T>
-using CudaUniquePtr = std::unique_ptr<T, decltype(&cuda_deleter<T>)>;
+using CudaUniquePtr [[maybe_unused]] = std::unique_ptr<T, decltype(&cuda_deleter<T>)>;
 
-#endif //DAPHNE_PROTOTYPE_CUDAHOSTUTILS_H
+#ifndef NDEBUG
+template<typename T>
+void debugPrintCUDABuffer(std::string_view title, const T* data, size_t num_items) {
+    std::vector<T> tmp(num_items);
+    CHECK_CUDART(cudaMemcpy(tmp.data(), data, num_items * sizeof(T), cudaMemcpyDeviceToHost));
+    std::cerr << title << ":\n";
+    for(auto i = 0u; i < num_items; ++i)
+        std::cerr << tmp[i] << " ";
+    std::cerr << "\n";
+}
+#endif

--- a/src/runtime/local/kernels/CUDA/Pooling.h
+++ b/src/runtime/local/kernels/CUDA/Pooling.h
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include "runtime/local/context/CUDAContext.h"
 #include "runtime/local/context/DaphneContext.h"
 #include "runtime/local/datastructures/DataObjectFactory.h"
 #include "runtime/local/datastructures/DenseMatrix.h"

--- a/src/runtime/local/kernels/CUDA/Softmax.cpp
+++ b/src/runtime/local/kernels/CUDA/Softmax.cpp
@@ -15,26 +15,30 @@
  */
 
 #include "Softmax.h"
+#include <runtime/local/datastructures/AllocationDescriptorCUDA.h>
 
 namespace CUDA::Softmax {
 
     template<typename DTRes, typename DTArg>
     void Forward<DTRes, DTArg>::apply(DTRes *&res, const DTArg *data, DCTX(dctx)) {
-        auto ctx = dctx->getCUDAContext(0);
+        const size_t deviceID = 0; //ToDo: multi device support
+        auto ctx = CUDAContext::get(dctx, deviceID);
+        AllocationDescriptorCUDA alloc_desc(dctx, deviceID);
+        
         using VT = typename DTRes::VT;
         int n = data->getNumRows();
         int d = data->getNumCols();
         const VT blend_alpha = 1;
         const VT blend_beta = 0;
-        const VT* d_input = data->getValuesCUDA();
+        const VT* d_input = data->getValues(&alloc_desc);
 
         CHECK_CUDNN(cudnnSetTensor4dDescriptor(ctx->src_tensor_desc, ctx->tensor_format, ctx->getCUDNNDataType<VT>(), n, d, 1, 1));
         CHECK_CUDNN(cudnnSetTensor4dDescriptor(ctx->dst_tensor_desc, ctx->tensor_format, ctx->getCUDNNDataType<VT>(), n, d, 1, 1));
 
         if (res == nullptr) {
-            res = DataObjectFactory::create<DTRes>(n,d, false, ALLOCATION_TYPE::CUDA_ALLOC);
+            res = DataObjectFactory::create<DTRes>(n,d, false, &alloc_desc);
         }
-        VT* d_res = res->getValuesCUDA();
+        VT* d_res = res->getValues(&alloc_desc);
 
         CHECK_CUDNN(cudnnSoftmaxForward(ctx->getCUDNNHandle(), CUDNN_SOFTMAX_ACCURATE, CUDNN_SOFTMAX_MODE_CHANNEL,
                 &blend_alpha, ctx->src_tensor_desc, d_input, &blend_beta, ctx->dst_tensor_desc, d_res));

--- a/src/runtime/local/kernels/CUDA/Softmax.h
+++ b/src/runtime/local/kernels/CUDA/Softmax.h
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include "runtime/local/context/CUDAContext.h"
 #include "runtime/local/context/DaphneContext.h"
 #include "runtime/local/datastructures/DataObjectFactory.h"
 #include "runtime/local/datastructures/DenseMatrix.h"

--- a/src/runtime/local/kernels/CUDA/Transpose.cpp
+++ b/src/runtime/local/kernels/CUDA/Transpose.cpp
@@ -60,18 +60,21 @@ namespace CUDA {
         const size_t nr1 = arg->getNumRows();
         const size_t nc1 = arg->getNumCols();
 
-        if(nr1 == 1 || nc1 == 1) {
-            res = arg->vectorTranspose();
-        }
-        else {
-            auto ctx = dctx->getCUDAContext(0);
+//        if(nr1 == 1 || nc1 == 1) {
+//            res = arg->vectorTranspose();
+//        }
+//        else
+        {
+            const size_t deviceID = 0; //ToDo: multi device support
+            auto ctx = CUDAContext::get(dctx, deviceID);
+            AllocationDescriptorCUDA alloc_desc(dctx, deviceID);
             const VT blend_alpha = 1.0f;
             const VT blend_beta = 0.0f;
-            const VT *d_arg = arg->getValuesCUDA();
+            const VT *d_arg = arg->getValues(&alloc_desc);
 
             if (res == nullptr)
-                res = DataObjectFactory::create<DenseMatrix<VT>>(nc1, nr1, false, ALLOCATION_TYPE::CUDA_ALLOC);
-            VT *d_res = res->getValuesCUDA();
+                res = DataObjectFactory::create<DenseMatrix<VT>>(nc1, nr1, false, &alloc_desc);
+            VT *d_res = res->getValues(&alloc_desc);
             launch_cublas_geam<VT>(*ctx, nr1, nc1, &blend_alpha, &blend_beta, d_arg, d_res);
         }
     }

--- a/src/runtime/local/kernels/CUDA/Transpose.h
+++ b/src/runtime/local/kernels/CUDA/Transpose.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <runtime/local/context/DaphneContext.h>
+#include "runtime/local/datastructures/AllocationDescriptorCUDA.h"
 #include <runtime/local/datastructures/DataObjectFactory.h>
 #include <runtime/local/datastructures/DenseMatrix.h>
 

--- a/src/runtime/local/kernels/Syrk.h
+++ b/src/runtime/local/kernels/Syrk.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef SRC_RUNTIME_LOCAL_KERNELS_SYRK_H
-#define SRC_RUNTIME_LOCAL_KERNELS_SYRK_H
+#pragma once
 
 #include <runtime/local/context/DaphneContext.h>
 #include <runtime/local/datastructures/CSRMatrix.h>
@@ -121,5 +120,3 @@ struct Syrk<CSRMatrix<VT>, CSRMatrix<VT>> {
         assert(false && "TODO: Syrk for Sparse");
     }
 };
-
-#endif //SRC_RUNTIME_LOCAL_KERNELS_SYRK_H

--- a/src/runtime/local/kernels/Transpose.h
+++ b/src/runtime/local/kernels/Transpose.h
@@ -57,10 +57,12 @@ struct Transpose<DenseMatrix<VT>, DenseMatrix<VT>> {
         const size_t numCols = arg->getNumCols();
 
         // skip data movement for vectors
-        if (numRows == 1 || numCols == 1) {
-            res = arg->vectorTranspose();
-        }
-        else {
+        // the additional check for rows == rowSkip guards against tiled transpose, where this shortcut does not apply
+//        if ((numRows == 1 || numCols == 1) && (numRows == arg->getRowSkip())) {
+//            res = arg->vectorTranspose();
+//        }
+//        else
+        {
             if (res == nullptr)
                 res = DataObjectFactory::create<DenseMatrix<VT>>(numCols, numRows, false);
 

--- a/src/runtime/local/vectorized/LoadPartitioning.h
+++ b/src/runtime/local/vectorized/LoadPartitioning.h
@@ -14,19 +14,14 @@
  * limitations under the License.
  */
 
-#ifndef SRC_RUNTIME_LOCAL_VECTORIZED_LOADPARTITIONING_H
-#define SRC_RUNTIME_LOCAL_VECTORIZED_LOADPARTITIONING_H
+#pragma once
+
+#include "LoadPartitioningDefs.h"
 
 #include <cmath>
 #include <cstdlib>
 #include <string>
 
-enum QueueTypeOption { CENTRALIZED=0, PERGROUP, PERCPU};
-enum victimSelectionLogic { SEQ=0, SEQPRI, RANDOM, RANDOMPRI};
-
-enum SelfSchedulingScheme { STATIC=0, SS, GSS, TSS, FAC2, TFSS, FISS, VISS, 
-                            PLS, MSTATIC, MFSC, PSS,
-                            INVALID=-1 /* only for JSON enum conversion */};
 class LoadPartitioning {
 
 private:
@@ -160,5 +155,3 @@ public:
         return chunkSize;
     } 
 };
-
-#endif //SRC_RUNTIME_LOCAL_VECTORIZED_LOADPARTITIONING_H

--- a/src/runtime/local/vectorized/LoadPartitioningDefs.h
+++ b/src/runtime/local/vectorized/LoadPartitioningDefs.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 The DAPHNE Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+enum QueueTypeOption {
+    CENTRALIZED=0,
+    PERGROUP,
+    PERCPU
+};
+
+enum victimSelectionLogic {
+    SEQ=0,
+    SEQPRI,
+    RANDOM,
+    RANDOMPRI
+};
+
+enum SelfSchedulingScheme {
+    STATIC=0,
+    SS,
+    GSS,
+    TSS,
+    FAC2,
+    TFSS,
+    FISS,
+    VISS,
+    PLS,
+    MSTATIC,
+    MFSC,
+    PSS,
+    INVALID=-1 /* only for JSON enum conversion */
+};

--- a/src/runtime/local/vectorized/MTWrapper_dense.cpp
+++ b/src/runtime/local/vectorized/MTWrapper_dense.cpp
@@ -327,14 +327,7 @@ void MTWrapper<DenseMatrix<VT>>::combineOutputs(DenseMatrix<VT>***& res_, DenseM
             auto data_dest = res->getValues();
             CHECK_CUDART(cudaMemcpy(data_dest, const_res_cuda.getValues(&alloc_desc), const_res_cuda.bufferSize(),
                                     cudaMemcpyDeviceToHost));
-#ifndef NDEBUG
-        std::vector<VT> tmp(const_res_cuda.getNumItems());
-        CHECK_CUDART(cudaMemcpy(tmp.data(), const_res_cuda.getValues(&alloc_desc), const_res_cuda.bufferSize(), cudaMemcpyDeviceToHost));
-        std::cerr << "combine outputs res cuda: ";
-        for(auto i = 0u; i < const_res_cuda.getNumItems(); ++i)
-            std::cerr << tmp[i] << " ";
-        std::cerr << "\n";
-#endif
+//            debugPrintCUDABuffer("MTWrapperDense: combine outputs", const_res_cuda.getValues(&alloc_desc), const_res_cuda.getNumItems());
             DataObjectFactory::destroy(res_cuda);
         }
         else if (combines[i] == mlir::daphne::VectorCombine::COLS) {
@@ -342,6 +335,7 @@ void MTWrapper<DenseMatrix<VT>>::combineOutputs(DenseMatrix<VT>***& res_, DenseM
             auto dst_base_ptr = res->getValues();
             auto src_base_ptr = const_res_cuda.getValues(&alloc_desc);
             for(auto j = 0u; j < res_cuda->getNumRows(); ++j) {
+                //ToDo: rowSkip would be correct here if res_cuda wasn't a shallow copy
 //                auto data_src = src_base_ptr + res_cuda->getRowSkip() * j;
                 auto data_src = src_base_ptr + res_cuda->getNumCols() * j;
                 auto data_dst = dst_base_ptr + res->getRowSkip() * j;

--- a/src/runtime/local/vectorized/TasksCUDA.cpp
+++ b/src/runtime/local/vectorized/TasksCUDA.cpp
@@ -80,15 +80,7 @@ void CompiledPipelineTaskCUDA<DenseMatrix<VT>>::accumulateOutputs(std::vector<De
                 auto data = result->getValues(&alloc_desc);
                 data += result->getRowSkip() * rowStart;
                 CHECK_CUDART(cudaMemcpy(data, localResults[o]->getValues(&alloc_desc), bufsize, cudaMemcpyDeviceToDevice));
-#ifndef NDEBUG
-                std::vector<VT> tmp(localResults[o]->getNumItems());
-                const auto& const_res_cuda = data;
-                CHECK_CUDART(cudaMemcpy(tmp.data(), const_res_cuda, bufsize, cudaMemcpyDeviceToHost));
-                std::cerr << "res task cuda:";
-                for(auto i = 0u; i < localResults[o]->getNumItems(); ++i)
-                    std::cerr << tmp[i] << " ";
-                std::cerr << "\n";
-#endif
+//                debugPrintCUDABuffer("TaskCUDA: accumulate outputs", localResults[o]->getValues(&alloc_desc), localResults[o]->getNumItems());
                 break;
             }
             case VectorCombine::COLS: {

--- a/test/runtime/local/kernels/CUDA_ContextTest.cpp
+++ b/test/runtime/local/kernels/CUDA_ContextTest.cpp
@@ -23,8 +23,9 @@
 
 TEST_CASE("CreateCUDAContext", TAG_KERNELS) {
     DaphneUserConfig user_config{};
+    const size_t deviceID = 0; //ToDo: multi device support
     auto dctx = std::make_unique<DaphneContext>(user_config);
     CUDA::createCUDAContext(dctx.get());
-    auto p = dctx->getCUDAContext(0)->getDeviceProperties();
+    auto p = CUDAContext::get(dctx.get(), deviceID)->getDeviceProperties();
     CHECK(p);
 }


### PR DESCRIPTION
…ata)

This change introduces a major change how external storage buffers (CUDA memory specifically) are handled. In that regard, the following noteworthy changes are implemented:
* Factor out CUDA allocations from DenseMatrix (one of the initial motivations of issue #191)
* Introduce a mechanism to handle several storage backends and track ranges of a Structure's data.
* To make use of the mechanism, an AllocationDescriptor is passed to create() and getValues() (at the moment only DenseMatrix is supported).
* Allocation descriptors need to implement the IAllocationDescriptor interface. This decouples backend specific dependencies.
* AllocationDescriptorHost and AllocationDescriptorCUDA are implemented atm. The former is more or less a no-op for now.
* The CUDA memory allocation and data movement is moved to the CUDAContext class. It keeps track of its allocations per device. For now this does nothing but can be used to reuse allocations in the future.
