### PR TITLE
[DAPHNE-#234] extractCol-kernel for Frame with positions in DenseMatr…

### DIFF
--- a/src/runtime/local/datastructures/Frame.h
+++ b/src/runtime/local/datastructures/Frame.h
@@ -107,6 +107,22 @@ class Frame : public Structure {
             labels2idxs[labels[i]] = i;
         }
     }
+
+    /**
+     * @brief Initializes the mapping from column labels to column positions in
+     * the frame and assigns default labels to duplicate column labels.
+     * 
+     * This method should only be called by constructors, that may intentionally duplicate 
+     * columns, instead of initLabels2Idxs(), after the column labels have been initialized.
+     */
+    void initDeduplicatedLabels2Idxs() {
+        labels2idxs.clear();
+        for(size_t i = 0; i < numCols; i++) {
+            if(labels2idxs.count(labels[i]))
+               labels[i] = getDefaultLabel(i);
+            labels2idxs[labels[i]] = i;
+        }
+    }
     
     // TODO Should the given schema array really be copied, or reused?
     /**
@@ -264,7 +280,7 @@ class Frame : public Structure {
                     src->columns[colIdxs[i]].get() + rowLowerIncl * ValueTypeUtils::sizeOf(schema[i])
             );
         }
-        initLabels2Idxs();
+        initDeduplicatedLabels2Idxs();
     }
     
     ~Frame() {

--- a/src/runtime/local/kernels/ExtractCol.h
+++ b/src/runtime/local/kernels/ExtractCol.h
@@ -97,3 +97,19 @@ struct ExtractCol<Frame, Frame, char> {
         res = DataObjectFactory::create<Frame>(arg, 0, arg->getNumRows(), 1, &colIdx);
     }
 };
+
+template< typename VTSel >
+struct ExtractCol<Frame, Frame, DenseMatrix<VTSel>> {
+    static void apply(Frame *& res, const Frame * arg, const DenseMatrix<VTSel> * sel, DCTX(ctx)) {
+        assert((sel->getNumCols() == 1) && "parameter colIdxs must be a column matrix");
+
+        const size_t numColsRes = sel->getNumRows();
+        const size_t * colIdxs = reinterpret_cast<const size_t *>(sel->getValues());
+        for(size_t i = 0; i < numColsRes; i++) {
+            assert((colIdxs[i] < arg->getNumCols()) && "column index out of bounds");
+        }
+        const size_t numRows = arg->getNumRows();
+
+        res = DataObjectFactory::create<Frame>(arg, 0, numRows, numColsRes, colIdxs);
+    }
+};

--- a/src/runtime/local/kernels/kernels.json
+++ b/src/runtime/local/kernels/kernels.json
@@ -638,7 +638,10 @@
             },
             {
                 "name":  ["CPP"],
-                "instantiations": [["Frame", "Frame", "char"]]
+                "instantiations": [
+                    ["Frame", "Frame", "char"],
+                    ["Frame", "Frame", ["DenseMatrix", "int64_t"]],
+                    ["Frame", "Frame", ["DenseMatrix", "size_t"]]]
             }
         ]
     },

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -66,6 +66,7 @@ set(TEST_SOURCES
         runtime/local/kernels/EwBinaryObjScaTest.cpp
         runtime/local/kernels/EwBinaryScaTest.cpp
         runtime/local/kernels/EwUnaryScaTest.cpp
+        runtime/local/kernels/ExtractColTest.cpp
         runtime/local/kernels/ExtractRowTest.cpp
         runtime/local/kernels/FilterRowTest.cpp
         runtime/local/kernels/GroupJoinTest.cpp

--- a/test/api/cli/indexing/right_indexing_success_2.daphne
+++ b/test/api/cli/indexing/right_indexing_success_2.daphne
@@ -112,11 +112,10 @@ print("X[, 2:3]");
 print(X[, 2:3]);
 print("X[, 0:5]");
 print(X[, 0:5]);
-// TODO This doesn't work yet, see #234).
-//print("X[, emptyIds]");
-//print(X[, emptyIds]);
-//print("X[, colIds]");
-//print(X[, colIds]);
+print("X[, emptyIds]");
+print(X[, emptyIds]);
+print("X[, colIds]");
+print(X[, colIds]);
 print("");
 
 // ****************************************************************************
@@ -150,11 +149,10 @@ print("X[4:5, 2:3]");
 print(X[4:5, 2:3]);
 print("X[0:9, 0:5]");
 print(X[0:9, 0:5]);
-// TODO This doesn't work yet, see #234).
-//print("X[emptyIds, emptyIds]");
-//print(X[emptyIds, emptyIds]);
-//print("X[rowIds, colIds]");
-//print(X[rowIds, colIds]);
+print("X[emptyIds, emptyIds]");
+print(X[emptyIds, emptyIds]);
+print("X[rowIds, colIds]");
+print(X[rowIds, colIds]);
 print("");
 
 // ****************************************************************************
@@ -164,14 +162,12 @@ print("");
 print("row and col - some mixed variants");
 print("X[4, 2:3]");
 print(X[4, 2:3]);
-// TODO This doesn't work yet, see #234).
-//print("X[4, colIds]");
-//print(X[4, colIds]);
+print("X[4, colIds]");
+print(X[4, colIds]);
 print("X[4:5, 2]");
 print(X[4:5, 2]);
-// TODO This doesn't work yet, see #234).
-//print("X[4:5, colIds]");
-//print(X[4:5, colIds]);
+print("X[4:5, colIds]");
+print(X[4:5, colIds]);
 print("X[rowIds, 2]");
 print(X[rowIds, 2]);
 print("X[rowIds, 2:3]");

--- a/test/api/cli/indexing/right_indexing_success_2.txt
+++ b/test/api/cli/indexing/right_indexing_success_2.txt
@@ -271,6 +271,30 @@ Frame(10x5, [a:int64_t, b:double, c:int64_t, d:double, e:int64_t])
 42 43 44 45 46
 48 49 50 51 52
 54 55 56 57 58
+X[, emptyIds]
+Frame(10x0, [])
+
+
+
+
+
+
+
+
+
+
+X[, colIds]
+Frame(10x2, [a:int64_t, c:int64_t])
+0 2
+6 8
+12 14
+18 20
+24 26
+30 32
+36 38
+42 44
+48 50
+54 56
 
 row and col - corresponding variants
 X[0, 0]
@@ -352,14 +376,27 @@ Frame(9x5, [a:int64_t, b:double, c:int64_t, d:double, e:int64_t])
 36 37 38 39 40
 42 43 44 45 46
 48 49 50 51 52
+X[emptyIds, emptyIds]
+Frame(0x0, [])
+X[rowIds, colIds]
+Frame(3x2, [a:int64_t, c:int64_t])
+6 8
+24 26
+42 44
 
 row and col - some mixed variants
 X[4, 2:3]
 Frame(1x1, [c:int64_t])
 26
+X[4, colIds]
+Frame(1x2, [a:int64_t, c:int64_t])
+24 26
 X[4:5, 2]
 Frame(1x1, [c:int64_t])
 26
+X[4:5, colIds]
+Frame(1x2, [a:int64_t, c:int64_t])
+24 26
 X[rowIds, 2]
 Frame(3x1, [c:int64_t])
 8

--- a/test/runtime/local/kernels/ExtractColTest.cpp
+++ b/test/runtime/local/kernels/ExtractColTest.cpp
@@ -1,0 +1,104 @@
+/*
+ * Copyrighq 2021 The DAPHNE Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <runtime/local/datagen/GenGivenVals.h>
+#include <runtime/local/datastructures/DenseMatrix.h>
+#include <runtime/local/datastructures/Frame.h>
+#include <runtime/local/datastructures/Structure.h>
+#include <runtime/local/kernels/CheckEq.h>
+#include <runtime/local/kernels/ExtractCol.h>
+
+#include <tags.h>
+
+#include <catch.hpp>
+
+#include <string>
+#include <vector>
+
+#include <cstdint>
+
+
+/**
+ * @brief Runs the extractCoöl-kernel with small input data and performs various
+ * checks.
+ */
+TEMPLATE_TEST_CASE("ExtractCol - Frame", TAG_KERNELS, int64_t, size_t) { // NOLINT(cert-err58-cpp)
+    using VTSel = TestType;
+    using DTSel = DenseMatrix<VTSel>;
+    
+    using DT0 = DenseMatrix<double>;
+    using DT1 = DenseMatrix<int32_t>;
+    using DT2 = DenseMatrix<uint64_t>;
+    
+    const size_t numRows = 5;
+    
+    auto c0 = genGivenVals<DT0>(numRows, {0.0, 1.1, 2.2, 3.3, 4.4});
+    auto c1 = genGivenVals<DT1>(numRows, {0, -10, -20, -30, -40});
+    auto c2 = genGivenVals<DT2>(numRows, {0, 1, 2, 3, 4});
+
+    std::vector<Structure *> colMats = {c0, c1, c2};
+    std::string labels[] = {"aaa", "bbb", "ccc"};
+    auto arg = DataObjectFactory::create<Frame>(colMats, labels);
+    size_t numColExp;
+    
+    Frame* res{};
+    Frame* exp{};
+    DTSel* sel{};
+
+    SECTION("selecting nothing") {
+        sel = DataObjectFactory::create<DTSel>(0, 1, false);
+        exp = DataObjectFactory::create<Frame>(arg, 0, arg->getNumRows(), 0, nullptr);
+    }
+    SECTION("selecting some, once, in-order") {
+        numColExp = 2;
+        sel = genGivenVals<DTSel>(numColExp, {0, 2});
+        std::vector<Structure *> colMatsExp = {c0, c2};
+        std::string labelsExp[] = {"aaa", "ccc"};
+        exp = DataObjectFactory::create<Frame>(colMatsExp, labelsExp);
+    }
+    SECTION("selecting everything, once, in-order") {
+        numColExp = 3;
+        sel = genGivenVals<DTSel>(numColExp, {0, 1, 2});
+        std::vector<Structure *> colMatsExp = {c0, c1, c2};
+        std::string labelsExp[] = {"aaa", "bbb", "ccc"};
+        exp = DataObjectFactory::create<Frame>(colMatsExp, labelsExp);
+    }
+    SECTION("selecting everything, once, permuted") {
+        numColExp = 3;
+        sel = genGivenVals<DTSel>(numColExp, {2, 0, 1});
+        std::vector<Structure *> colMatsExp = {c2, c0, c1};
+        std::string labelsExp[] = {"ccc", "aaa", "bbb"};
+        exp = DataObjectFactory::create<Frame>(colMatsExp, labelsExp);
+    }
+    SECTION("selecting some, repeated") {
+        numColExp = 8;
+        sel = genGivenVals<DTSel>(numColExp, {1, 2, 2, 0, 1, 0, 1, 2});
+        std::vector<Structure *> colMatsExp = {c1, c2, c2, c0, c1, c0, c1, c2};
+        std::string labelsExp[] = {"bbb", "ccc", "col_2", "aaa", "col_4", "col_5", "col_6", "col_7"};
+        exp = DataObjectFactory::create<Frame>(colMatsExp, labelsExp);
+    }
+    
+    extractCol<Frame, Frame, DTSel>(res, arg, sel, nullptr);
+
+    CHECK(*res == *exp);
+    
+    DataObjectFactory::destroy(c0);
+    DataObjectFactory::destroy(c1);
+    DataObjectFactory::destroy(c2);
+    DataObjectFactory::destroy(arg);
+    DataObjectFactory::destroy(exp);
+    DataObjectFactory::destroy(res);
+}


### PR DESCRIPTION
- Implements extracting multiple columns from a Frame given a list of positions (Densematrix of either int64_t or size_t)
- Enables right-indexing on frames (incl. already existing testcases)
- Modifies Frame Constructor for subframes to automatically deduplicate column labels
- Replaces deduplicate column labels with default labels (enables repeated selction in ExtractCol)
- Closes #234