### PR TITLE
Support for mean operation for all-aggregation and row-aggregation.

### DIFF
--- a/src/runtime/local/kernels/AggAll.h
+++ b/src/runtime/local/kernels/AggAll.h
@@ -59,19 +59,39 @@ struct AggAll<DenseMatrix<VT>> {
         const size_t numCols = arg->getNumCols();
         
         const VT * valuesArg = arg->getValues();
-        
-        assert(AggOpCodeUtils::isPureBinaryReduction(opCode));
-        
-        EwBinaryScaFuncPtr<VT, VT, VT> func = getEwBinaryScaFuncPtr<VT, VT, VT>(AggOpCodeUtils::getBinaryOpCode(opCode));
 
-        VT agg = AggOpCodeUtils::template getNeutral<VT>(opCode);
+        EwBinaryScaFuncPtr<VT, VT, VT> func;
+        VT agg;
+        if (AggOpCodeUtils::isPureBinaryReduction(opCode)) {
+            func = getEwBinaryScaFuncPtr<VT, VT, VT>(AggOpCodeUtils::getBinaryOpCode(opCode));
+            agg = AggOpCodeUtils::template getNeutral<VT>(opCode);
+        }
+        else {
+            // TODO Setting the function pointer yields the correct result.
+            // However, since MEAN and STDDEV are not sparse-safe, the program
+            // does not take the same path for doing the summation, and is less
+            // efficient.
+            // for MEAN and STDDDEV, we need to sum
+            func = getEwBinaryScaFuncPtr<VT, VT, VT>(AggOpCodeUtils::getBinaryOpCode(AggOpCode::SUM));
+            agg = VT(0);
+        }
+
         for(size_t r = 0; r < numRows; r++) {
             for(size_t c = 0; c < numCols; c++)
                 agg = func(agg, valuesArg[c], ctx);
             valuesArg += arg->getRowSkip();
         }
+        if (AggOpCodeUtils::isPureBinaryReduction(opCode))
+            return agg;
 
-        return agg;
+        // The op-code is either MEAN or STDDEV.
+        if (opCode == AggOpCode::MEAN) {
+            agg /= arg->getNumCols() * arg->getNumRows();
+            return agg;
+        }
+        // else op-code is STDDEV
+        // TODO STDDEV
+        return agg; // return something for now to avoid compiler warnings
     }
 };
 
@@ -97,19 +117,37 @@ struct AggAll<CSRMatrix<VT>> {
     }
     
     static VT apply(AggOpCode opCode, const CSRMatrix<VT> * arg, DCTX(ctx)) {
-        assert(AggOpCodeUtils::isPureBinaryReduction(opCode));
+        if(AggOpCodeUtils::isPureBinaryReduction(opCode)) {
 
-        EwBinaryScaFuncPtr<VT, VT, VT> func = getEwBinaryScaFuncPtr<VT, VT, VT>(AggOpCodeUtils::getBinaryOpCode(opCode));
-        
-        return aggArray(
+            EwBinaryScaFuncPtr<VT, VT, VT> func = getEwBinaryScaFuncPtr<VT, VT, VT>(AggOpCodeUtils::getBinaryOpCode(opCode));
+            
+            return aggArray(
+                    arg->getValues(0),
+                    arg->getNumNonZeros(),
+                    arg->getNumRows() * arg->getNumCols(),
+                    func,
+                    AggOpCodeUtils::isSparseSafe(opCode),
+                    AggOpCodeUtils::template getNeutral<VT>(opCode),
+                    ctx
+            );
+        }
+        else { // The op-code is either MEAN or STDDEV.
+            EwBinaryScaFuncPtr<VT, VT, VT> func = getEwBinaryScaFuncPtr<VT, VT, VT>(AggOpCodeUtils::getBinaryOpCode(AggOpCode::SUM));            
+            auto agg = aggArray(
                 arg->getValues(0),
                 arg->getNumNonZeros(),
                 arg->getNumRows() * arg->getNumCols(),
                 func,
-                AggOpCodeUtils::isSparseSafe(opCode),
-                AggOpCodeUtils::template getNeutral<VT>(opCode),
+                true,
+                VT(0),
                 ctx
-        );
+            );
+            if (opCode == AggOpCode::MEAN)
+                return agg / (arg->getNumRows() * arg->getNumCols());
+            
+            // TODO STDDEV
+            return agg;
+        }
     }
 };
 

