### PR TITLE
[DAPHNE-#230]:  String as value type of DenseMatrix

### DIFF
--- a/src/runtime/local/datagen/GenGivenVals.h
+++ b/src/runtime/local/datagen/GenGivenVals.h
@@ -93,6 +93,22 @@ struct GenGivenVals<DenseMatrix<VT>> {
     }
 };
 
+template<>
+struct GenGivenVals<DenseMatrix<const char*>> {
+    static DenseMatrix<const char*> * generate(size_t numRows, const std::vector<const char*> & elements, size_t minNumNonZeros = 0) {
+        const size_t numCells = elements.size();
+        assert((numCells % numRows == 0) && "number of given data elements must be divisible by given number of rows");
+        const size_t numCols = numCells / numRows;
+        auto res = DataObjectFactory::create<DenseMatrix<const char*>>(numRows, numCols, false);
+        res->prepareAppend();
+        for(size_t r = 0; r < numRows; r++)
+            for(size_t c = 0; c < numCols; c++)
+                res->append(r, c, elements[r * res->getRowSkip() + c]);
+        res->finishAppend();
+        return res;
+    }
+};
+
 // ----------------------------------------------------------------------------
 // CSRMatrix
 // ----------------------------------------------------------------------------

--- a/src/runtime/local/datastructures/DenseMatrix.cpp
+++ b/src/runtime/local/datastructures/DenseMatrix.cpp
@@ -166,7 +166,6 @@ void DenseMatrix<const char*>::alloc_shared_values(std::shared_ptr<const char*[]
 }
 
 void DenseMatrix<const char*>::alloc_shared_strings(std::shared_ptr<CharBuf> src, size_t strBufferCapacity_) {
-    // correct since C++17: Calls delete[] instead of simple delete
     if(src) {
         strBuf = std::shared_ptr<CharBuf>(src);
     }

--- a/src/runtime/local/datastructures/DenseMatrix.cpp
+++ b/src/runtime/local/datastructures/DenseMatrix.cpp
@@ -173,7 +173,7 @@ void DenseMatrix<const char*>::alloc_shared_strings(std::shared_ptr<CharBuf> src
     {
         if(!values)
             alloc_shared_values();
-        strBuf = std::shared_ptr<CharBuf>(new CharBuf(strBufferCapacity_, getNumItems()));
+        strBuf = std::make_shared<CharBuf>(strBufferCapacity_, getNumItems());
         appendZerosRange(&values[0], getNumItems());
     }
 }

--- a/src/runtime/local/datastructures/DenseMatrix.cpp
+++ b/src/runtime/local/datastructures/DenseMatrix.cpp
@@ -106,6 +106,91 @@ DenseMatrix<ValueType>* DenseMatrix<ValueType>::vectorTranspose() const {
     return transposed;
 }
 
+DenseMatrix<const char*>::DenseMatrix(size_t maxNumRows, size_t numCols, bool zero, size_t strBufferCapacity_, ALLOCATION_TYPE type) :
+        Matrix<const char*>(maxNumRows, numCols), rowSkip(numCols), lastAppendedRowIdx(0), lastAppendedColIdx(0)
+{
+#ifndef NDEBUG
+    std::cout << "creating dense matrix of allocation type " << static_cast<int>(type) <<
+              ", dims: " << numRows << "x" << numCols << " req.mem.: " << printBufferSize() << "Mb" << " with at least " << strBufferCapacity_ << " bytes for strings" <<  std::endl;
+#endif
+    if (type == ALLOCATION_TYPE::HOST_ALLOC) {
+        alloc_shared_values();
+        alloc_shared_strings(nullptr, strBufferCapacity_);
+    }
+    else {
+        throw std::runtime_error("Unknown allocation type: " + std::to_string(static_cast<int>(type)));
+    }
+}
+
+DenseMatrix<const char*>::DenseMatrix(size_t numRows, size_t numCols, std::shared_ptr<const char*[]>& strings_, size_t strBufferCapacity_, std::shared_ptr<const char*> cuda_ptr_): 
+            Matrix<const char*>(numRows, numCols), rowSkip(numCols), cuda_ptr(cuda_ptr_), lastAppendedRowIdx(0), lastAppendedColIdx(0){ 
+                alloc_shared_values();
+                alloc_shared_strings();
+                prepareAppend();
+                for(size_t r = 0; r < numRows; r++)
+                    for(size_t c = 0; c < numCols; c++)
+                        append(r, c, strings_.get()[r * rowSkip + c]);
+                finishAppend();
+            }
+
+DenseMatrix<const char*>::DenseMatrix(const DenseMatrix * src, size_t rowLowerIncl, size_t rowUpperExcl, size_t colLowerIncl,
+        size_t colUpperExcl) : Matrix<const char*>(rowUpperExcl - rowLowerIncl, colUpperExcl - colLowerIncl), lastAppendedRowIdx(0), lastAppendedColIdx(0)
+{
+    assert(src && "src must not be null");
+    assert((rowLowerIncl < src->numRows) && "rowLowerIncl is out of bounds");
+    assert((rowUpperExcl <= src->numRows) && "rowUpperExcl is out of bounds");
+    assert((rowLowerIncl < rowUpperExcl) && "rowLowerIncl must be lower than rowUpperExcl");
+    assert((colLowerIncl < src->numCols) && "colLowerIncl is out of bounds");
+    assert((colUpperExcl <= src->numCols) && "colUpperExcl is out of bounds");
+    assert((colLowerIncl < colUpperExcl) && "colLowerIncl must be lower than colUpperExcl");
+
+    rowSkip = src->rowSkip;
+    auto offset = rowLowerIncl * src->rowSkip + colLowerIncl;
+    alloc_shared_values(src->values, offset);
+    alloc_shared_strings(src->strBuf);
+}
+
+void DenseMatrix<const char*>::printValue(std::ostream & os, const char* val) const {
+    os << '\"' << val << "\"";
+}
+
+void DenseMatrix<const char*>::alloc_shared_values(std::shared_ptr<const char*[]> src, size_t offset) {
+    // correct since C++17: Calls delete[] instead of simple delete
+    if(src) {
+        values = std::shared_ptr<const char*[]>(src, src.get() + offset);
+    }
+    else
+    {
+        values = std::shared_ptr<const char*[]>(new const char*[getNumItems()]);
+    }
+}
+
+void DenseMatrix<const char*>::alloc_shared_strings(std::shared_ptr<CharBuf> src, size_t strBufferCapacity_) {
+    // correct since C++17: Calls delete[] instead of simple delete
+    if(src) {
+        strBuf = std::shared_ptr<CharBuf>(src);
+    }
+    else
+    {
+        if(!values)
+            alloc_shared_values();
+        strBuf = std::shared_ptr<CharBuf>(new CharBuf(strBufferCapacity_, getNumItems()));
+        appendZerosRange(&values[0], getNumItems());
+    }
+}
+
+size_t DenseMatrix<const char*>::bufferSize() {
+    return this->getNumItems() * sizeof(const char*);
+}
+
+DenseMatrix<const char*>* DenseMatrix<const char*>::vectorTranspose() const {
+    assert((this->numRows == 1 || this->numCols == 1) && "no-op transpose for vectors only");
+
+    auto transposed = DataObjectFactory::create<DenseMatrix<const char*>>(this->getNumCols(), this->getNumRows(),
+                                                                        this->getValuesSharedPtr());
+    return transposed;
+}
+
 // Convert to an integer to print uint8_t values as numbers
 // even if they fall into the range of special ASCII characters.
 template <> void DenseMatrix<unsigned char>::printValue(std::ostream & os, unsigned char val) const
@@ -191,3 +276,4 @@ template class DenseMatrix<unsigned char>;
 template class DenseMatrix<unsigned int>;
 template class DenseMatrix<unsigned long>;
 template class DenseMatrix<bool>;
+template class DenseMatrix<const char*>;

--- a/src/runtime/local/datastructures/DenseMatrix.h
+++ b/src/runtime/local/datastructures/DenseMatrix.h
@@ -353,13 +353,16 @@ struct CharBuf
         strings = new char[capacity];
         currentTop = strings;
     }
