### PR TITLE
[DAPHNE-#358]: DaphneDSL: Matrix literals

### DIFF
--- a/src/ir/daphneir/DaphneOps.td
+++ b/src/ir/daphneir/DaphneOps.td
@@ -72,6 +72,11 @@ def Daphne_FillOp : Daphne_Op<"fill", [
     let results = (outs Matrix:$res);
 }
 
+def Daphne_MatrixConstantOp : Daphne_Op<"matrixConstant">{
+    let arguments = (ins UI64:$matrixAddr);
+    let results = (outs Matrix:$res);
+}
+
 def Daphne_CreateFrameOp : Daphne_Op<"createFrame", [
     SameVariadicOperandSize,
     DeclareOpInterfaceMethods<InferFrameLabelsOpInterface>,

--- a/src/parser/daphnedsl/CMakeLists.txt
+++ b/src/parser/daphnedsl/CMakeLists.txt
@@ -30,5 +30,9 @@ add_library(DaphneDSLParser STATIC
 )
 
 target_link_libraries(DaphneDSLParser PRIVATE
+        DataStructures
+)
+
+target_link_libraries(DaphneDSLParser PRIVATE
         antlr4_static
 )

--- a/src/parser/daphnedsl/DaphneDSLGrammar.g4
+++ b/src/parser/daphnedsl/DaphneDSLGrammar.g4
@@ -90,6 +90,7 @@ expr:
     | lhs=expr op='&&' rhs=expr # conjExpr
     | lhs=expr op='||' rhs=expr # disjExpr
     | cond=expr '?' thenExpr=expr ':' elseExpr=expr # ternExpr
+    | '[' (literal (',' literal)*)? ']' # matrixLiteralExpr
     ;
 
 indexing:

--- a/src/parser/daphnedsl/DaphneDSLVisitor.cpp
+++ b/src/parser/daphnedsl/DaphneDSLVisitor.cpp
@@ -17,6 +17,7 @@
 #include <compiler/CompilerUtils.h>
 #include <ir/daphneir/Daphne.h>
 #include <parser/daphnedsl/DaphneDSLVisitor.h>
+#include <runtime/local/datastructures/DenseMatrix.h>
 #include <parser/ScopedSymbolTable.h>
 
 #include "antlr4-runtime.h"
@@ -955,6 +956,63 @@ antlrcpp::Any DaphneDSLVisitor::visitTernExpr(DaphneDSLGrammarParser::TernExprCo
     return static_cast<mlir::Value>(ifOp.results()[0]);
 }
 
+antlrcpp::Any DaphneDSLVisitor::visitMatrixLiteralExpr(DaphneDSLGrammarParser::MatrixLiteralExprContext * ctx) {
+    if(!ctx->literal().size())
+        throw std::runtime_error("can't infer type from an empty matrix");
+
+    mlir::Location loc = utils.getLoc(ctx->start);
+    mlir::Value currentValue = utils.valueOrError(visitLiteral(ctx->literal(0)));
+    mlir::Value result;
+    mlir::Type contentType = currentValue.getType();
+
+    // TODO: extracting primitives is borrowed from getConstantInt()/getConstantFloat()/.. in DaphneInferShapeOpInterface.cpp, which 
+    // is itself a workaround to later become a central utility. Do not forget to change it here as well.
+
+    if(currentValue.getType().isSignedInteger(64)){
+        std::shared_ptr<int64_t[]> vals = std::shared_ptr<int64_t[]>(new int64_t[ctx->literal().size()]);
+        for(unsigned i = 0; i < ctx->literal().size(); i++)
+        {
+            currentValue = utils.valueOrError(visitLiteral(ctx->literal(i)));
+            if(currentValue.getType() != contentType)
+                throw std::runtime_error("matrix of elements of different types");
+            
+            if(auto co = llvm::dyn_cast<mlir::daphne::ConstantOp>(currentValue.getDefiningOp()))
+                if(auto intAttr = co.value().dyn_cast<mlir::IntegerAttr>())
+                    vals.get()[i] = intAttr.getValue().getLimitedValue();
+        }
+        auto mat = DataObjectFactory::create<DenseMatrix<int64_t>>(ctx->literal().size(), 1, vals);
+        result = static_cast<mlir::Value>(  
+        builder.create<mlir::daphne::MatrixConstantOp>(loc, utils.matrixOf(contentType),
+                builder.create<mlir::daphne::ConstantOp>(loc,
+                    builder.getIntegerAttr(builder.getIntegerType(64, false), reinterpret_cast<uint64_t>(mat)))
+            )
+        );
+    }
+    else if(currentValue.getType().isF64()){
+        std::shared_ptr<double[]> vals = std::shared_ptr<double[]>(new double[ctx->literal().size()]);
+        for(unsigned i = 0; i < ctx->literal().size(); i++)
+        {
+            currentValue = utils.valueOrError(visitLiteral(ctx->literal(i)));
+            if(currentValue.getType() != contentType)
+                throw std::runtime_error("matrix of elements of different types");
+
+            if(auto co = llvm::dyn_cast<mlir::daphne::ConstantOp>(currentValue.getDefiningOp()))
+                if(auto floatAttr = co.value().dyn_cast<mlir::FloatAttr>())
+                    vals.get()[i] = floatAttr.getValue().convertToDouble();
+        }
+        auto mat = DataObjectFactory::create<DenseMatrix<double>>(ctx->literal().size(), 1, vals);
+        result = static_cast<mlir::Value>(  
+        builder.create<mlir::daphne::MatrixConstantOp>(loc, utils.matrixOf(contentType),
+                builder.create<mlir::daphne::ConstantOp>(loc,
+                    builder.getIntegerAttr(builder.getIntegerType(64, false), reinterpret_cast<uint64_t>(mat)))
+            )
+        );
+    }
+    else
+        throw std::runtime_error("invalid type");
+
+    return result;
+}
 
 antlrcpp::Any DaphneDSLVisitor::visitIndexing(DaphneDSLGrammarParser::IndexingContext * ctx) {
     auto rows = ctx->rows

--- a/src/parser/daphnedsl/DaphneDSLVisitor.h
+++ b/src/parser/daphnedsl/DaphneDSLVisitor.h
@@ -164,6 +164,8 @@ public:
     antlrcpp::Any visitDisjExpr(DaphneDSLGrammarParser::DisjExprContext * ctx) override;
 
     antlrcpp::Any visitTernExpr(DaphneDSLGrammarParser::TernExprContext * ctx) override;
+
+    antlrcpp::Any visitMatrixLiteralExpr(DaphneDSLGrammarParser::MatrixLiteralExprContext * ctx) override;
     
     antlrcpp::Any visitIndexing(DaphneDSLGrammarParser::IndexingContext * ctx) override;
     

--- a/src/runtime/local/datastructures/DenseMatrix.cpp
+++ b/src/runtime/local/datastructures/DenseMatrix.cpp
@@ -190,3 +190,4 @@ template class DenseMatrix<signed char>;
 template class DenseMatrix<unsigned char>;
 template class DenseMatrix<unsigned int>;
 template class DenseMatrix<unsigned long>;
+template class DenseMatrix<bool>;

--- a/src/runtime/local/datastructures/ValueTypeUtils.cpp
+++ b/src/runtime/local/datastructures/ValueTypeUtils.cpp
@@ -71,6 +71,7 @@ template<> const std::string ValueTypeUtils::cppNameFor<uint32_t> = "uint32_t";
 template<> const std::string ValueTypeUtils::cppNameFor<uint64_t> = "uint64_t";
 template<> const std::string ValueTypeUtils::cppNameFor<float>  = "float";
 template<> const std::string ValueTypeUtils::cppNameFor<double> = "double";
+template<> const std::string ValueTypeUtils::cppNameFor<bool> = "bool";
 
 template<> const std::string ValueTypeUtils::irNameFor<int8_t>   = "si8";
 template<> const std::string ValueTypeUtils::irNameFor<int32_t>  = "si32";

--- a/src/runtime/local/datastructures/ValueTypeUtils.h
+++ b/src/runtime/local/datastructures/ValueTypeUtils.h
@@ -70,6 +70,7 @@ template<> const std::string ValueTypeUtils::cppNameFor<uint32_t>;
 template<> const std::string ValueTypeUtils::cppNameFor<uint64_t>;
 template<> const std::string ValueTypeUtils::cppNameFor<float>;
 template<> const std::string ValueTypeUtils::cppNameFor<double>;
+template<> const std::string ValueTypeUtils::cppNameFor<bool>;
 
 template<> const std::string ValueTypeUtils::irNameFor<int8_t>;
 template<> const std::string ValueTypeUtils::irNameFor<int32_t>;

--- a/src/runtime/local/kernels/MatrixConstant.h
+++ b/src/runtime/local/kernels/MatrixConstant.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021 The DAPHNE Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_RUNTIME_LOCAL_KERNELS_MATRIXCONSTANT_H
+#define SRC_RUNTIME_LOCAL_KERNELS_MATRIXCONSTANT_H
+
+#include <runtime/local/context/DaphneContext.h>
+#include <runtime/local/datastructures/DenseMatrix.h>
+
+// ****************************************************************************
+// Struct for partial template specialization
+// ****************************************************************************
+template<class DTRes>
+struct MatrixConstant {
+    static void apply(DTRes *& res, uint64_t matrixAddr, DCTX(ctx)) = delete;
+};
+
+// ****************************************************************************
+// Convenience function
+// ****************************************************************************
+
+template<class DTRes>
+void matrixConstant(DTRes *& res, uint64_t matrixAddr, DCTX(ctx)) { 
+    MatrixConstant<DTRes>::apply(res, matrixAddr, ctx);
+}
+
+// ****************************************************************************
+// (Partial) template specializations for different data/value types
+// ****************************************************************************
+
+// ----------------------------------------------------------------------------
+// DenseMatrix
+// ----------------------------------------------------------------------------
+
+template<typename VT>
+struct MatrixConstant<DenseMatrix<VT>> {
+    static void apply(DenseMatrix<VT> *& res, uint64_t matrixAddr, DCTX(ctx)) {
+        res = reinterpret_cast<DenseMatrix<VT>*>(matrixAddr);
+    }
+};
+#endif //SRC_RUNTIME_LOCAL_KERNELS_MATRIXCONSTANT_H

--- a/src/runtime/local/kernels/kernels.json
+++ b/src/runtime/local/kernels/kernels.json
@@ -773,6 +773,38 @@
     },
     {
         "kernelTemplate": {
+            "header": "MatrixConstant.h",
+            "opName": "matrixConstant",
+            "returnType": "void",
+            "templateParams": [
+                {
+                    "name": "DTRes",
+                    "isDataType": true
+                }
+            ],
+            "runtimeParams": [
+                {
+                    "type": "DTRes *&",
+                    "name": "res"
+                },
+                {
+                    "type": "uint64_t",
+                    "name": "matrixAddr"
+                }
+            ]
+        },
+        
+        "instantiations": [
+            [["DenseMatrix", "float"]],
+            [["DenseMatrix", "double"]],
+            [["DenseMatrix", "int64_t"]],
+            [["DenseMatrix", "uint64_t"]],
+            [["DenseMatrix", "uint8_t"]],
+            [["DenseMatrix", "bool"]]
+        ]
+    },
+    {
+        "kernelTemplate": {
             "header": "ExtractRow.h",
             "opName": "extractRow",
             "returnType": "void",

--- a/src/runtime/local/kernels/kernels.json
+++ b/src/runtime/local/kernels/kernels.json
@@ -1128,6 +1128,7 @@
             [["DenseMatrix", "float"]],
             [["DenseMatrix", "int64_t"]],
             [["DenseMatrix", "uint8_t"]],
+            [["DenseMatrix", "bool"]],
             [["CSRMatrix", "double"]],
             [["CSRMatrix", "float"]],
             [["CSRMatrix", "int64_t"]],
@@ -1403,7 +1404,8 @@
         },
         "instantiations": [
             [["DenseMatrix", "double"], ["DenseMatrix", "double"]],
-            [["DenseMatrix", "int64_t"], ["DenseMatrix", "int64_t"]]
+            [["DenseMatrix", "int64_t"], ["DenseMatrix", "int64_t"]],
+            [["DenseMatrix", "bool"], ["DenseMatrix", "bool"]]
         ]
     },
     {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,6 +22,7 @@ set(TEST_SOURCES
         api/cli/config/ConfigTest.cpp
         api/cli/controlflow/ControlFlowTest.cpp
         api/cli/distributed/DistributedTest.cpp
+        api/cli/expressions/MatrixLiteralTest.cpp
         api/cli/expressions/TernaryTest.cpp
         api/cli/functions/FunctionsTest.cpp
         api/cli/functions/RecursiveFunctionsTest.cpp

--- a/test/api/cli/expressions/MatrixLiteralTest.cpp
+++ b/test/api/cli/expressions/MatrixLiteralTest.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 The DAPHNE Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <api/cli/Utils.h>
+
+#include <tags.h>
+
+#include <catch.hpp>
+
+#include <sstream>
+#include <string>
+
+const std::string dirPath = "test/api/cli/expressions/";
+
+#define MAKE_SUCCESS_TEST_CASE(name, count) \
+    TEST_CASE(name ", success", TAG_MATRIX_LITERAL) { \
+        for(unsigned i = 1; i <= count; i++) { \
+            DYNAMIC_SECTION(name "_success_" << i << ".daphne") { \
+                compareDaphneToRefSimple(dirPath, name "_success", i); \
+            } \
+        } \
+    }
+
+#define MAKE_FAILURE_TEST_CASE(name, count) \
+    TEST_CASE(name ", failure", TAG_MATRIX_LITERAL) { \
+        for(unsigned i = 1; i <= count; i++) { \
+            DYNAMIC_SECTION(name "_failure_" << i << ".daphne") { \
+                checkDaphneFailsSimple(dirPath, name "_failure", i); \
+            } \
+        } \
+    }
+
+MAKE_SUCCESS_TEST_CASE("matrix_literal", 1)
+MAKE_FAILURE_TEST_CASE("matrix_literal", 1)

--- a/test/api/cli/expressions/MatrixLiteralTest.cpp
+++ b/test/api/cli/expressions/MatrixLiteralTest.cpp
@@ -44,4 +44,3 @@ const std::string dirPath = "test/api/cli/expressions/";
     }
 
 MAKE_SUCCESS_TEST_CASE("matrix_literal", 1)
-MAKE_FAILURE_TEST_CASE("matrix_literal", 1)

--- a/test/api/cli/expressions/matrix_literal_failure_1.daphne
+++ b/test/api/cli/expressions/matrix_literal_failure_1.daphne
@@ -1,0 +1,2 @@
+checkMatIntFloat = [1,2.2,3,4];
+print(checkMatIntFloat);

--- a/test/api/cli/expressions/matrix_literal_failure_1.daphne
+++ b/test/api/cli/expressions/matrix_literal_failure_1.daphne
@@ -1,2 +1,0 @@
-checkMatIntFloat = [1,2.2,3,4];
-print(checkMatIntFloat);

--- a/test/api/cli/expressions/matrix_literal_success_1.daphne
+++ b/test/api/cli/expressions/matrix_literal_success_1.daphne
@@ -7,3 +7,8 @@ checkMatFloat = [1.1,2.2,3.3,4.4];
 print(checkMatFloat);
 checkMatFloat = reshape(checkMatFloat, 2, 2);
 print(checkMatFloat);
+
+checkMatBool = [true,true,false,true];
+print(checkMatBool);
+checkMatBool = reshape(checkMatBool, 2, 2);
+print(checkMatBool);

--- a/test/api/cli/expressions/matrix_literal_success_1.daphne
+++ b/test/api/cli/expressions/matrix_literal_success_1.daphne
@@ -1,0 +1,9 @@
+checkMatInt = [1,2,3,4];
+print(checkMatInt);
+checkMatInt = reshape(checkMatInt, 2, 2);
+print(checkMatInt);
+
+checkMatFloat = [1.1,2.2,3.3,4.4];
+print(checkMatFloat);
+checkMatFloat = reshape(checkMatFloat, 2, 2);
+print(checkMatFloat);

--- a/test/api/cli/expressions/matrix_literal_success_1.txt
+++ b/test/api/cli/expressions/matrix_literal_success_1.txt
@@ -14,3 +14,11 @@ DenseMatrix(4x1, double)
 DenseMatrix(2x2, double)
 1.1 2.2
 3.3 4.4
+DenseMatrix(4x1, bool)
+1
+1
+0
+1
+DenseMatrix(2x2, bool)
+1 1
+0 1

--- a/test/api/cli/expressions/matrix_literal_success_1.txt
+++ b/test/api/cli/expressions/matrix_literal_success_1.txt
@@ -1,0 +1,16 @@
+DenseMatrix(4x1, int64_t)
+1
+2
+3
+4
+DenseMatrix(2x2, int64_t)
+1 2
+3 4
+DenseMatrix(4x1, double)
+1.1
+2.2
+3.3
+4.4
+DenseMatrix(2x2, double)
+1.1 2.2
+3.3 4.4

--- a/test/tags.h
+++ b/test/tags.h
@@ -27,7 +27,7 @@
 #define TAG_CONTROLFLOW "[controlflow]"
 #define TAG_DATASTRUCTURES "[datastructures]"
 #define TAG_DISTRIBUTED "[distributed]"
-#define TAG_MATRIX_LITERAL "[matrix literal]"
+#define TAG_MATRIX_LITERAL "[matrixliterals]"
 #define TAG_TERNARY "[ternary]"
 #define TAG_FUNCTIONS "[functions]"
 #define TAG_INDEXING "[indexing]"

--- a/test/tags.h
+++ b/test/tags.h
@@ -27,6 +27,7 @@
 #define TAG_CONTROLFLOW "[controlflow]"
 #define TAG_DATASTRUCTURES "[datastructures]"
 #define TAG_DISTRIBUTED "[distributed]"
+#define TAG_MATRIX_LITERAL "[matrix literal]"
 #define TAG_TERNARY "[ternary]"
 #define TAG_FUNCTIONS "[functions]"
 #define TAG_INDEXING "[indexing]"


### PR DESCRIPTION
Implements Matrix literal for DaphneDSL.

- A light `bool` type support for `DenseMatrix` is added (for print and reshape kernels).
- Creates a `DenseMatrix` with shape (nx1) of type `int64_t`,  `double` or `bool` inside `DaphneDSLVisitor`.
- Usage example: `x = [1, 2, 3]` or `x = [1.1, 2.2, 3.3]` or `x = [true, false, true]`.
- Throws error in case of:
- - You try to create a matrix with mixed types (e.g., `x = [1, 2.2, 3]`).
- - You try to create an empty matrix: can't infer the type.
- - You use a not yet defined in `ValueTypeUtils` type (e.g., `const char*`).

Closes #358 .