### PR TITLE
[DAPHNE-#224]: reshape-kernel for non-zero-copy cases

### DIFF
--- a/src/runtime/local/kernels/Reshape.h
+++ b/src/runtime/local/kernels/Reshape.h
@@ -59,9 +59,20 @@ struct Reshape<DenseMatrix<VT>, DenseMatrix<VT>> {
 
         if(arg->getRowSkip() == arg->getNumCols() && res == nullptr)
             res = DataObjectFactory::create<DenseMatrix<VT>>(numRows, numCols, arg->getValuesSharedPtr());
-        else
-            // TODO Support those cases. See #224.
-            throw std::runtime_error("reshape does not support cases which aren't pure meta data operations yet");
+        else {
+            if(res == nullptr)
+                res = DataObjectFactory::create<DenseMatrix<VT>>(numRows, numCols, false);
+
+            auto resVals = res->getValues();
+            auto argVals = arg->getValues();
+            size_t numArgRows = arg->getNumRows();
+            size_t numArgCols = arg->getNumCols();
+            for(size_t r = 0; r < numArgRows; r++) {
+                memcpy(resVals, argVals, numArgCols * sizeof(VT));
+                argVals += arg->getRowSkip();
+                resVals += numArgCols;
+            }
+        }
     }
 };
 

--- a/test/runtime/local/kernels/ReshapeTest.cpp
+++ b/test/runtime/local/kernels/ReshapeTest.cpp
@@ -52,6 +52,27 @@ TEMPLATE_PRODUCT_TEST_CASE("Reshape", TAG_KERNELS, (DenseMatrix), (double, uint3
         checkReshape(arg, 3, 4, exp);
         DataObjectFactory::destroy(exp);
     }
+    SECTION("Reshape view 1") {
+        const DT * initial = genGivenVals<DT>(3, vals); // 3x4
+        const DT * view = DataObjectFactory::create<DT>(initial, 0, 3, 2, 4); // 3x2
+        const DT * exp = genGivenVals<DT>(2, {2,3,6, 7,10,11}); // 2x3
+        checkReshape(view, 2, 3, exp);
+
+        DataObjectFactory::destroy(exp);
+        DataObjectFactory::destroy(initial);
+        DataObjectFactory::destroy(view);
+    }
+    SECTION("Reshape view 2") {
+
+        const DT * initial = genGivenVals<DT>(2, vals); // 2x6
+        const DT * view = DataObjectFactory::create<DT>(initial, 1, 2, 0, 6); // 1x6
+        const DT * exp = genGivenVals<DT>(3, {6,7 ,8,9, 10,11}); // 3x2
+        checkReshape(view, 3, 2, exp);
+
+        DataObjectFactory::destroy(exp);
+        DataObjectFactory::destroy(initial);
+        DataObjectFactory::destroy(view);
+    }
     SECTION("invalid reshape") {
         DT * res = nullptr;
         CHECK_THROWS(reshape<DT, DT>(res, arg, 5, 2, nullptr));

--- a/test/runtime/local/kernels/ReshapeTest.cpp
+++ b/test/runtime/local/kernels/ReshapeTest.cpp
@@ -52,7 +52,7 @@ TEMPLATE_PRODUCT_TEST_CASE("Reshape", TAG_KERNELS, (DenseMatrix), (double, uint3
         checkReshape(arg, 3, 4, exp);
         DataObjectFactory::destroy(exp);
     }
-    SECTION("Reshape view 1") {
+    SECTION("view 1") {
         const DT * initial = genGivenVals<DT>(3, vals); // 3x4
         const DT * view = DataObjectFactory::create<DT>(initial, 0, 3, 2, 4); // 3x2
         const DT * exp = genGivenVals<DT>(2, {2,3,6, 7,10,11}); // 2x3
@@ -62,7 +62,7 @@ TEMPLATE_PRODUCT_TEST_CASE("Reshape", TAG_KERNELS, (DenseMatrix), (double, uint3
         DataObjectFactory::destroy(initial);
         DataObjectFactory::destroy(view);
     }
-    SECTION("Reshape view 2") {
+    SECTION("view 2") {
         const DT * initial = genGivenVals<DT>(2, vals); // 2x6
         const DT * view = DataObjectFactory::create<DT>(initial, 1, 2, 0, 6); // 1x6
         const DT * exp = genGivenVals<DT>(3, {6,7 ,8,9, 10,11}); // 3x2
@@ -72,7 +72,7 @@ TEMPLATE_PRODUCT_TEST_CASE("Reshape", TAG_KERNELS, (DenseMatrix), (double, uint3
         DataObjectFactory::destroy(initial);
         DataObjectFactory::destroy(view);
     }
-    SECTION("Reshape view 3") {
+    SECTION("view 3") {
         const DT * initial = genGivenVals<DT>(2, vals); // 2x6
         const DT * view = DataObjectFactory::create<DT>(initial, 1, 2, 0, 4); // 1x4
         const DT * exp = genGivenVals<DT>(2, {6,7 ,8,9}); // 2x2

--- a/test/runtime/local/kernels/ReshapeTest.cpp
+++ b/test/runtime/local/kernels/ReshapeTest.cpp
@@ -63,11 +63,20 @@ TEMPLATE_PRODUCT_TEST_CASE("Reshape", TAG_KERNELS, (DenseMatrix), (double, uint3
         DataObjectFactory::destroy(view);
     }
     SECTION("Reshape view 2") {
-
         const DT * initial = genGivenVals<DT>(2, vals); // 2x6
         const DT * view = DataObjectFactory::create<DT>(initial, 1, 2, 0, 6); // 1x6
         const DT * exp = genGivenVals<DT>(3, {6,7 ,8,9, 10,11}); // 3x2
         checkReshape(view, 3, 2, exp);
+
+        DataObjectFactory::destroy(exp);
+        DataObjectFactory::destroy(initial);
+        DataObjectFactory::destroy(view);
+    }
+    SECTION("Reshape view 3") {
+        const DT * initial = genGivenVals<DT>(2, vals); // 2x6
+        const DT * view = DataObjectFactory::create<DT>(initial, 1, 2, 0, 4); // 1x4
+        const DT * exp = genGivenVals<DT>(2, {6,7 ,8,9}); // 2x2
+        checkReshape(view, 2, 2, exp);
 
         DataObjectFactory::destroy(exp);
         DataObjectFactory::destroy(initial);


### PR DESCRIPTION
- Implements reshape-kernel for views on `DenseMatrix` datatype.
- Closes #224.