### PR TITLE
[DAPHNE-#31] Kernel for diagMatrix-operation

### DIFF
--- a/src/ir/daphneir/DaphneInferSparsityOpInterface.cpp
+++ b/src/ir/daphneir/DaphneInferSparsityOpInterface.cpp
@@ -57,6 +57,18 @@ double getSparsityOrUnknownFromScalar(Value v) {
 // Sparsity inference interface implementations
 // ****************************************************************************
 
+std::vector<double> daphne::DiagMatrixOp::inferSparsity() {
+    auto argTy = arg().getType().dyn_cast<daphne::MatrixType>();
+    auto k = argTy.getNumRows();
+    auto sparsity = argTy.getSparsity();
+
+    if(argTy.getSparsity() == -1.0) {
+        sparsity = 1;
+    }
+
+    return {sparsity / k};
+}
+
 std::vector<double> daphne::MatMulOp::inferSparsity() {
     auto lhsTy = lhs().getType().dyn_cast<daphne::MatrixType>();
     auto rhsTy = rhs().getType().dyn_cast<daphne::MatrixType>();

--- a/src/ir/daphneir/DaphneOps.td
+++ b/src/ir/daphneir/DaphneOps.td
@@ -83,7 +83,8 @@ def Daphne_CreateFrameOp : Daphne_Op<"createFrame", [
 }
 
 def Daphne_DiagMatrixOp : Daphne_Op<"diagMatrix", [
-    NumRowsFromArg, NumColsFromArgNumRows
+    NumRowsFromArg, NumColsFromArgNumRows,
+    DeclareOpInterfaceMethods<InferSparsityOpInterface>
 ]> {
     let arguments = (ins Matrix:$arg);
     let results = (outs Matrix:$res);

--- a/src/runtime/local/kernels/kernels.json
+++ b/src/runtime/local/kernels/kernels.json
@@ -424,7 +424,16 @@
         "instantiations": [
             [["DenseMatrix", "double"], ["DenseMatrix", "double"]],
             [["DenseMatrix", "float"], ["DenseMatrix", "float"]],
-            [["DenseMatrix", "int64_t"], ["DenseMatrix", "int64_t"]]
+            [["DenseMatrix", "int64_t"], ["DenseMatrix", "int64_t"]],
+            [["DenseMatrix", "int32_t"], ["DenseMatrix", "int32_t"]],
+            [["CSRMatrix", "double"], ["DenseMatrix", "double"]],
+            [["CSRMatrix", "float"], ["DenseMatrix", "float"]],
+            [["CSRMatrix", "int64_t"], ["DenseMatrix", "int64_t"]],
+            [["CSRMatrix", "int32_t"], ["DenseMatrix", "int32_t"]],
+            [["CSRMatrix", "double"], ["CSRMatrix", "double"]],
+            [["CSRMatrix", "float"], ["CSRMatrix", "float"]],
+            [["CSRMatrix", "int64_t"], ["CSRMatrix", "int64_t"]],
+            [["CSRMatrix", "int32_t"], ["CSRMatrix", "int32_t"]]
         ]
     },
     {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -60,6 +60,7 @@ set(TEST_SOURCES
         runtime/local/kernels/CheckEqTest.cpp
         runtime/local/kernels/ColBindTest.cpp
         runtime/local/kernels/CreateFrameTest.cpp
+        runtime/local/kernels/DiagMatrixTest.cpp
         runtime/local/kernels/DiagVectorTest.cpp
         runtime/local/kernels/DNNPoolingTest.cpp
         runtime/local/kernels/EwBinaryMatTest.cpp

--- a/test/runtime/local/kernels/DiagMatrixTest.cpp
+++ b/test/runtime/local/kernels/DiagMatrixTest.cpp
@@ -1,0 +1,103 @@
+/*
+ * copyright 2021 The DAPHNE Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <runtime/local/datastructures/DenseMatrix.h>
+#include <runtime/local/datastructures/CSRMatrix.h>
+#include <runtime/local/datagen/GenGivenVals.h>
+#include <runtime/local/kernels/CheckEq.h>
+#include <runtime/local/kernels/DiagMatrix.h>
+
+#include <tags.h>
+#include <cstdint>
+#include <catch.hpp>
+
+#define TEST_NAME(opName) "DiagMatrix (" opName ")"
+#define VALUE_TYPES int32_t, float
+
+template<class DTRes, class DT>
+void checkDiagMatrix(const DT * arg, const DTRes * exp) {
+    DTRes * res = nullptr;
+    diagMatrix<DTRes, DT>(res, arg, nullptr);
+    CHECK(*res == *exp);
+}
+
+TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("diag-dense"), TAG_KERNELS, (DenseMatrix), (VALUE_TYPES)) { // NOLINT(cert-err58-cpp)
+    using DT = TestType;
+    using VT = typename DT::VT;
+
+    auto arg = genGivenVals<DT>(3, {
+        3,
+        1,
+        2,
+    });
+    auto dense_exp = genGivenVals<DenseMatrix<VT>>(3, {
+        3,0,0,
+        0,1,0,
+        0,0,2,
+    });
+    auto csr_exp = genGivenVals<CSRMatrix<VT>>(3, {
+        3,0,0,
+        0,1,0,
+        0,0,2,
+    });
+
+    checkDiagMatrix(arg, dense_exp);
+    checkDiagMatrix(arg, csr_exp);
+
+    DataObjectFactory::destroy(csr_exp);
+    DataObjectFactory::destroy(dense_exp);
+    DataObjectFactory::destroy(arg);
+}
+
+TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("diag-csr"), TAG_KERNELS, (CSRMatrix), (VALUE_TYPES)) { // NOLINT(cert-err58-cpp)
+    using DT = TestType;
+
+    auto arg = genGivenVals<DT>(5, {
+        3,
+        0,
+        0,
+	1,
+	0,
+    });
+    auto exp = genGivenVals<DT>(5, {
+        3,0,0,0,0,
+        0,0,0,0,0,
+        0,0,0,0,0,
+        0,0,0,1,0,
+        0,0,0,0,0,
+    });
+
+    checkDiagMatrix(arg, exp);
+
+    DataObjectFactory::destroy(exp);
+    DataObjectFactory::destroy(arg);
+
+    arg = genGivenVals<DT>(3, {
+        3,
+	1,
+	2,
+    });
+    exp = genGivenVals<DT>(3, {
+        3,0,0,
+        0,1,0,
+        0,0,2,
+    });
+
+    checkDiagMatrix(arg, exp);
+
+    DataObjectFactory::destroy(exp);
+    DataObjectFactory::destroy(arg);
+}

--- a/test/runtime/local/kernels/DiagMatrixTest.cpp
+++ b/test/runtime/local/kernels/DiagMatrixTest.cpp
@@ -27,11 +27,12 @@
 #define TEST_NAME(opName) "DiagMatrix (" opName ")"
 #define VALUE_TYPES int32_t, float
 
-template<class DTRes, class DT>
-void checkDiagMatrix(const DT * arg, const DTRes * exp) {
+template<class DTRes, class DTArg>
+void checkDiagMatrix(const DTArg * arg, const DTRes * exp) {
     DTRes * res = nullptr;
-    diagMatrix<DTRes, DT>(res, arg, nullptr);
+    diagMatrix<DTRes, DTArg>(res, arg, nullptr);
     CHECK(*res == *exp);
+    DataObjectFactory::destroy(res);
 }
 
 TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("diag-dense"), TAG_KERNELS, (DenseMatrix), (VALUE_TYPES)) { // NOLINT(cert-err58-cpp)


### PR DESCRIPTION
- Add CSR specializations for the diagMatrix kernel.
- Add sparsity inference for the diagMatrix() daphne op.

Closes https://github.com/daphne-eu/daphne/issues/31