--- a/src/runtime/local/kernels/AggAll.h
+++ b/src/runtime/local/kernels/AggAll.h
@@ -91,7 +91,7 @@ struct AggAll<DenseMatrix<VT>> {
         }
         // else op-code is STDDEV
         // TODO STDDEV
-        return agg; // return something for now to avoid compiler warnings
+        throw std::runtime_error("unsupported AggOpCode in AggAll for DenseMatrix");
     }
 };
 
@@ -146,7 +146,7 @@ struct AggAll<CSRMatrix<VT>> {
                 return agg / (arg->getNumRows() * arg->getNumCols());
             
             // TODO STDDEV
-            return agg;
+            throw std::runtime_error("unsupported AggOpCode in AggAll for CSRMatrix");
         }
     }
 };

--- a/src/runtime/local/kernels/AggRow.h
+++ b/src/runtime/local/kernels/AggRow.h
@@ -95,9 +95,16 @@ struct AggRow<DenseMatrix<VT>, DenseMatrix<VT>> {
             }
         }
         else {
-            assert(AggOpCodeUtils::isPureBinaryReduction(opCode));
-
-            EwBinaryScaFuncPtr<VT, VT, VT> func = getEwBinaryScaFuncPtr<VT, VT, VT>(AggOpCodeUtils::getBinaryOpCode(opCode));
+            EwBinaryScaFuncPtr<VT, VT, VT> func;    
+            if(AggOpCodeUtils::isPureBinaryReduction(opCode))
+                func = getEwBinaryScaFuncPtr<VT, VT, VT>(AggOpCodeUtils::getBinaryOpCode(opCode));
+            else
+                // TODO Setting the function pointer yields the correct result.
+                // However, since MEAN and STDDEV are not sparse-safe, the program
+                // does not take the same path for doing the summation, and is less
+                // efficient.
+                // for MEAN and STDDDEV, we need to sum
+                func = getEwBinaryScaFuncPtr<VT, VT, VT>(AggOpCodeUtils::getBinaryOpCode(AggOpCode::SUM));
 
             for(size_t r = 0; r < numRows; r++) {
                 VT agg = *valuesArg;
@@ -107,6 +114,21 @@ struct AggRow<DenseMatrix<VT>, DenseMatrix<VT>> {
                 valuesArg += arg->getRowSkip();
                 valuesRes += res->getRowSkip();
             }
+
+            if(AggOpCodeUtils::isPureBinaryReduction(opCode))
+                return;
+
+            // The op-code is either MEAN or STDDEV
+            valuesRes = res->getValues();
+            for(size_t r = 0; r < numRows; r++) {
+                *valuesRes = (*valuesRes) / numCols;
+                valuesRes += res->getRowSkip();
+            }
+            if(opCode == AggOpCode::MEAN)
+                return;
+            
+            // else op-code is STDDEV
+            // TODO
         }
     }
 };
