### PR TITLE
 [DAPHNE-#390]: Kernel for ctable operation

### DIFF
--- a/src/runtime/local/kernels/CTable.h
+++ b/src/runtime/local/kernels/CTable.h
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2021 The DAPHNE Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_RUNTIME_LOCAL_KERNELS_CTABLE_H
+#define SRC_RUNTIME_LOCAL_KERNELS_CTABLE_H
+
+#include <runtime/local/context/DaphneContext.h>
+#include <runtime/local/datastructures/DataObjectFactory.h>
+#include <runtime/local/datastructures/DenseMatrix.h>
+#include <runtime/local/datastructures/CSRMatrix.h>
+
+// ****************************************************************************
+// Struct for partial template specialization
+// ****************************************************************************
+
+template<class DTRes, class DTLhs, class DTRhs>
+struct CTable {
+    static void apply(DTRes *& res, const DTLhs * lhs, const DTRhs * rhs, DCTX(ctx)) = delete;
+};
+
+// ****************************************************************************
+// Convenience function
+// ****************************************************************************
+
+template<class DTRes, class DTLhs, class DTRhs>
+void ctable(DTRes *& res, const DTLhs * lhs, const DTRhs * rhs, DCTX(ctx)) {
+    CTable<DTRes, DTLhs, DTRhs>::apply(res, lhs, rhs, ctx);
+}
+
+// ****************************************************************************
+// (Partial) template specializations for different data/value types
+// ****************************************************************************
+
+// ----------------------------------------------------------------------------
+// DenseMatrix <- DenseMatrix, DenseMatrix
+// ----------------------------------------------------------------------------
+
+template<typename VTArg>
+struct CTable<DenseMatrix<VTArg>, DenseMatrix<VTArg>, DenseMatrix<VTArg>> {
+    static void apply(DenseMatrix<VTArg> *& res, const DenseMatrix<VTArg> * lhs, const DenseMatrix<VTArg> * rhs, DCTX(ctx)) {
+        const size_t lhsNumRows = lhs->getNumRows();
+        const size_t lhsNumCols = lhs->getNumCols();
+        const size_t rhsNumRows = rhs->getNumRows();
+        const size_t rhsNumCols = rhs->getNumCols();
+
+        auto lhsVals = lhs->getValues();
+        auto rhsVals = rhs->getValues();
+
+        if((lhsNumCols != 1) || (rhsNumCols != 1))
+            throw std::runtime_error("lhs and rhs must have only one column");
+        if(lhsNumRows != rhsNumRows)
+            throw std::runtime_error("lhs and rhs must have the same number of rows");
+        if(res == nullptr)
+            res = DataObjectFactory::create<DenseMatrix<VTArg>>(*std::max_element(lhsVals, &lhsVals[lhsNumRows-1]) + 1, 
+                                                                *std::max_element(rhsVals, &rhsVals[rhsNumRows-1]) + 1, true);
+
+        // res[i, j] = |{ k | A[k] = i and B[k] = j, 0 ≤ k ≤ n-1 }|.
+        auto resVals = res->getValues();
+        const size_t resRowSkip = res->getRowSkip();
+        for(size_t c = 0; c < lhsNumRows; c++)
+            resVals[static_cast<size_t>(lhsVals[c] * resRowSkip + rhsVals[c])]++;
+    }
+};
+
+// ----------------------------------------------------------------------------
+// CSRMatrix <- DenseMatrix, DenseMatrix
+// ----------------------------------------------------------------------------
+template<typename VTArg>
+struct CTable<CSRMatrix<VTArg>, DenseMatrix<VTArg>, DenseMatrix<VTArg>> {
+    static void apply(CSRMatrix<VTArg> *& res, const DenseMatrix<VTArg> * lhs, const DenseMatrix<VTArg> * rhs, DCTX(ctx)) {
+        const size_t lhsNumRows = lhs->getNumRows();
+        const size_t lhsNumCols = lhs->getNumCols();
+        const size_t rhsNumRows = rhs->getNumRows();
+        const size_t rhsNumCols = rhs->getNumCols();
+
+        auto lhsVals = lhs->getValues();
+        auto rhsVals = rhs->getValues();
+
+        if((lhsNumCols != 1) || (rhsNumCols != 1))
+            throw std::runtime_error("lhs and rhs must have only one column");
+        if(lhsNumRows != rhsNumRows)
+            throw std::runtime_error("lhs and rhs must have the same number of rows");
+        if(res == nullptr)
+            res = DataObjectFactory::create<CSRMatrix<VTArg>>(*std::max_element(lhsVals, &lhsVals[lhsNumRows-1]) + 1, 
+                                                              *std::max_element(rhsVals, &rhsVals[rhsNumRows-1]) + 1, lhsNumRows, true);
+
+        for(size_t c = 0; c < lhsNumRows; c++){
+            auto i = lhsVals[c];
+            auto j = rhsVals[c];
+            res->set(i, j, res->get(i, j) + 1);
+        }
+    }
+};
+#endif //SRC_RUNTIME_LOCAL_KERNELS_CTABLE_H

--- a/src/runtime/local/kernels/kernels.json
+++ b/src/runtime/local/kernels/kernels.json
@@ -461,6 +461,50 @@
     },
     {
         "kernelTemplate": {
+            "header": "CTable.h",
+            "opName": "ctable",
+            "returnType": "void",
+            "templateParams": [
+                {
+                    "name": "DTRes",
+                    "isDataType": true
+                },
+                {
+                    "name": "DTLhs",
+                    "isDataType": true
+                },
+                {
+                    "name": "DTRhs",
+                    "isDataType": true
+                }
+            ],
+            "runtimeParams": [
+                {
+                    "type": "DTRes *&",
+                    "name": "res"
+                },
+                {
+                    "type": "const DTLhs *",
+                    "name": "lhs"
+                },
+                {
+                    "type": "const DTRhs *",
+                    "name": "rhs"
+                }
+            ]
+        },
+        "instantiations": [
+            [["DenseMatrix", "int64_t"], ["DenseMatrix", "int64_t"], ["DenseMatrix", "int64_t"]],
+            [["DenseMatrix", "int32_t"], ["DenseMatrix", "int32_t"], ["DenseMatrix", "int32_t"]],
+            [["DenseMatrix", "double"], ["DenseMatrix", "double"], ["DenseMatrix", "double"]],
+
+            [["CSRMatrix", "int64_t"], ["DenseMatrix", "int64_t"], ["DenseMatrix", "int64_t"]],
+            [["CSRMatrix", "int32_t"], ["DenseMatrix", "int32_t"], ["DenseMatrix", "int32_t"]],
+            [["CSRMatrix", "double"], ["DenseMatrix", "double"], ["DenseMatrix", "double"]]
+        ]
+    },
+    {
+        "kernelTemplate": {
             "header": "DestroyDaphneContext.h",
             "opName": "destroyDaphneContext",
             "returnType": "void",

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -69,6 +69,7 @@ set(TEST_SOURCES
         runtime/local/kernels/CheckEqTest.cpp
         runtime/local/kernels/ColBindTest.cpp
         runtime/local/kernels/CreateFrameTest.cpp
+        runtime/local/kernels/CTableTest.cpp
         runtime/local/kernels/DiagMatrixTest.cpp
         runtime/local/kernels/DiagVectorTest.cpp
         runtime/local/kernels/DNNPoolingTest.cpp

--- a/test/runtime/local/kernels/CTableTest.cpp
+++ b/test/runtime/local/kernels/CTableTest.cpp
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2021 The DAPHNE Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <runtime/local/datagen/GenGivenVals.h>
+#include <runtime/local/datastructures/DenseMatrix.h>
+#include <runtime/local/datastructures/CSRMatrix.h>
+#include <runtime/local/kernels/CTable.h>
+#include <runtime/local/kernels/CheckEq.h>
+
+#include <tags.h>
+#include <catch.hpp>
+#include <vector>
+#include <cstdint>
+
+TEMPLATE_PRODUCT_TEST_CASE("CTable DenseMatrix", TAG_KERNELS, (DenseMatrix), (int64_t, int32_t, double)) {
+    using DT = TestType;
+
+    SECTION("Small") {
+        auto m0 = genGivenVals<DT>(4, {2,4,5,4,});
+        auto m1 = genGivenVals<DT>(4, {0,3,1,3,});
+
+        auto exp = genGivenVals<DT>(6, {
+            0, 0, 0, 0,
+            0, 0, 0, 0,
+            1, 0, 0, 0,
+            0, 0, 0, 0,
+            0, 0, 0, 2,
+            0, 1, 0, 0,
+        });
+        
+        DT * res = nullptr;
+        ctable<DT, DT, DT>(res, m0, m1, nullptr);
+        CHECK(*res == *exp);
+        
+        DataObjectFactory::destroy(m0);
+        DataObjectFactory::destroy(m1);
+        DataObjectFactory::destroy(exp);
+        DataObjectFactory::destroy(res);
+    }
+
+    SECTION("Larger") {
+        auto m0 = genGivenVals<DT>(7, {2,4,5,4,5,1,0,});
+        auto m1 = genGivenVals<DT>(7, {0,3,1,3,1,6,3,});
+
+        auto exp = genGivenVals<DT>(6, {
+            0, 0, 0, 1, 0, 0, 0, 
+            0, 0, 0, 0, 0, 0, 1, 
+            1, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 
+            0, 0, 0, 2, 0, 0, 0,
+            0, 2, 0, 0, 0, 0, 0,
+        });
+        
+        DT * res = nullptr;
+        ctable<DT, DT, DT>(res, m0, m1, nullptr);
+        CHECK(*res == *exp);
+        
+        DataObjectFactory::destroy(m0);
+        DataObjectFactory::destroy(m1);
+        DataObjectFactory::destroy(exp);
+        DataObjectFactory::destroy(res);
+    }
+}
+
+TEMPLATE_PRODUCT_TEST_CASE("CTable CSRMatrix", TAG_KERNELS, (CSRMatrix), (int64_t, int32_t, double)) {
+    using DT = TestType;
+    using VT = typename DT::VT;
+
+    SECTION("Small") {
+        auto m0 = genGivenVals<DenseMatrix<VT>>(1, {2});
+        auto m1 = genGivenVals<DenseMatrix<VT>>(1, {2});
+
+        auto exp = DataObjectFactory::create<DT>(3, 3, 1, true);
+        exp->set(2,2, VT(1));
+        DT * res = nullptr;
+        ctable<DT, DenseMatrix<VT>, DenseMatrix<VT>>(res, m0, m1, nullptr);
+        CHECK(*res == *exp);
+        
+        DataObjectFactory::destroy(m0);
+        DataObjectFactory::destroy(m1);
+        DataObjectFactory::destroy(exp);
+        DataObjectFactory::destroy(res);
+    }
+
+    SECTION("Larger") {
+        auto m0 = genGivenVals<DenseMatrix<VT>>(4, {2,4,5,4,});
+        auto m1 = genGivenVals<DenseMatrix<VT>>(4, {0,3,1,3,});
+
+        auto exp = DataObjectFactory::create<DT>(6, 4, 4, true);
+        exp->set(2,0, VT(1));
+        exp->set(4,3, VT(2));
+        exp->set(5,1, VT(1));
+
+        DT * res = nullptr;
+        ctable<DT, DenseMatrix<VT>, DenseMatrix<VT>>(res, m0, m1, nullptr);
+        CHECK(*res == *exp);
+        
+        DataObjectFactory::destroy(m0);
+        DataObjectFactory::destroy(m1);
+        DataObjectFactory::destroy(exp);
+        DataObjectFactory::destroy(res);
+    }
+}

--- a/test/runtime/local/kernels/CTableTest.cpp
+++ b/test/runtime/local/kernels/CTableTest.cpp
@@ -25,14 +25,29 @@
 #include <vector>
 #include <cstdint>
 
-TEMPLATE_PRODUCT_TEST_CASE("CTable DenseMatrix", TAG_KERNELS, (DenseMatrix), (int64_t, int32_t, double)) {
-    using DT = TestType;
+TEMPLATE_PRODUCT_TEST_CASE("CTable", TAG_KERNELS, (DenseMatrix, CSRMatrix), (int64_t, int32_t, double)) {
+    using DTRes = TestType;
+    using VT = typename DTRes::VT;
 
+    DenseMatrix<VT> * m0 = nullptr;
+    DenseMatrix<VT> * m1 = nullptr;
+    DTRes * exp = nullptr;
+    
+    SECTION("Very small") {
+        m0 = genGivenVals<DenseMatrix<VT>>(1, {2});
+        m1 = genGivenVals<DenseMatrix<VT>>(1, {2});
+
+        exp = genGivenVals<DTRes>(3, {
+            0, 0, 0,
+            0, 0, 0,
+            0, 0, 1,
+        });
+    }
     SECTION("Small") {
-        auto m0 = genGivenVals<DT>(4, {2,4,5,4,});
-        auto m1 = genGivenVals<DT>(4, {0,3,1,3,});
+        m0 = genGivenVals<DenseMatrix<VT>>(4, {2,4,5,4,});
+        m1 = genGivenVals<DenseMatrix<VT>>(4, {0,3,1,3,});
 
-        auto exp = genGivenVals<DT>(6, {
+        exp = genGivenVals<DTRes>(6, {
             0, 0, 0, 0,
             0, 0, 0, 0,
             1, 0, 0, 0,
@@ -40,22 +55,12 @@ TEMPLATE_PRODUCT_TEST_CASE("CTable DenseMatrix", TAG_KERNELS, (DenseMatrix), (in
             0, 0, 0, 2,
             0, 1, 0, 0,
         });
-        
-        DT * res = nullptr;
-        ctable<DT, DT, DT>(res, m0, m1, nullptr);
-        CHECK(*res == *exp);
-        
-        DataObjectFactory::destroy(m0);
-        DataObjectFactory::destroy(m1);
-        DataObjectFactory::destroy(exp);
-        DataObjectFactory::destroy(res);
     }
-
     SECTION("Larger") {
-        auto m0 = genGivenVals<DT>(7, {2,4,5,4,5,1,0,});
-        auto m1 = genGivenVals<DT>(7, {0,3,1,3,1,6,3,});
+        m0 = genGivenVals<DenseMatrix<VT>>(7, {2,4,5,4,5,1,0,});
+        m1 = genGivenVals<DenseMatrix<VT>>(7, {0,3,1,3,1,6,3,});
 
-        auto exp = genGivenVals<DT>(6, {
+        exp = genGivenVals<DTRes>(6, {
             0, 0, 0, 1, 0, 0, 0, 
             0, 0, 0, 0, 0, 0, 1, 
             1, 0, 0, 0, 0, 0, 0,
@@ -63,54 +68,14 @@ TEMPLATE_PRODUCT_TEST_CASE("CTable DenseMatrix", TAG_KERNELS, (DenseMatrix), (in
             0, 0, 0, 2, 0, 0, 0,
             0, 2, 0, 0, 0, 0, 0,
         });
-        
-        DT * res = nullptr;
-        ctable<DT, DT, DT>(res, m0, m1, nullptr);
-        CHECK(*res == *exp);
-        
-        DataObjectFactory::destroy(m0);
-        DataObjectFactory::destroy(m1);
-        DataObjectFactory::destroy(exp);
-        DataObjectFactory::destroy(res);
     }
-}
+    
+    DTRes * res = nullptr;
+    ctable(res, m0, m1, nullptr);
+    CHECK(*res == *exp);
 
-TEMPLATE_PRODUCT_TEST_CASE("CTable CSRMatrix", TAG_KERNELS, (CSRMatrix), (int64_t, int32_t, double)) {
-    using DT = TestType;
-    using VT = typename DT::VT;
-
-    SECTION("Small") {
-        auto m0 = genGivenVals<DenseMatrix<VT>>(1, {2});
-        auto m1 = genGivenVals<DenseMatrix<VT>>(1, {2});
-
-        auto exp = DataObjectFactory::create<DT>(3, 3, 1, true);
-        exp->set(2,2, VT(1));
-        DT * res = nullptr;
-        ctable<DT, DenseMatrix<VT>, DenseMatrix<VT>>(res, m0, m1, nullptr);
-        CHECK(*res == *exp);
-        
-        DataObjectFactory::destroy(m0);
-        DataObjectFactory::destroy(m1);
-        DataObjectFactory::destroy(exp);
-        DataObjectFactory::destroy(res);
-    }
-
-    SECTION("Larger") {
-        auto m0 = genGivenVals<DenseMatrix<VT>>(4, {2,4,5,4,});
-        auto m1 = genGivenVals<DenseMatrix<VT>>(4, {0,3,1,3,});
-
-        auto exp = DataObjectFactory::create<DT>(6, 4, 4, true);
-        exp->set(2,0, VT(1));
-        exp->set(4,3, VT(2));
-        exp->set(5,1, VT(1));
-
-        DT * res = nullptr;
-        ctable<DT, DenseMatrix<VT>, DenseMatrix<VT>>(res, m0, m1, nullptr);
-        CHECK(*res == *exp);
-        
-        DataObjectFactory::destroy(m0);
-        DataObjectFactory::destroy(m1);
-        DataObjectFactory::destroy(exp);
-        DataObjectFactory::destroy(res);
-    }
+    DataObjectFactory::destroy(m0);
+    DataObjectFactory::destroy(m1);
+    DataObjectFactory::destroy(exp);
+    DataObjectFactory::destroy(res);
 }


### PR DESCRIPTION
Implements kernel for contingency table (`ctable`) operation.
- Implements kernel for `DenseMatrix` inputs and `DenseMatrix` output.
- Implements kernel for `DenseMatrix` inputs and `CSRMatrix` output.

Closes #390.