### PR TITLE
Draft: [DAPHNE-#242] Kernel for GroupOp on Frame

### DIFF
--- a/src/runtime/local/kernels/Group.h
+++ b/src/runtime/local/kernels/Group.h
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2021 The DAPHNE Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_RUNTIME_LOCAL_KERNELS_GROUP_H
+#define SRC_RUNTIME_LOCAL_KERNELS_GROUP_H
+
+#include <runtime/local/context/DaphneContext.h>
+#include <runtime/local/datastructures/DataObjectFactory.h>
+#include <runtime/local/datastructures/DenseMatrix.h>
+#include <runtime/local/datastructures/Frame.h>
+#include <runtime/local/datastructures/ValueTypeCode.h>
+#include <runtime/local/datastructures/ValueTypeUtils.h>
+#include <runtime/local/kernels/Order.h>
+#include <runtime/local/kernels/ExtractCol.h>
+#include <util/DeduceType.h>
+#include <ir/daphneir/Daphne.h>
+
+#include <algorithm>
+#include <iterator>
+#include <memory>
+#include <variant>
+#include <vector>
+#include <iostream>
+
+using mlir::daphne::GroupEnumAttr;
+using mlir::daphne::GroupEnum;
+
+// ****************************************************************************
+// Struct for partial template specialization
+// ****************************************************************************
+
+template<class DTRes>
+struct Group {
+    static void apply(DTRes *& res, const DTRes * arg,const char ** keyCols, size_t numKeyCols,
+        const char ** aggCols, size_t numAggCols, GroupEnumAttr * aggFuncs, size_t numAggFuncs, DCTX(ctx)) = delete;
+};
+
+// ****************************************************************************
+// Convenience function
+// ****************************************************************************
+
+template<class DTRes>
+void group(DTRes *& res, const DTRes * arg, const char ** keyCols, size_t numKeyCols,
+        const char ** aggCols, size_t numAggCols, GroupEnumAttr * aggFuncs, size_t numAggFuncs, DCTX(ctx)) {
+    Group<DTRes>::apply(res, arg, keyCols, numKeyCols, aggCols, numAggCols, aggFuncs, numAggFuncs, ctx);
+}
+
+// ****************************************************************************
+// (Partial) template specializations for different data/value types
+// ****************************************************************************
+
+// ----------------------------------------------------------------------------
+// Frame <- Frame
+// ----------------------------------------------------------------------------
+
+template<typename VTRes, typename VTArg>
+VTRes aggregate (const GroupEnum & aggFunc, const VTArg * begin, const VTArg* end) { 
+    switch(aggFunc) {
+        case GroupEnum::COUNT: return end-begin; break; // TODO: Do we need to check for Null elements here?
+        case GroupEnum::SUM: return std::accumulate(begin, end, 0); break;
+        case GroupEnum::MIN: return *std::min_element(begin, end); break;
+        case GroupEnum::MAX: return *std::max_element(begin, end); break; 
+        case GroupEnum::AVG: return ((float) std::accumulate(begin, end, 0))/(end-begin); break;
+        default : return *begin; break;
+    }
+}
+
+template<typename VTRes, typename VTArg>
+struct ColumnGroupAgg {
+    static void apply(Frame * res, const Frame * arg, size_t colIdx, std::vector<std::pair<size_t, size_t>> * groups, GroupEnum aggFunc, DCTX(ctx)) {
+        VTRes * valuesRes = res->getColumn<VTRes>(colIdx)->getValues();
+        const VTArg * valuesArg = arg->getColumn<VTArg>(colIdx)->getValues();
+        size_t rowRes = 0;
+        size_t numRows = arg->getNumRows();
+
+        // case for no duplicates
+        if (groups == nullptr || groups->empty()) {
+            for(size_t r = 0; r < numRows; r++) 
+                valuesRes[rowRes++] = aggregate<VTRes,VTArg>(aggFunc, valuesArg + r, valuesArg + r + 1);
+            return;
+        }
+        
+        std::cout << groups->front().first << std::endl;
+        std::cout << rowRes << std::endl;
+        for(size_t r = 0; r < groups->front().first; r++)
+            valuesRes[rowRes++] = aggregate<VTRes,VTArg>(aggFunc, valuesArg + r, valuesArg + r + 1);
+        for(auto it = groups->begin(); it != groups->end(); ++it) {
+            valuesRes[rowRes++] = aggregate<VTRes,VTArg>(aggFunc, valuesArg + it->first, valuesArg + it->second);
+            for(size_t r = it->second; r < (std::next(it) != groups->end() ? std::next(it)->first : it->second); r++){
+                valuesRes[rowRes++] = aggregate<VTRes,VTArg>(aggFunc, valuesArg + r, valuesArg + r + 1);
+            } 
+        }
+        for(size_t r = groups->back().second; r < numRows; r++) 
+            valuesRes[rowRes++] = aggregate<VTRes,VTArg>(aggFunc, valuesArg + r, valuesArg + r + 1);
+    }
+};
+
+template <> struct Group<Frame> {
+    static void apply(Frame *& res, const Frame * arg, const char ** keyCols, size_t numKeyCols,
+        const char ** aggCols, size_t numAggCols, GroupEnumAttr * aggFuncs, size_t numAggFuncs, DCTX(ctx)) {
+        size_t numRows = arg->getNumRows();
+        size_t numCols = numKeyCols + numAggCols;
+        size_t numRowsRes = numRows;
+        if (arg == nullptr || keyCols == nullptr || aggCols == nullptr || aggFuncs == nullptr || numAggFuncs == 0) {
+            throw std::runtime_error("group-kernel called with invalid arguments");
+        }
+
+        // convert labels to indices
+        auto idxs = std::shared_ptr<size_t[]>(new size_t[numCols]);
+        bool * ascending = new bool[numKeyCols];
+        for (size_t i = 0; i < numKeyCols; i++) {
+            idxs[i] = arg->getColumnIdx(keyCols[i]);
+            ascending[i] = true;
+        }   
+        for (size_t i = numKeyCols; i < numCols; i++) {
+            idxs[i] = arg->getColumnIdx(aggCols[i-numKeyCols]);
+        }
+        
+        // reduce frame columns to keyCols and numAggCols (without copying values or the idx array) and reorder them accordingly 
+        Frame* reduced{};
+        auto sel = DataObjectFactory::create<DenseMatrix<size_t>>(numCols, 1, idxs);
+        sel->print(std::cout);
+        extractCol(reduced, arg, sel, ctx);
+        DataObjectFactory::destroy(sel);
+    
+        std::iota(idxs.get(), idxs.get()+numCols, 0);
+        auto groups = new std::vector<std::pair<size_t, size_t>>;
+        Frame* ordered{};     
+
+        // order frame rows by groups and get the group vector 
+        order(ordered, reduced, idxs.get(), numKeyCols, ascending, ctx, groups);
+        delete [] ascending;
+        DataObjectFactory::destroy(reduced);
+        ordered->print(std::cout);
+        size_t inGroups = 0;
+        for (auto & group : *groups){
+            inGroups += group.second-group.first;
+            std::cout << "Group: " << group.first << " " << group.second << std::endl;
+        }  
+        numRowsRes -= inGroups-groups->size();
+
+        // create the result frame
+        std::string * labels = new std::string[numCols];
+        ValueTypeCode * schema = new ValueTypeCode[numCols];
+
+        for (size_t i = 0; i < numKeyCols; i++) {
+            labels[i] = keyCols[i];
+            schema[i] = ordered->getColumnType(idxs[i]);
+        }
+        for (size_t i = numKeyCols; i < numCols; i++) {
+            labels[i] = mlir::daphne::stringifyGroupEnum(aggFuncs[i-numKeyCols].getValue()).str() + "(" +  aggCols[i-numKeyCols] + ")";
+            switch(aggFuncs[i-numKeyCols].getValue()) {
+                case GroupEnum::COUNT: schema[i] = ValueTypeCode::UI64; break;
+                case GroupEnum::SUM: schema[i] = ordered->getColumnType(idxs[i]); break;
+                case GroupEnum::MIN: schema[i] = ordered->getColumnType(idxs[i]); break;
+                case GroupEnum::MAX: schema[i] = ordered->getColumnType(idxs[i]); break;
+                case GroupEnum::AVG: schema[i] = ValueTypeCode::F64; break;
+            }
+        } 
+        
+        res = DataObjectFactory::create<Frame>(numRowsRes, numCols, schema, labels, false);
+        delete [] labels;
+        delete [] schema;
+
+        // copying key columns and column-wise group aggregation
+        for (size_t i = 0; i < numCols; i++) {
+            DeduceValueTypeAndExecute<ColumnGroupAgg>::apply(res->getSchema()[i], ordered->getSchema()[i], res, ordered, i, groups, (i < numKeyCols) ? (GroupEnum) 0 : aggFuncs[i-numKeyCols].getValue(), ctx);
+        }        
+        delete groups;
+        DataObjectFactory::destroy(ordered);
+   }
+};
+
+#endif //SRC_RUNTIME_LOCAL_KERNELS_GROUP_H
+
+/*
+[DAPHNE-#242] Kernel for GroupOp (grouping by with aggregation) on Frame
+
+To support SQL GROUP BY, we need a kernel for DaphneIR's GroupOp (see src/ir/daphneir/DaphneOps.td). The kernel should have the following interface:
+
+void group(
+        Frame *& res,
+        const Frame * arg,
+        const char ** keyCols, size_t numKeyCols,
+        const char ** aggCols, size_t numAggCols,
+        mlir::daphne::GroupEnumAttr * aggFuncs, size_t numAggFuncs
+);
+The Frame arg shall be grouped by the numKeyCols columns (indicated by name) in keyCols. In addition to that, numAggCols aggregates shall be calculated for each group, whereby the columns to group on are indicated by aggCols and the corresponding aggregate functions (COUNT, SUM, ...) are indicated by aggFuncs. Note that numAggCols and numAggFuncs will always have the same value. Having this information replicated is an artifact of the way we currently lower variadic DaphneIR operations to kernel calls.
+
+For now, it's just about making it work. We can make it efficient later. A straightforward approach would be a sort-based grouping, which sorts the input frame by the key columns using the order-kernel, and calculates the aggregates over the subsequent data elements in a group.
+
+Hints:
+COUNT shall always return a UI64 column.
+AVG shall always return a FP64 column.
+*/

--- a/src/runtime/local/kernels/Order.h
+++ b/src/runtime/local/kernels/Order.h
@@ -23,6 +23,7 @@
 #include <runtime/local/datastructures/ValueTypeCode.h>
 #include <runtime/local/datastructures/ValueTypeUtils.h>
 #include <runtime/local/kernels/ExtractRow.h>
+#include <util/DeduceType.h>
 
 #include <algorithm>
 #include <functional>
@@ -35,7 +36,7 @@
 
 template<class DT>
 struct Order {
-    static void apply(DT *& res, const DT * arg, size_t * colIdxs, size_t numColIdxs, bool * ascending, size_t numAscending, bool returnIdx, DCTX(ctx)) = delete;
+    static void apply(DT *& res, const DT * arg, size_t * colIdxs, size_t numColIdxs, bool * ascending, size_t numAscending, bool returnIdx, DCTX(ctx), std::vector<std::pair<size_t, size_t>> * groupsRes = nullptr) = delete;
 };
 
 // ****************************************************************************
@@ -43,8 +44,13 @@ struct Order {
 // ****************************************************************************
 
 template<class DT>
-void order(DT *& res, const DT * arg, size_t * colIdxs, size_t numColIdxs, bool * ascending, size_t numAscending, bool returnIdx, DCTX(ctx)) {
-    Order<DT>::apply(res, arg, colIdxs, numColIdxs, ascending, numAscending, returnIdx, ctx);
+void order(DT *& res, const DT * arg, size_t * colIdxs, size_t numColIdxs, bool * ascending, size_t numAscending, bool returnIdx, DCTX(ctx), std::vector<std::pair<size_t, size_t>> * groupsRes = nullptr) {
+    Order<DT>::apply(res, arg, colIdxs, numColIdxs, ascending, numAscending, returnIdx, ctx, groupRes);
+}
+
+template<class DT>
+void orderGroups(DT *& res, const DT * arg, size_t * colIdxs, size_t numColIdxs, bool * ascending, size_t numAscending, DCTX(ctx), std::vector<std::pair<size_t, size_t>> * groupsRes = nullptr) {
+    Order<DT>::apply(res, arg, colIdxs, numColIdxs, ascending, numAscending, ctx, groupsRes);
 }
 
 // ****************************************************************************
@@ -89,63 +95,60 @@ void columnIDSort(DenseMatrix<VTIdx> *&idx, const DenseMatrix<VT>* col, std::vec
 
 // sorts IDs inside groups by the key column, reorder the column via a row extraction into a temporary 
 // DenseMatrix and then scan for groups of duplicates to be tie broken by another subsequent key column
-template<typename VTIdx, typename VT>
-void multiColumnIDSort(DenseMatrix<VTIdx> *&idx, const DenseMatrix<VT>* col, std::vector<std::pair<VTIdx, VTIdx>> &groups, bool ascending, DCTX(ctx)){
-    columnIDSort(idx, col, groups, ascending, ctx);
-    DenseMatrix<VT> * tmp = nullptr;
-    extractRow<DenseMatrix<VT>, DenseMatrix<VT>, VTIdx>(tmp, col, idx, ctx);
-    columnGroupScan(groups, tmp, ctx);
-    DataObjectFactory::destroy(tmp);
-} 
+template<typename VTCol>
+struct MultiColumnIDSort {
+    static void apply(const Frame * arg, DenseMatrix<size_t> *&idx, std::vector<std::pair<size_t, size_t>> &groups, bool ascending, size_t colIdx, DCTX(ctx)) {
+        auto col = arg->getColumn<VTCol>(colIdx);
+        columnIDSort(idx, col, groups, ascending, ctx);
+        DenseMatrix<VTCol> * tmp = nullptr;
+        extractRow(tmp, col, idx, ctx);
+        columnGroupScan(groups, tmp, ctx);
+        DataObjectFactory::destroy(tmp);
+    }
+};
+
+template<typename VTCol>
+struct ColumnIDSort {
+    static void apply(const Frame * arg, DenseMatrix<size_t> *&idx, std::vector<std::pair<size_t, size_t>> &groups, bool ascending, size_t colIdx, DCTX(ctx)) {
+        auto col = arg->getColumn<VTCol>(colIdx);
+        columnIDSort(idx, col, groups, ascending, ctx);
+    }
+};
 
 template <> struct Order<Frame> {
-    static void apply(Frame *& res, const Frame * arg, size_t * colIdxs, size_t numColIdxs, bool * ascending, size_t numAscending, bool returnIdx, DCTX(ctx)) {
+    static void apply(Frame *& res, const Frame * arg, size_t * colIdxs, size_t numColIdxs, bool * ascending, size_t numAscending, DCTX(ctx), std::vector<std::pair<size_t, size_t>> * groupsRes = nullptr) {
         size_t numRows = arg->getNumRows();
         if (arg == nullptr || colIdxs == nullptr || numColIdxs == 0 || ascending == nullptr) {
             throw std::runtime_error("order-kernel called with invalid arguments");
         }
-
-        size_t colIdx;
+        
         auto idx = DataObjectFactory::create<DenseMatrix<size_t>>(numRows, 1, false);
         auto indicies = idx->getValues();
         std::iota(indicies, indicies+numRows, 0);
+        
         std::vector<std::pair<size_t, size_t>> groups;
         groups.push_back(std::make_pair(0, numRows));
-        
+            
         if (numColIdxs > 1) {
             for (size_t i = 0; i < numColIdxs-1; i++) {
-                colIdx = colIdxs[i];
-                switch(arg->getColumnType(colIdx)) {
-                    // TODO Memory leak (getColumn(), see #222).
-                    case ValueTypeCode::F64: multiColumnIDSort(idx, arg->getColumn<double>(colIdx), groups, ascending[i], ctx); break;
-                    case ValueTypeCode::F32: multiColumnIDSort(idx, arg->getColumn<float>(colIdx), groups, ascending[i], ctx); break;
-                    case ValueTypeCode::SI64: multiColumnIDSort(idx, arg->getColumn<int64_t>(colIdx), groups, ascending[i], ctx); break;
-                    case ValueTypeCode::SI32: multiColumnIDSort(idx, arg->getColumn<int32_t>(colIdx), groups, ascending[i], ctx); break;
-                    case ValueTypeCode::SI8 : multiColumnIDSort(idx, arg->getColumn<int8_t>(colIdx), groups, ascending[i], ctx); break;
-                    case ValueTypeCode::UI64: multiColumnIDSort(idx, arg->getColumn<uint64_t>(colIdx), groups, ascending[i], ctx); break;
-                    case ValueTypeCode::UI32: multiColumnIDSort(idx, arg->getColumn<uint32_t>(colIdx), groups, ascending[i], ctx); break;
-                    case ValueTypeCode::UI8 : multiColumnIDSort(idx, arg->getColumn<uint8_t>(colIdx), groups, ascending[i], ctx); break;
-                    default: throw std::runtime_error("unknown value type code");
-                }
+                DeduceValueTypeAndExecute<MultiColumnIDSort>::apply(arg->getSchema()[colIdxs[i]], arg, idx, groups, ascending[i], colIdxs[i], ctx);
             }
         }
 
-        colIdx = colIdxs[numColIdxs-1];
-        switch(arg->getColumnType(colIdx)) {
-            // TODO Memory leak (getColumn(), see #222).
-            case ValueTypeCode::F64: columnIDSort(idx, arg->getColumn<double>(colIdx), groups, ascending[numColIdxs-1], ctx); break;
-            case ValueTypeCode::F32: columnIDSort(idx, arg->getColumn<float>(colIdx), groups, ascending[numColIdxs-1], ctx); break;
-            case ValueTypeCode::SI64: columnIDSort(idx, arg->getColumn<int64_t>(colIdx), groups, ascending[numColIdxs-1], ctx); break;
-            case ValueTypeCode::SI32: columnIDSort(idx, arg->getColumn<int32_t>(colIdx), groups, ascending[numColIdxs-1], ctx); break; 
-            case ValueTypeCode::SI8 : columnIDSort(idx, arg->getColumn<int8_t>(colIdx), groups, ascending[numColIdxs-1], ctx); break; 
-            case ValueTypeCode::UI64: columnIDSort(idx, arg->getColumn<uint64_t>(colIdx), groups, ascending[numColIdxs-1], ctx); break;
-            case ValueTypeCode::UI32: columnIDSort(idx, arg->getColumn<uint32_t>(colIdx), groups, ascending[numColIdxs-1], ctx); break;
-            case ValueTypeCode::UI8 : columnIDSort(idx, arg->getColumn<uint8_t>(colIdx), groups, ascending[numColIdxs-1], ctx); break;
-            default: throw std::runtime_error("unknown value type code");
+        // efficient last sort pass OR finalizing the groups vector for further use
+        size_t colIdx = colIdxs[numColIdxs-1];
+        if (groupsRes == nullptr) {
+            DeduceValueTypeAndExecute<ColumnIDSort>::apply(arg->getSchema()[colIdx], arg, idx, groups, ascending[numColIdxs-1], colIdx, ctx);
+        } else {
+            DeduceValueTypeAndExecute<MultiColumnIDSort>::apply(arg->getSchema()[colIdx], arg, idx, groups, ascending[numColIdxs-1], colIdx, ctx);
+            if (groups.front().first == 0 && groups.front().second == numRows) {
+                groups.clear();
+            }
+            groupsRes->insert(groupsRes->end(), groups.begin(), groups.end());
         }
 
         //applying the final object ID permutation (result of the sorting procedure) to the frame via a row extraction
-        extractRow<Frame, Frame, size_t>(res, arg, idx, ctx);
+        extractRow(res, arg, idx, ctx);
         DataObjectFactory::destroy(idx);
     }
 };

--- a/src/runtime/local/kernels/Order.h
+++ b/src/runtime/local/kernels/Order.h
@@ -48,11 +48,6 @@ void order(DT *& res, const DT * arg, size_t * colIdxs, size_t numColIdxs, bool 
     Order<DT>::apply(res, arg, colIdxs, numColIdxs, ascending, numAscending, returnIdx, ctx, groupsRes);
 }
 
-template<class DT>
-void orderGroups(DT *& res, const DT * arg, size_t * colIdxs, size_t numColIdxs, bool * ascending, size_t numAscending, bool returnIdx, DCTX(ctx), std::vector<std::pair<size_t, size_t>> * groupsRes = nullptr) {
-    Order<DT>::apply(res, arg, colIdxs, numColIdxs, ascending, numAscending, returnIdx, ctx, groupsRes);
-}
-
 // ****************************************************************************
 // (Partial) template specializations for different data/value types
 // ****************************************************************************

--- a/src/runtime/local/kernels/Order.h
+++ b/src/runtime/local/kernels/Order.h
@@ -45,12 +45,12 @@ struct Order {
 
 template<class DT>
 void order(DT *& res, const DT * arg, size_t * colIdxs, size_t numColIdxs, bool * ascending, size_t numAscending, bool returnIdx, DCTX(ctx), std::vector<std::pair<size_t, size_t>> * groupsRes = nullptr) {
-    Order<DT>::apply(res, arg, colIdxs, numColIdxs, ascending, numAscending, returnIdx, ctx, groupRes);
+    Order<DT>::apply(res, arg, colIdxs, numColIdxs, ascending, numAscending, returnIdx, ctx, groupsRes);
 }
 
 template<class DT>
-void orderGroups(DT *& res, const DT * arg, size_t * colIdxs, size_t numColIdxs, bool * ascending, size_t numAscending, DCTX(ctx), std::vector<std::pair<size_t, size_t>> * groupsRes = nullptr) {
-    Order<DT>::apply(res, arg, colIdxs, numColIdxs, ascending, numAscending, ctx, groupsRes);
+void orderGroups(DT *& res, const DT * arg, size_t * colIdxs, size_t numColIdxs, bool * ascending, size_t numAscending, bool returnIdx, DCTX(ctx), std::vector<std::pair<size_t, size_t>> * groupsRes = nullptr) {
+    Order<DT>::apply(res, arg, colIdxs, numColIdxs, ascending, numAscending, returnIdx, ctx, groupsRes);
 }
 
 // ****************************************************************************
@@ -116,7 +116,7 @@ struct ColumnIDSort {
 };
 
 template <> struct Order<Frame> {
-    static void apply(Frame *& res, const Frame * arg, size_t * colIdxs, size_t numColIdxs, bool * ascending, size_t numAscending, DCTX(ctx), std::vector<std::pair<size_t, size_t>> * groupsRes = nullptr) {
+    static void apply(Frame *& res, const Frame * arg, size_t * colIdxs, size_t numColIdxs, bool * ascending, size_t numAscending, bool returnIdx, DCTX(ctx), std::vector<std::pair<size_t, size_t>> * groupsRes = nullptr) {
         size_t numRows = arg->getNumRows();
         if (arg == nullptr || colIdxs == nullptr || numColIdxs == 0 || ascending == nullptr) {
             throw std::runtime_error("order-kernel called with invalid arguments");

--- a/src/runtime/local/kernels/Order.h
+++ b/src/runtime/local/kernels/Order.h
@@ -43,6 +43,9 @@ struct Order {
 // Convenience function
 // ****************************************************************************
 
+// Note that we normally don't pass any arguments after the DaphneContext. In
+// this case it is only okay because groupsRes has a default and is meant to be
+// used only by other kernels, not from DaphneDSL.
 template<class DT>
 void order(DT *& res, const DT * arg, size_t * colIdxs, size_t numColIdxs, bool * ascending, size_t numAscending, bool returnIdx, DCTX(ctx), std::vector<std::pair<size_t, size_t>> * groupsRes = nullptr) {
     Order<DT>::apply(res, arg, colIdxs, numColIdxs, ascending, numAscending, returnIdx, ctx, groupsRes);

--- a/src/runtime/local/kernels/kernels.json
+++ b/src/runtime/local/kernels/kernels.json
@@ -2819,17 +2819,17 @@
             "returnType": "void",
             "templateParams": [
                 {
-                    "name": "DTRes",
+                    "name": "DT",
                     "isDataType": true
                 }
             ],
             "runtimeParams": [
                 {
-                    "type": "DTRes *&",
+                    "type": "DT *&",
                     "name": "res"
                 },
                 {
-                    "type": "const DTRes *",
+                    "type": "const DT *",
                     "name": "arg"
                 },
                 {
@@ -2849,7 +2849,7 @@
                     "name": "numAggCols"
                 },
                 {
-                    "type": "GroupEnum *",
+                    "type": "mlir::daphne::GroupEnum *",
                     "name": "aggFuncs",
                     "isVariadic": true
                 },

--- a/src/runtime/local/kernels/kernels.json
+++ b/src/runtime/local/kernels/kernels.json
@@ -2811,5 +2811,56 @@
         "instantiations": [
             ["Frame"]
         ]
+    },
+    {
+        "kernelTemplate": {
+            "header": "Group.h",
+            "opName": "group",
+            "returnType": "void",
+            "templateParams": [
+                {
+                    "name": "DTRes",
+                    "isDataType": true
+                }
+            ],
+            "runtimeParams": [
+                {
+                    "type": "DTRes *&",
+                    "name": "res"
+                },
+                {
+                    "type": "const DTRes *",
+                    "name": "arg"
+                },
+                {
+                    "type": "const char **",
+                    "name": "keyCols"
+                },
+                {
+                    "type": "size_t",
+                    "name": "numKeyCols"
+                },
+                {
+                    "type": "const char **",
+                    "name": "aggCols"
+                },
+                {
+                    "type": "size_t",
+                    "name": "numAggCols"
+                },
+                {
+                    "type": "GroupEnum *",
+                    "name": "aggFuncs",
+                    "isVariadic": true
+                },
+                {
+                    "type": "size_t",
+                    "name": "numAggFuncs"
+                }
+            ]
+        },
+        "instantiations": [
+            ["Frame"]
+        ]
     }
 ]

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -83,6 +83,7 @@ set(TEST_SOURCES
         runtime/local/kernels/ExtractRowTest.cpp
         runtime/local/kernels/FilterRowTest.cpp
         runtime/local/kernels/GroupJoinTest.cpp
+        runtime/local/kernels/GroupTest.cpp
         runtime/local/kernels/HasSpecialValueTest.cpp
         runtime/local/kernels/InnerJoinTest.cpp
         runtime/local/kernels/IsSymmetricTest.cpp

--- a/test/api/cli/sql/SQLTest.cpp
+++ b/test/api/cli/sql/SQLTest.cpp
@@ -71,9 +71,7 @@ MAKE_SUCCESS_TEST_CASE("where", 4);
 
 MAKE_SUCCESS_TEST_CASE("join", 1);
 
-// TODO Use these test cases once we have a kernel for GroupOp, otherwise they
-// always fail.
-//MAKE_SUCCESS_TEST_CASE("group", 3);
+MAKE_SUCCESS_TEST_CASE("group", 3);
 MAKE_PASS_FAILURE_TEST_CASE("group", 1);
 
 // TODO Use the scripts testing failure cases.

--- a/test/runtime/local/kernels/GroupTest.cpp
+++ b/test/runtime/local/kernels/GroupTest.cpp
@@ -159,6 +159,40 @@ TEMPLATE_TEST_CASE("Group", TAG_KERNELS, (Frame)) {
         exp = DataObjectFactory::create<Frame>(colsExp, labelsExp);
         DataObjectFactory::destroy(c0Exp, c1Exp, c2Exp, c3Exp, c4Exp, c5Exp, c6Exp, c7Exp, c8Exp, c9Exp);
     }
+    SECTION("0 grouping columns, 2 identical aggregation columns") {
+        numKeyCols = 0;
+        numAggCols = 2;
+        keyCols = new const char*[10]{};
+        aggCols = new const char*[10]{labels[2].c_str(), labels[2].c_str()};
+        aggFuncs = new mlir::daphne::GroupEnum[numAggCols];
+        aggFuncs[0] = mlir::daphne::GroupEnum::COUNT;
+        aggFuncs[1] = mlir::daphne::GroupEnum::SUM;
+
+        numRows = 1;
+        DenseMatrix<uint64_t> * c0Exp = genGivenVals<DenseMatrix<uint64_t>>(numRows, { 20 });
+        DenseMatrix<VT2> * c1Exp = genGivenVals<DenseMatrix<VT2>>(numRows, { 5 });
+        std::vector<Structure *> colsExp {c0Exp, c1Exp};
+        std::string labelsExp[] = {"COUNT(ccc)", "SUM(ccc)"};
+        exp = DataObjectFactory::create<Frame>(colsExp, labelsExp);
+        DataObjectFactory::destroy(c0Exp, c1Exp);
+    }
+    SECTION("3 grouping column, 0 aggregation columns") {
+        numKeyCols = 3;
+        numAggCols = 0;
+        keyCols = new const char*[10]{labels[0].c_str(), labels[2].c_str(), labels[3].c_str()};
+        aggCols = new const char*[10]{};
+        aggFuncs = nullptr;
+
+        numRows = 9;
+        DenseMatrix<VT0> * c0Exp = genGivenVals<DenseMatrix<VT0>>(numRows, { 1.5, 1.5, 1.5, 1.5, 2.7, 2.7, 2.7, 2.7, 3.2 });
+        DenseMatrix<VT2> * c1Exp = genGivenVals<DenseMatrix<VT2>>(numRows, { -1, 0, 1, 3, -1, 0, 1, 2, 1 });
+        DenseMatrix<VT3> * c2Exp = genGivenVals<DenseMatrix<VT3>>(numRows, { 1, 0, 1, 3, 1, 0, 1, 2, 1 });
+
+        std::vector<Structure *> colsExp {c0Exp, c1Exp, c2Exp};
+        std::string labelsExp[] = {"aaa", "ccc", "ddd"};
+        exp = DataObjectFactory::create<Frame>(colsExp, labelsExp);
+        DataObjectFactory::destroy(c0Exp, c1Exp, c2Exp);
+    }
 
     group(res, arg, keyCols, numKeyCols, aggCols, numAggCols, aggFuncs, numAggCols, nullptr);
     CHECK(*res == *exp);

--- a/test/runtime/local/kernels/GroupTest.cpp
+++ b/test/runtime/local/kernels/GroupTest.cpp
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2021 The DAPHNE Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <runtime/local/datagen/GenGivenVals.h>
+#include <runtime/local/datastructures/DataObjectFactory.h>
+#include <runtime/local/datastructures/DenseMatrix.h>
+#include <runtime/local/datastructures/Frame.h>
+#include <runtime/local/kernels/Order.h>
+#include <runtime/local/kernels/Group.h>
+#include <runtime/local/kernels/CheckEq.h>
+#include <ir/daphneir/Daphne.h>
+
+#include <tags.h>
+#include <catch.hpp>
+#include <vector>
+
+
+TEMPLATE_TEST_CASE("Group", TAG_KERNELS, (Frame)) {
+    using VT0 = double;
+    using VT1 = float;
+    using VT2 = int64_t;
+    using VT3 = uint32_t;
+
+    GroupEnum aggFuncArray[] = { GroupEnum::COUNT, GroupEnum::SUM, GroupEnum::MIN, GroupEnum::MAX, GroupEnum::AVG };
+    size_t numRows = 20;
+
+    auto c0 = genGivenVals<DenseMatrix<VT0>>(numRows, { 1.5, 2.7, 3.2, 1.5, 2.7, 1.5, 2.7, 1.5, 2.7, 1.5,
+                                                        2.7, 1.5, 2.7, 1.5, 2.7, 1.5, 2.7, 1.5, 2.7, 1.5 });
+    auto c1 = genGivenVals<DenseMatrix<VT1>>(numRows, { 1.6, 2.7, 3.2, 1.5, 2.7, 1.5, 2.7, 1.6, 2.8, 1.5,
+                                                        2.7, 1.6, 2.7, 1.5, 2.8, 1.5, 2.7, 1.6, 2.8, 1.5 });
+    auto c2 = genGivenVals<DenseMatrix<VT2>>(numRows, { -1, 0, 1, -1, 0, 1, -1, 0, 1, 3,
+                                                        2, -1, 0, 1, 1, 1, 1, -1, -1, -1});
+    auto c3 = genGivenVals<DenseMatrix<VT3>>(numRows, { 1, 0, 1, 1, 0, 1, 1, 0, 1, 3,
+                                                        2, 1, 0, 1, 1, 1, 1, 1, 1, 1});;
+    auto c4 = genGivenVals<DenseMatrix<VT0>>(numRows, { 1.5, 2.7, 3.2, 1.5, 2.7, 1.5, 2.7, 1.5, 2.7, 1.5,
+                                                        2.7, 1.5, 2.7, 1.5, 2.7, 1.5, 2.7, 1.5, 2.7, 1.5 });
+    auto c5 = genGivenVals<DenseMatrix<VT1>>(numRows, { 1.6, 2.7, 3.2, 1.5, 2.7, 1.5, 2.7, 1.6, 2.8, 1.5,
+                                                        2.7, 1.6, 2.7, 1.5, 2.8, 1.5, 2.7, 1.6, 2.8, 1.5 });
+    auto c6 = genGivenVals<DenseMatrix<VT2>>(numRows, { -1, 0, 1, -1, 0, 1, -1, 0, 1, 3,
+                                                        2, -1, 0, 1, 1, 1, 1, -1, -1, -1});
+    auto c7 = genGivenVals<DenseMatrix<VT3>>(numRows, { 1, 0, 1, 1, 0, 1, 1, 0, 1, 3,
+                                                        2, 1, 0, 1, 1, 1, 1, 1, 1, 1});
+    auto c8 = genGivenVals<DenseMatrix<VT0>>(numRows, { 1.5, 2.7, 3.2, 1.5, 2.7, 1.5, 2.7, 1.5, 2.7, 1.5,
+                                                        2.7, 1.5, 2.7, 1.5, 2.7, 1.5, 2.7, 1.5, 2.7, 1.5 });
+    auto c9 = genGivenVals<DenseMatrix<VT1>>(numRows, { 1.6, 2.7, 3.2, 1.5, 2.7, 1.5, 2.7, 1.6, 2.8, 1.5,
+                                                        2.7, 1.6, 2.7, 1.5, 2.8, 1.5, 2.7, 1.6, 2.8, 1.5 });
+    
+    std::vector<Structure *> colsArg {c0, c1, c2, c3, c4, c5, c6, c7, c8, c9};
+    std::string labels[] = {"aaa", "bbb", "ccc", "ddd", "eee", "fff", "ggg", "hhh", "iii", "jjj",
+                            "kkk", "lll", "mmm", "nnn", "ooo", "ppp", "qqq", "rrr", "sss", "ttt",};
+    auto arg = DataObjectFactory::create<Frame>(colsArg, labels);
+    Frame* exp{};
+    Frame* res{};
+    size_t numKeyCols;
+    size_t numAggCols;
+    const char** keyCols;
+    const char** aggCols;
+    GroupEnumAttr * aggFuncs;
+    
+    std::vector<Structure *> colsExp;
+    std::string * labelsExp;
+
+    auto context = new mlir::MLIRContext();
+
+    SECTION("1 grouping column, 1 aggregation column") {
+        numKeyCols = 1;
+        numAggCols = 1;
+        keyCols = new const char*[10]{labels[0].c_str()};
+        aggCols = new const char*[10]{labels[2].c_str()};
+        aggFuncs = new mlir::daphne::GroupEnumAttr[numAggCols];
+        aggFuncs[0] = mlir::daphne::GroupEnumAttr::get(context, mlir::daphne::GroupEnum::COUNT);
+
+        DenseMatrix<VT0> * c0Exp = genGivenVals<DenseMatrix<VT0>>(3, { 1.5, 2.7, 3.2 });
+        DenseMatrix<uint64_t> * c1Exp = genGivenVals<DenseMatrix<uint64_t>>(3, { 10, 9, 1});
+        std::vector<Structure *> colsExp {c0Exp, c1Exp};
+        std::string labelsExp[] = {"aaa", "COUNT(ccc)"};
+        exp = DataObjectFactory::create<Frame>(colsExp, labelsExp);
+        DataObjectFactory::destroy(c0Exp, c1Exp);
+    }
+    //TODO: more testcases (multi group combinations: 1-3 SUM, MIN, MAX; 3-1 AVG; 5-5 all functions)
+
+    DataObjectFactory::destroy(c0, c1, c2, c3, c4, c5, c6, c7, c8, c9);
+    group(res, arg, keyCols, numKeyCols, aggCols, numAggCols, aggFuncs, numAggCols, nullptr);
+    CHECK(*res == *exp);
+
+    delete [] keyCols;
+    delete [] aggCols;
+    delete aggFuncs;
+    DataObjectFactory::destroy(arg, exp, res);
+}

--- a/test/runtime/local/kernels/GroupTest.cpp
+++ b/test/runtime/local/kernels/GroupTest.cpp
@@ -68,7 +68,7 @@ TEMPLATE_TEST_CASE("Group", TAG_KERNELS, (Frame)) {
     size_t numAggCols;
     const char** keyCols = nullptr;
     const char** aggCols = nullptr;;
-    GroupEnumAttr * aggFuncs = nullptr;
+    GroupEnum * aggFuncs = nullptr;
     
     std::vector<Structure *> colsExp;
 
@@ -79,8 +79,8 @@ TEMPLATE_TEST_CASE("Group", TAG_KERNELS, (Frame)) {
         numAggCols = 1;
         keyCols = new const char*[10]{labels[0].c_str()};
         aggCols = new const char*[10]{labels[2].c_str()};
-        aggFuncs = new mlir::daphne::GroupEnumAttr[numAggCols];
-        aggFuncs[0] = mlir::daphne::GroupEnumAttr::get(context, mlir::daphne::GroupEnum::COUNT);
+        aggFuncs = new mlir::daphne::GroupEnum[numAggCols];
+        aggFuncs[0] = mlir::daphne::GroupEnum::COUNT;
 
         numRows = 3;
         DenseMatrix<VT0> * c0Exp = genGivenVals<DenseMatrix<VT0>>(numRows, { 1.5, 2.7, 3.2 });
@@ -95,10 +95,10 @@ TEMPLATE_TEST_CASE("Group", TAG_KERNELS, (Frame)) {
         numAggCols = 3;
         keyCols = new const char*[10]{labels[7].c_str()};
         aggCols = new const char*[10]{labels[0].c_str(), labels[3].c_str(), labels[2].c_str()};
-        aggFuncs = new mlir::daphne::GroupEnumAttr[numAggCols];
-        aggFuncs[0] = mlir::daphne::GroupEnumAttr::get(context, mlir::daphne::GroupEnum::SUM);
-        aggFuncs[1] = mlir::daphne::GroupEnumAttr::get(context, mlir::daphne::GroupEnum::MIN);
-        aggFuncs[2] = mlir::daphne::GroupEnumAttr::get(context, mlir::daphne::GroupEnum::MAX);
+        aggFuncs = new mlir::daphne::GroupEnum[numAggCols];
+        aggFuncs[0] = mlir::daphne::GroupEnum::SUM;
+        aggFuncs[1] = mlir::daphne::GroupEnum::MIN;
+        aggFuncs[2] = mlir::daphne::GroupEnum::MAX;
 
         numRows = 4;
         DenseMatrix<VT2> * c0Exp = genGivenVals<DenseMatrix<VT2>>(numRows, { 0, 1, 2, 3 });
@@ -116,8 +116,8 @@ TEMPLATE_TEST_CASE("Group", TAG_KERNELS, (Frame)) {
         numAggCols = 1;
         keyCols = new const char*[10]{labels[2].c_str(), labels[1].c_str(), labels[0].c_str()};
         aggCols = new const char*[10]{labels[6].c_str()};
-        aggFuncs = new mlir::daphne::GroupEnumAttr[numAggCols];
-        aggFuncs[0] = mlir::daphne::GroupEnumAttr::get(context, mlir::daphne::GroupEnum::AVG);
+        aggFuncs = new mlir::daphne::GroupEnum[numAggCols];
+        aggFuncs[0] = mlir::daphne::GroupEnum::AVG;
 
         numRows = 12;
         DenseMatrix<VT2> * c0Exp = genGivenVals<DenseMatrix<VT2>>(numRows, { -1, -1, -1, -1, 0, 0, 1, 1, 1, 1, 2, 3 });
@@ -134,12 +134,12 @@ TEMPLATE_TEST_CASE("Group", TAG_KERNELS, (Frame)) {
         numAggCols = 5;
         keyCols = new const char*[10]{labels[0].c_str(), labels[6].c_str(), labels[2].c_str(), labels[8].c_str(), labels[4].c_str()};
         aggCols = new const char*[10]{labels[5].c_str(), labels[1].c_str(), labels[7].c_str(), labels[3].c_str(), labels[9].c_str()};
-        aggFuncs = new mlir::daphne::GroupEnumAttr[numAggCols];
-        aggFuncs[0] = mlir::daphne::GroupEnumAttr::get(context, mlir::daphne::GroupEnum::COUNT);
-        aggFuncs[1] = mlir::daphne::GroupEnumAttr::get(context, mlir::daphne::GroupEnum::SUM);
-        aggFuncs[2] = mlir::daphne::GroupEnumAttr::get(context, mlir::daphne::GroupEnum::MIN);
-        aggFuncs[3] = mlir::daphne::GroupEnumAttr::get(context, mlir::daphne::GroupEnum::MAX);
-        aggFuncs[4] = mlir::daphne::GroupEnumAttr::get(context, mlir::daphne::GroupEnum::AVG);
+        aggFuncs = new mlir::daphne::GroupEnum[numAggCols];
+        aggFuncs[0] = mlir::daphne::GroupEnum::COUNT;
+        aggFuncs[1] = mlir::daphne::GroupEnum::SUM;
+        aggFuncs[2] = mlir::daphne::GroupEnum::MIN;
+        aggFuncs[3] = mlir::daphne::GroupEnum::MAX;
+        aggFuncs[4] = mlir::daphne::GroupEnum::AVG;
 
         numRows = 11;
         DenseMatrix<VT0> * c0Exp = genGivenVals<DenseMatrix<VT0>>(numRows, { 1.5, 1.5, 1.5, 1.5, 1.5, 2.7, 2.7, 2.7, 2.7, 2.7, 3.2 });

--- a/test/runtime/local/kernels/GroupTest.cpp
+++ b/test/runtime/local/kernels/GroupTest.cpp
@@ -68,7 +68,7 @@ TEMPLATE_TEST_CASE("Group", TAG_KERNELS, (Frame)) {
     size_t numAggCols;
     const char** keyCols = nullptr;
     const char** aggCols = nullptr;;
-    GroupEnum * aggFuncs = nullptr;
+    mlir::daphne::GroupEnum * aggFuncs = nullptr;
     
     std::vector<Structure *> colsExp;
 


### PR DESCRIPTION
* Implements column-wise group aggregation on Frames
* Supports the aggregation functions count, sum, min, max and average
* Only materialzes an ordered version of the input frame and the result frame
* Reduces the input frame to key and aggregation columns before mutli-column ordering (without copying) for efficieny
* Utilizes the Order & extractCol Kernel, as well as the  DeduceType Util
* Refactors the Order Kernel to use the DeduceType Util
* Adds an optional export the group vector from the Order Kernel
* This option is less efficient in the last sort step, but overall increases efficiency in scenarios where the final group vector is reused (e.g. Group Kernel)
* Fixes a Warning in ExtractCol (redundant comparison)
* closes https://github.com/daphne-eu/daphne/issues/242