@@ -126,15 +148,33 @@ struct AggRow<DenseMatrix<VT>, CSRMatrix<VT>> {
         
         VT * valuesRes = res->getValues();
         
-        assert(AggOpCodeUtils::isPureBinaryReduction(opCode));
+        if (AggOpCodeUtils::isPureBinaryReduction(opCode)) {
         
-        EwBinaryScaFuncPtr<VT, VT, VT> func = getEwBinaryScaFuncPtr<VT, VT, VT>(AggOpCodeUtils::getBinaryOpCode(opCode));
+            EwBinaryScaFuncPtr<VT, VT, VT> func = getEwBinaryScaFuncPtr<VT, VT, VT>(AggOpCodeUtils::getBinaryOpCode(opCode));
 
-        const bool isSparseSafe = AggOpCodeUtils::isSparseSafe(opCode);
-        const VT neutral = AggOpCodeUtils::template getNeutral<VT>(opCode);
+            const bool isSparseSafe = AggOpCodeUtils::isSparseSafe(opCode);
+            const VT neutral = AggOpCodeUtils::template getNeutral<VT>(opCode);
         
-        for(size_t r = 0; r < numRows; r++) {
-            *valuesRes = AggAll<CSRMatrix<VT>>::aggArray(
+            for(size_t r = 0; r < numRows; r++) {
+                *valuesRes = AggAll<CSRMatrix<VT>>::aggArray(
+                        arg->getValues(r),
+                        arg->getNumNonZeros(r),
+                        numCols,
+                        func,
+                        isSparseSafe,
+                        neutral,
+                        ctx
+                );
+                valuesRes += res->getRowSkip();
+            }
+        }
+        else { // The op-code is either MEAN or STDDEV
+            // get sum for each row
+            const VT neutral = VT(0);
+            const bool isSparseSafe = true;
+            EwBinaryScaFuncPtr<VT, VT, VT> func = getEwBinaryScaFuncPtr<VT, VT, VT>(AggOpCodeUtils::getBinaryOpCode(AggOpCode::SUM));
+            for (size_t r = 0; r < numRows; r++){
+                *valuesRes = AggAll<CSRMatrix<VT>>::aggArray(
                     arg->getValues(r),
                     arg->getNumNonZeros(r),
                     numCols,
@@ -142,8 +182,11 @@ struct AggRow<DenseMatrix<VT>, CSRMatrix<VT>> {
                     isSparseSafe,
                     neutral,
                     ctx
-            );
-            valuesRes += res->getRowSkip();
+                );
+                if (opCode == AggOpCode::MEAN)
+                    *valuesRes = *valuesRes / (arg->getNumRows() * arg->getNumCols());
+                valuesRes += res->getRowSkip();
+            }
         }
     }
 };

--- a/src/runtime/local/kernels/AggRow.h
+++ b/src/runtime/local/kernels/AggRow.h
@@ -128,7 +128,8 @@ struct AggRow<DenseMatrix<VT>, DenseMatrix<VT>> {
                 return;
             
             // else op-code is STDDEV
-            // TODO
+            // TODO STDDEV
+            throw std::runtime_error("unsupported AggOpCode in AggRow for DenseMatrix");
         }
     }
 };
@@ -184,7 +185,9 @@ struct AggRow<DenseMatrix<VT>, CSRMatrix<VT>> {
                     ctx
                 );
                 if (opCode == AggOpCode::MEAN)
-                    *valuesRes = *valuesRes / (arg->getNumRows() * arg->getNumCols());
+                    *valuesRes = *valuesRes / numCols;
+                else
+                    throw std::runtime_error("unsupported AggOpCode in AggRow for CSRMatrix");
                 valuesRes += res->getRowSkip();
             }
         }

--- a/src/runtime/local/kernels/kernels.json
+++ b/src/runtime/local/kernels/kernels.json
@@ -28,7 +28,7 @@
             [["CSRMatrix", "double"]],
             [["CSRMatrix", "int64_t"]]
         ],
