### PR TITLE
[DAPHNE-#350]: DaphneDSL: rbind checks number of rows instead the number of columns

### DIFF
--- a/src/ir/daphneir/DaphneInferShapeOpInterface.cpp
+++ b/src/ir/daphneir/DaphneInferShapeOpInterface.cpp
@@ -109,12 +109,12 @@ ssize_t inferNumColsFromArgs(ValueRange vs) {
     // infered #cols. If the known #cols of any two arguments mismatch, an
     // exception is thrown. Otherwise, if the #cols of any argument is unknown,
     // the infered #cols is unknown.
-    ssize_t numCols = getShape(vs[0]).first;
+    ssize_t numCols = getShape(vs[0]).second;
     bool someUnknown = false;
     if(numCols == -1)
         someUnknown = true;
     for(size_t i = 1; i < vs.size(); i++) {
-        const ssize_t nextNumCols = getShape(vs[i]).first;
+        const ssize_t nextNumCols = getShape(vs[i]).second;
         if(nextNumCols == -1)
             someUnknown = true;
         else if(numCols == -1)


### PR DESCRIPTION
Fixed a bug where inferNumColsFromArgs would use rows instead of columns.