+    ~CharBuf() {
+        delete[] strings;
+    }
     
     void expandStringBuffer(const size_t toFit, const char **vals, const size_t valsSize) {
         size_t strBufSize = getSize();
 
         size_t largerStrCapacity = (capacity * 2) > toFit ? (capacity * 2) : toFit;
         char* largerStrings = new char[largerStrCapacity];
-        memcpy(static_cast<void*>(largerStrings), static_cast<const void*>(strings), strBufSize);
+        memcpy(largerStrings, strings, strBufSize);
 
         auto start = vals[0];
         for(size_t offset = 0; offset < valsSize; offset++)
@@ -513,10 +516,10 @@ public:
         size_t currentSize = strBuf.get()->getSize();
         int32_t diff = strlen(value) - strlen(currentVal);
 
-        if(currentSize + diff > strBuf->capacity)
+        if(currentSize + diff > strBuf->capacity){
             strBuf.get()->expandStringBuffer(currentSize + diff, vals, getNumItems());
-        
-        currentVal = vals[currentPos];
+            currentVal = vals[currentPos];
+        }
 
         if(diff && (currentPos + 1 < getStrBuf()->numCells)) {
             const char* from = values[currentPos + 1];
@@ -528,7 +531,7 @@ public:
 
         if(diff){
             for(size_t offset = currentPos + 1; offset < getStrBuf()->numCells; offset++)
-                vals[offset] = vals[offset] + diff; 
+                vals[offset] += diff; 
         }
 
         strBuf->currentTop += diff;

--- a/src/runtime/local/datastructures/DenseMatrix.h
+++ b/src/runtime/local/datastructures/DenseMatrix.h
@@ -27,7 +27,7 @@
 #include <cassert>
 #include <cstddef>
 #include <cstring>
-
+#include <stdexcept>
 // TODO DenseMatrix should not be concerned about CUDA.
 
 /**
@@ -109,8 +109,10 @@ class DenseMatrix : public Matrix<ValueType>
     ~DenseMatrix() override = default;
 
     [[nodiscard]] size_t pos(size_t rowIdx, size_t colIdx) const {
-        assert((rowIdx < numRows) && "rowIdx is out of bounds");
-        assert((colIdx < numCols) && "colIdx is out of bounds");
+        if(rowIdx >= numRows)
+            throw std::runtime_error("rowIdx is out of bounds");
+        if(colIdx >= numCols)
+            throw std::runtime_error("colIdx is out of bounds");
         return rowIdx * rowSkip + colIdx;
     }
     
@@ -335,4 +337,275 @@ std::ostream & operator<<(std::ostream & os, const DenseMatrix<ValueType> & obj)
     return os;
 }
 
+/*
+    Helper struct for DenseMatrix with strings, represents a char buffer.
+    Needs to keep numCells from original DenseMatrix to manage modifications from views.
+*/
+struct CharBuf
+{
+    char* strings;
+    char* currentTop;
+
+    size_t capacity;
+    size_t numCells;
+
+    CharBuf(size_t capacity_, size_t numCells_) : capacity(capacity_), numCells(numCells_) {
+        strings = new char[capacity];
+        currentTop = strings;
+    }
+    
+    void expandStringBuffer(const size_t toFit, const char **vals, const size_t valsSize) {
+        size_t strBufSize = getSize();
+
+        size_t largerStrCapacity = (capacity * 2) > toFit ? (capacity * 2) : toFit;
+        char* largerStrings = new char[largerStrCapacity];
+        memcpy(static_cast<void*>(largerStrings), static_cast<const void*>(strings), strBufSize);
+
+        auto start = vals[0];
+        for(size_t offset = 0; offset < valsSize; offset++)
+            vals[offset] = &largerStrings[static_cast<size_t>(vals[offset] - start)];
+
+        delete[] strings;
+        strings = largerStrings;
+        capacity = largerStrCapacity;
+        currentTop = &largerStrings[strBufSize];
+    }
+
+    size_t getSize() {
+        return currentTop - strings;
+    }
+};
+
+template <>
+class DenseMatrix<const char*> : public Matrix<const char*>
+{
+    // `using`, so that we do not need to prefix each occurrence of these
+    // fields from the super-classes.
+    using Matrix<const char*>::numRows;
+    using Matrix<const char*>::numCols;
+    
+    size_t rowSkip;
+    std::shared_ptr<const char*[]> values{};
+    std::shared_ptr<CharBuf> strBuf;
+
+    std::shared_ptr<const char*> cuda_ptr{};
+    uint32_t deleted = 0;
+
+    size_t lastAppendedRowIdx;
+    size_t lastAppendedColIdx;
+    
+    // Grant DataObjectFactory access to the private constructors and
+    // destructors.
+    template<class DataType, typename ... ArgTypes>
+    friend DataType * DataObjectFactory::create(ArgTypes ...);
+    template<class DataType>
+    friend void DataObjectFactory::destroy(const DataType * obj);
+
+    DenseMatrix(size_t maxNumRows, size_t numCols, bool zero, size_t strBufCapacity = 1024, ALLOCATION_TYPE type = ALLOCATION_TYPE::HOST_ALLOC);
+    
+    DenseMatrix(size_t numRows, size_t numCols, std::shared_ptr<const char*[]>& strings, size_t strBufCapacity = 1024, std::shared_ptr<const char*> cuda_ptr_ = nullptr);
+
+    DenseMatrix(const DenseMatrix * src, size_t rowLowerIncl, size_t rowUpperExcl, size_t colLowerIncl, size_t colUpperExcl);
+
+    ~DenseMatrix() override = default;
+
+    [[nodiscard]] size_t pos(size_t rowIdx, size_t colIdx) const {
+        if(rowIdx >= numRows)
+            throw std::runtime_error("rowIdx is out of bounds");
+        if(colIdx >= numCols)
+            throw std::runtime_error("colIdx is out of bounds");
+        return rowIdx * rowSkip + colIdx;
+    }
+    
+    void appendZerosRange(const char** valsStartPos, const size_t length)
+    {
+        memset(strBuf->currentTop, '\0', length * sizeof(char));
+        for(size_t val = 0; val < length; val++){
+            valsStartPos[val] = &strBuf->currentTop[val];
+        }
+        strBuf->currentTop += length;
+    }
+
+    void fillZeroUntil(size_t rowIdx, size_t colIdx) {
+        auto vals = values.get();
+        if(rowSkip == numCols || lastAppendedRowIdx == rowIdx) {
+            const size_t startPosIncl = pos(lastAppendedRowIdx, lastAppendedColIdx) + 1;
+            const size_t endPosExcl = pos(rowIdx, colIdx);
+            if(startPosIncl < endPosExcl){
+                appendZerosRange(&vals[startPosIncl], endPosExcl - startPosIncl);
+            }
+        }
+        else {
+            auto v = vals + lastAppendedRowIdx * rowSkip;
+            appendZerosRange(&v[lastAppendedColIdx + 1], numCols - lastAppendedColIdx - 1);
+            v += rowSkip;
+            
+            for(size_t r = lastAppendedRowIdx + 1; r < rowIdx; r++) {
+                appendZerosRange(v, numCols);
+                v += rowSkip;
+            }
+
+            if(colIdx)
+                appendZerosRange(v, colIdx - 1);
+        }
+    }
+
+    void printValue(std::ostream & os, const char* val) const;
+
+    void alloc_shared_values(std::shared_ptr<const char*[]> src = nullptr, size_t offset = 0);
+
+    void alloc_shared_strings(std::shared_ptr<CharBuf> src = nullptr, size_t strBufferCapacity = 1024);
+
+    void alloc_shared_cuda_buffer(std::shared_ptr<const char*> src = nullptr, size_t offset = 0);
+
+public:
+
+    void shrinkNumRows(size_t numRows) {
+        assert((numRows <= this->numRows) && "number of rows can only the shrunk");
+        // TODO Here we could reduce the allocated size of the values array.
+        this->numRows = numRows;
+    }
+    
+    [[nodiscard]] size_t getRowSkip() const {
+        return rowSkip;
+    }
+
+    const char** getValues() const{
+        if(!values)
+            const_cast<DenseMatrix*>(this)->alloc_shared_values();
+        return values.get();
+    }
+
+    const char** getValues(){
+        if(!values)
+            alloc_shared_values();
+        return values.get();
+    }
+
+    std::shared_ptr<CharBuf> getStrBufSharedPtr() const{
+        return strBuf;
+    }
+
+    CharBuf* getStrBuf() const{
+        if(!strBuf)
+            const_cast<DenseMatrix*>(this)->alloc_shared_strings();
+        return strBuf.get();
+    }
+
+    CharBuf* getStrBuf() {
+        if(!strBuf)
+            alloc_shared_strings();
+        return strBuf.get();
+    }
+
+    std::shared_ptr<const char*[]> getValuesSharedPtr() const {
+        return values;
+    }
+    
+    const char* get(size_t rowIdx, size_t colIdx) const override {
+        return getValues()[pos(rowIdx, colIdx)];
+    }
+
+    void set(size_t rowIdx, size_t colIdx, const char* value) override {
+        auto vals = getValues();
+        size_t currentPos = pos(rowIdx, colIdx);
+        auto currentVal = vals[currentPos];
+        size_t currentSize = strBuf.get()->getSize();
+        int32_t diff = strlen(value) - strlen(currentVal);
+
+        if(currentSize + diff > strBuf->capacity)
+            strBuf.get()->expandStringBuffer(currentSize + diff, vals, getNumItems());
+        
+        currentVal = vals[currentPos];
+
+        if(diff && (currentPos + 1 < getStrBuf()->numCells)) {
+            const char* from = values[currentPos + 1];
+            const char* to = from + diff;
+            size_t length = strBuf->currentTop - from;
+            memmove(const_cast<char*>(to), from, length);
+        }
+        memcpy(const_cast<char*>(currentVal), value, strlen(value) + 1);
+
+        if(diff){
+            for(size_t offset = currentPos + 1; offset < getStrBuf()->numCells; offset++)
+                vals[offset] = vals[offset] + diff; 
+        }
+
+        strBuf->currentTop += diff;
+    }
+    
+    void prepareAppend() override {
+        values.get()[0] = "\0";
+        lastAppendedRowIdx = 0;
+        lastAppendedColIdx = 0;
+        strBuf->currentTop = strBuf.get()->strings;
+    }
+    
+    void append(size_t rowIdx, size_t colIdx, const char* value) override {
+        // Set all cells since the last one that was appended to zero.
+        fillZeroUntil(rowIdx, colIdx);
+        auto vals = getValues();
+        // Set the specified cell.
+        size_t length = strlen(value) + 1;
+        size_t currentSize = strBuf.get()->getSize();
+
+        if(currentSize + length > strBuf->capacity)
+            strBuf.get()->expandStringBuffer(currentSize + length, vals, getNumRows() * getNumCols());
+    
+        memcpy(strBuf->currentTop, value, length);
+        vals[pos(rowIdx, colIdx)] = strBuf->currentTop;
+
+        strBuf->currentTop += length;
+        // Update append state.
+        lastAppendedRowIdx = rowIdx;
+        lastAppendedColIdx = colIdx;
+    }
+    
+    void finishAppend() override {
+        if((lastAppendedRowIdx < numRows - 1) || (lastAppendedColIdx < numCols - 1))
+            append(numRows - 1, numCols - 1, "\0");
+    }
+
+    void print(std::ostream & os) const override {
+        os << "DenseMatrix(" << numRows << 'x' << numCols << ", "
+                << ValueTypeUtils::cppNameFor<const char*> << ')' << std::endl;
+        for (size_t r = 0; r < numRows; r++) {
+            for (size_t c = 0; c < numCols; c++) {
+                printValue(os, get(r, c));
+                if (c < numCols - 1)
+                    os << ' ';
+            }
+            os << std::endl;
+        }
+    }
+
+    DenseMatrix<const char*>* sliceRow(size_t rl, size_t ru) const override {
+        return slice(rl, ru, 0, numCols);
+    }
+
+    DenseMatrix<const char*>* sliceCol(size_t cl, size_t cu) const override {
+        return slice(0, numRows, cl, cu);
+    }
+
+    DenseMatrix<const char*>* slice(size_t rl, size_t ru, size_t cl, size_t cu) const override {
+        return DataObjectFactory::create<DenseMatrix<const char*>>(this, rl, ru, cl, cu);
+    }
+
+    size_t bufferSize();
+
+    size_t bufferSize() const { return const_cast<DenseMatrix*>(this)->bufferSize(); }
+
+    float printBufferSize() const { return static_cast<float>(bufferSize()) / (1048576); }
+
+    DenseMatrix<const char*>* vectorTranspose() const;
+
+    bool operator==(const DenseMatrix<const char*> &M) const {
+        assert(getNumRows() != 0 && getNumCols() != 0 && strBuf && values && "Invalid matrix");
+        for(size_t r = 0; r < getNumRows(); r++)
+            for(size_t c = 0; c < getNumCols(); c++)
+                if(strcmp(M.getValues()[M.pos(r,c)], values.get()[pos(r,c)]))
+                    return false;
+        return true;
+  }
+};
 #endif //SRC_RUNTIME_LOCAL_DATASTRUCTURES_DENSEMATRIX_H

--- a/src/runtime/local/datastructures/ValueTypeUtils.cpp
+++ b/src/runtime/local/datastructures/ValueTypeUtils.cpp
@@ -72,6 +72,7 @@ template<> const std::string ValueTypeUtils::cppNameFor<uint64_t> = "uint64_t";
 template<> const std::string ValueTypeUtils::cppNameFor<float>  = "float";
 template<> const std::string ValueTypeUtils::cppNameFor<double> = "double";
 template<> const std::string ValueTypeUtils::cppNameFor<bool> = "bool";
+template<> const std::string ValueTypeUtils::cppNameFor<const char*> = "const char*";
 
 template<> const std::string ValueTypeUtils::irNameFor<int8_t>   = "si8";
 template<> const std::string ValueTypeUtils::irNameFor<int32_t>  = "si32";

--- a/test/runtime/local/datastructures/DenseMatrixTest.cpp
+++ b/test/runtime/local/datastructures/DenseMatrixTest.cpp
@@ -17,6 +17,7 @@
 #include <runtime/local/datastructures/DataObjectFactory.h>
 #include <runtime/local/datastructures/DenseMatrix.h>
 #include <runtime/local/datastructures/ValueTypeUtils.h>
+#include <runtime/local/datagen/GenGivenVals.h>
 
 #include <tags.h>
 
@@ -43,6 +44,129 @@ TEMPLATE_TEST_CASE("DenseMatrix allocates enough space", TAG_DATASTRUCTURES, ALL
         values[i] = ValueType(1);
     
     DataObjectFactory::destroy(m);
+}
+
+TEST_CASE("DenseMatrix for strings", TAG_KERNELS) {
+    
+    const size_t numRows = 3;
+    const size_t numCols = 4;
+    const size_t bytesPerCell = 1;
+
+    SECTION("Append") {
+        auto m = DataObjectFactory::create<DenseMatrix<const char*>>(numRows, numCols, false);
+        auto exp = genGivenVals<DenseMatrix<const char*>>(numRows, {"0", "", "", "3", 
+                                                                    "10", "", "", "13",    
+                                                                    "20", "", "", "23"});
+        m->prepareAppend();
+        for(size_t r = 0; r < numRows; r++)
+            for(size_t c = 0; c < numCols; c++)
+                if(c % 3 == 0)
+                    m->append(r, c, std::string(std::to_string(r*10+c)).c_str());
+
+        m->finishAppend();
+        CHECK(*m == *exp);
+        DataObjectFactory::destroy(m);
+        DataObjectFactory::destroy(exp);
+    }
+
+    SECTION("Set") {
+        auto exp1 = genGivenVals<DenseMatrix<const char*>>(numRows, {"", "1", "", "3",
+                                                                    "", "11", "", "13",
+                                                                    "", "21", "", "23"});
+
+        auto exp2 = genGivenVals<DenseMatrix<const char*>>(numRows, {"0", "1" ,"2", "3",
+                                                                    "10", "11", "12", "13",
+                                                                    "20", "21", "22", "23"});
+        DenseMatrix<const char*> * m = DataObjectFactory::create<DenseMatrix<const char*>>(numRows, numCols, false, numRows*numCols*bytesPerCell);
+
+        for(size_t r = 0; r < numRows; r++)
+            for(size_t c = 0; c < numCols; c++){
+                size_t num = r*10+c;
+                if(num % 2){
+                    // m->set(r, c, std::string(num, 'X').c_str());
+                    m->set(r, c, std::string(std::to_string(num)).c_str());
+                }
+            }
+        CHECK(*m == *exp1);
+        for(size_t r = 0; r < numRows; r++)
+            for(size_t c = 0; c < numCols; c++){
+                size_t num = r*10+c;
+                if(!(num % 2)){
+                    // m->set(r, c, std::string(num, 'Y').c_str());
+                    m->set(r, c, std::string(std::to_string(num)).c_str());
+                }
+            }
+        CHECK(*m == *exp2);
+        DataObjectFactory::destroy(m);
+        DataObjectFactory::destroy(exp1);
+        DataObjectFactory::destroy(exp2);
+    }
+
+    SECTION("Append + Set") {
+
+        auto exp1 = genGivenVals<DenseMatrix<const char*>>(numRows, {"0", "", "", "3", 
+                                                                    "10", "", "", "13",    
+                                                                    "20", "", "", "23"});
+
+        auto exp2 = genGivenVals<DenseMatrix<const char*>>(numRows, {"0", "", "", "3", 
+                                                                    "10", std::string(100, 'O').c_str(), "", "13",    
+                                                                    "20", "", "", "23"});
+
+        auto exp3 = genGivenVals<DenseMatrix<const char*>>(numRows, {"0", "", "", "3", 
+                                                                    "10", std::string(100, 'O').c_str(), "", "13",    
+                                                                    "20", std::string(5000, 'X').c_str(), "", "23"});
+
+        auto exp4 = genGivenVals<DenseMatrix<const char*>>(numRows, {"0", "", "", "3", 
+                                                                    "10", std::string(100, 'O').c_str(), "", "13",    
+                                                                    "20", std::string(5, 'X').c_str(), "", "23"});
+
+        DenseMatrix<const char*> * m = DataObjectFactory::create<DenseMatrix<const char*>>(numRows, numCols, false, numRows*numCols*bytesPerCell);
+        m->set(1, 1, std::string(20, 'C').c_str());
+        m->prepareAppend();
+        for(size_t r = 0; r < numRows; r++)
+            for(size_t c = 0; c < numCols; c++)
+                if(c % 3 == 0)
+                    m->append(r, c, std::string(std::to_string(r*10+c)).c_str());
+
+        m->finishAppend();
+
+        CHECK(*m == *exp1);
+        m->set(1, 1, std::string(100, 'O').c_str());
+        CHECK(*m == *exp2);
+        m->set(2, 1, std::string(5000, 'X').c_str());
+        CHECK(*m == *exp3);
+        m->set(2, 1, std::string(5, 'X').c_str());
+        CHECK(*m == *exp4);
+        DataObjectFactory::destroy(m);
+        DataObjectFactory::destroy(exp1);
+        DataObjectFactory::destroy(exp2);
+        DataObjectFactory::destroy(exp3);
+        DataObjectFactory::destroy(exp4);
+    }
+
+    SECTION("View") {
+        auto exp1 = genGivenVals<DenseMatrix<const char*>>(2, {"1", "2", "11", "12"});
+        auto exp2 = genGivenVals<DenseMatrix<const char*>>(2, {"1", "2", "11", std::string(5, 'X').c_str()});
+        auto exp3 = genGivenVals<DenseMatrix<const char*>>(3, {"0", "1", "2", "3",
+                                                                "10", "11", std::string(5, 'X').c_str(), "13",
+                                                                "20", "21", "22", "23"});
+        DenseMatrix<const char*> * m = DataObjectFactory::create<DenseMatrix<const char*>>(numRows, numCols, false, numRows*numCols*bytesPerCell);
+        for(size_t r = 0; r < numRows; r++)
+            for(size_t c = 0; c < numCols; c++)
+                m->set(r, c, std::string(std::to_string(r*10+c)).c_str());
+        auto mView = DataObjectFactory::create<DenseMatrix<const char*>>(m, 0, 2, 1, 3);
+
+        CHECK(*mView == *exp1);
+        
+        mView->set(1, 1, std::string(5, 'X').c_str());
+        CHECK(*mView == *exp2);
+        CHECK(*m == *exp3);
+
+        DataObjectFactory::destroy(m);
+        DataObjectFactory::destroy(exp1);
+        DataObjectFactory::destroy(exp2);
+        DataObjectFactory::destroy(mView);
+    }
 }
 
 TEST_CASE("DenseMatrix sub-matrix works properly", TAG_DATASTRUCTURES) {

--- a/test/runtime/local/datastructures/DenseMatrixTest.cpp
+++ b/test/runtime/local/datastructures/DenseMatrixTest.cpp
@@ -46,19 +46,21 @@ TEMPLATE_TEST_CASE("DenseMatrix allocates enough space", TAG_DATASTRUCTURES, ALL
     DataObjectFactory::destroy(m);
 }
 
-TEST_CASE("DenseMatrix for strings", TAG_KERNELS) {
+TEST_CASE("DenseMatrix for strings", TAG_DATASTRUCTURES) {
     const size_t numRows = 3;
     const size_t numCols = 4;
     const size_t bytesPerCell = 1;
 
     using expectedStrings = const std::vector<std::string>;
     
+    // We do not use operator== to compare to a matrix created by genGivenVals()
+    // here, since this would rely on the functionality we want to test.
     auto compareMatToArr = [](const DenseMatrix<const char*>* mat, const expectedStrings& exp) {
-        int64_t d = 0;
         for(size_t r = 0; r < mat->getNumRows(); r++)
             for(size_t c = 0; c < mat->getNumCols(); c++)
-                d += strcmp(mat->get(r,c), exp[r*mat->getNumCols() + c].c_str());
-        return d;
+                if(strcmp(mat->get(r,c), exp[r*mat->getNumCols() + c].c_str()))
+                    return false;
+        return true;
     };
 
     SECTION("Append") {
@@ -74,8 +76,7 @@ TEST_CASE("DenseMatrix for strings", TAG_KERNELS) {
                     m->append(r, c, std::string(std::to_string(r*10+c)).c_str());
 
         m->finishAppend();
-        CHECK(compareMatToArr(m, exp) == 0);
-        compareMatToArr(m, exp);
+        CHECK(compareMatToArr(m, exp));
         DataObjectFactory::destroy(m);
     }
 
@@ -93,20 +94,18 @@ TEST_CASE("DenseMatrix for strings", TAG_KERNELS) {
             for(size_t c = 0; c < numCols; c++){
                 size_t num = r*10+c;
                 if(num % 2){
-                    // m->set(r, c, std::string(num, 'X').c_str());
                     m->set(r, c, std::string(std::to_string(num)).c_str());
                 }
             }
-        CHECK(compareMatToArr(m, exp1) == 0);
+        CHECK(compareMatToArr(m, exp1));
         for(size_t r = 0; r < numRows; r++)
             for(size_t c = 0; c < numCols; c++){
                 size_t num = r*10+c;
                 if(!(num % 2)){
-                    // m->set(r, c, std::string(num, 'Y').c_str());
                     m->set(r, c, std::string(std::to_string(num)).c_str());
                 }
             }
-        CHECK(compareMatToArr(m, exp2) == 0);
+        CHECK(compareMatToArr(m, exp2));
         DataObjectFactory::destroy(m);
     }
 
@@ -128,23 +127,22 @@ TEST_CASE("DenseMatrix for strings", TAG_KERNELS) {
                                     "10", std::string(100, 'O').c_str(), "", "13",    
                                     "20", std::string(5, 'X').c_str(), "", "23"};
 
-        DenseMatrix<const char*> * m = DataObjectFactory::create<DenseMatrix<const char*>>(numRows, numCols, false, numRows*numCols*bytesPerCell);
-        m->set(1, 1, std::string(20, 'C').c_str());
+        auto m = DataObjectFactory::create<DenseMatrix<const char*>>(numRows, numCols, false, numRows*numCols*bytesPerCell);
+        m->set(1, 1, std::string(20, 'C').c_str()); // will be overwritten by append
         m->prepareAppend();
         for(size_t r = 0; r < numRows; r++)
             for(size_t c = 0; c < numCols; c++)
                 if(c % 3 == 0)
                     m->append(r, c, std::string(std::to_string(r*10+c)).c_str());
-
         m->finishAppend();
 
-        CHECK(compareMatToArr(m, exp1) == 0);
+        CHECK(compareMatToArr(m, exp1));
         m->set(1, 1, std::string(100, 'O').c_str());
-        CHECK(compareMatToArr(m, exp2) == 0);
+        CHECK(compareMatToArr(m, exp2));
         m->set(2, 1, std::string(5000, 'X').c_str());
-        CHECK(compareMatToArr(m, exp3) == 0);
+        CHECK(compareMatToArr(m, exp3));
         m->set(2, 1, std::string(5, 'X').c_str());
-        CHECK(compareMatToArr(m, exp4) == 0);
+        CHECK(compareMatToArr(m, exp4));
         DataObjectFactory::destroy(m);
     }
 
@@ -159,11 +157,11 @@ TEST_CASE("DenseMatrix for strings", TAG_KERNELS) {
             for(size_t c = 0; c < numCols; c++)
                 m->set(r, c, std::string(std::to_string(r*10+c)).c_str());
         auto mView = DataObjectFactory::create<DenseMatrix<const char*>>(m, 0, 2, 1, 3);
-        CHECK(compareMatToArr(mView, exp1) == 0);
+        CHECK(compareMatToArr(mView, exp1));
         
         mView->set(1, 1, std::string(5, 'X').c_str());
-        CHECK(compareMatToArr(mView, exp2) == 0);
-        CHECK(compareMatToArr(m, exp3) == 0);
+        CHECK(compareMatToArr(mView, exp2));
+        CHECK(compareMatToArr(m, exp3));
 
         DataObjectFactory::destroy(m);
         DataObjectFactory::destroy(mView);


### PR DESCRIPTION
- Implements `DenseMatrix` template specification for `const char*`.
- Additional argument `strBufCapacity` is introduced to allow user-defined initial strings buffer capacity.
- A small `CharBuf` struct is introduced and used for storing and managing `char *` buffer of **null-terminated** strings.
- `DenseMatrix` for strings is built around two arrays:
- - `strings` - Character array stored in `CharBuf`.
- - `values` - A `DenseMatrix` local array with `const char *` offsets in `strings`.
- `DenseMatrix` constructor sets all strings to `\0` by default to avoid issues regarding null-termination.
- Supports `set()`: memory in `strings` is shifted and `values` are adjusted according to `diff` between strings.
- Supports `append()`: any previous content gets simply overwritten.
- Supports `get()`: no changes, a pointer to null-terminated string is returned.
- Supports views: `CharBuf` is shared, so changes are propagated accordingly.
- - Note: `CharBuf` has to remember the number of cells in the original `DenseMatrix` to properly handle memory shifts when using views.
- Overruns are handled by expanding `strings` to either double the storage or, if more required, exactly to the required size, the content is copied over to the new storage, the old pointer is deleted.
- Changed asserts in `pos()` to exceptions to actually report an issue.