-        "opCodes": ["SUM", "MIN", "MAX"]
+        "opCodes": ["SUM", "MIN", "MAX", "MEAN"]
     },
     {
         "kernelTemplate": {
@@ -122,7 +122,7 @@
             [["DenseMatrix", "double"], ["CSRMatrix", "double"]],
             [["DenseMatrix", "int64_t"], ["CSRMatrix", "int64_t"]]
         ],
-        "opCodes": ["SUM", "MIN", "MAX", "IDXMIN", "IDXMAX"]
+        "opCodes": ["SUM", "MIN", "MAX", "MEAN", "IDXMIN", "IDXMAX"]
     },
     {
         "kernelTemplate": {

--- a/test/runtime/local/kernels/AggAllTest.cpp
+++ b/test/runtime/local/kernels/AggAllTest.cpp
@@ -113,3 +113,32 @@ TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("max"), TAG_KERNELS, (DATA_TYPES), (VALUE_T
     DataObjectFactory::destroy(m1);
     DataObjectFactory::destroy(m2);
 }
+
+
+TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("mean"), TAG_KERNELS, (DATA_TYPES), (VALUE_TYPES)) {
+    using DT = TestType;
+    
+    auto m0 = genGivenVals<DT>(3, {
+        0, 0, 0, 0,
+        0, 0, 0, 0,
+        0, 0, 0, 0,
+    });
+    auto m1 = genGivenVals<DT>(3, {
+        4, 6, 3, 9,
+        2, 2, 8, 9,
+        4, 4, 5, 4,
+    });
+    auto m2 = genGivenVals<DT>(3, {
+        4, 0, 0, 9,
+        0, 6, 0, 0,
+        0, 0, 5, 0,
+    });
+    
+    checkAggAll(AggOpCode::MEAN, m0, 0);
+    checkAggAll(AggOpCode::MEAN, m1, 5);
+    checkAggAll(AggOpCode::MEAN, m2, 2);
+    
+    DataObjectFactory::destroy(m0);
+    DataObjectFactory::destroy(m1);
+    DataObjectFactory::destroy(m2);
+}

--- a/test/runtime/local/kernels/AggRowTest.cpp
+++ b/test/runtime/local/kernels/AggRowTest.cpp
@@ -193,3 +193,34 @@ TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("idxmax"), TAG_KERNELS, (DenseMatrix), (VAL
     
     DataObjectFactory::destroy(m0, m0exp, m1, m1exp, m2, m2exp);
 }
+
+
+TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("mean"), TAG_KERNELS, (DenseMatrix), (VALUE_TYPES)) {
+    using DTArg = TestType;
+    using DTRes = DenseMatrix<typename DTArg::VT>;
+    
+    auto m0 = genGivenVals<DTArg>(3, {
+        0, 0, 0, 0,
+        0, 0, 0, 0,
+        0, 0, 0, 0,
+    });
+    auto m0exp = genGivenVals<DTRes>(3, {0, 0, 0});
+    auto m1 = genGivenVals<DTArg>(3, {
+        5, 7, 3, 9,
+        2, 5, 0, 1,
+        7, 4, 5, 4,
+    });
+    auto m1exp = genGivenVals<DTRes>(3, {6, 2, 5});
+    auto m2 = genGivenVals<DTArg>(3, {
+        4, 0, 0, 8,
+        0, 4, 0, 0,
+        0, 0, 8, 0,
+    });
+    auto m2exp = genGivenVals<DTRes>(3, {3, 1, 2});
+    
+    checkAggRow(AggOpCode::MEAN, m0, m0exp);
+    checkAggRow(AggOpCode::MEAN, m1, m1exp);
+    checkAggRow(AggOpCode::MEAN, m2, m2exp);
+    
+    DataObjectFactory::destroy(m0, m0exp, m1, m1exp, m2, m2exp);
+}

--- a/test/runtime/local/kernels/AggRowTest.cpp
+++ b/test/runtime/local/kernels/AggRowTest.cpp
@@ -195,7 +195,7 @@ TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("idxmax"), TAG_KERNELS, (DenseMatrix), (VAL
 }
 
 
-TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("mean"), TAG_KERNELS, (DenseMatrix), (VALUE_TYPES)) {
+TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("mean"), TAG_KERNELS, (DATA_TYPES), (VALUE_TYPES)) {
     using DTArg = TestType;
     using DTRes = DenseMatrix<typename DTArg::VT>;
     


### PR DESCRIPTION
- Support for Aggregate-All `mean` for Dense and CSR matrices.
- Support for Aggregate-Row `mean` for Dense and CSR matrices.
- Some testcases.

Closes #393.