### PR TITLE
[DAPHNE-#388] order-kernel for DenseMatrix

### DIFF
--- a/src/runtime/local/kernels/Order.h
+++ b/src/runtime/local/kernels/Order.h
@@ -73,7 +73,7 @@ void columnIDSort(DenseMatrix<VTIdx> *&idx, const DenseMatrix<VT>* arg, size_t c
 
 template<typename VT>
 VT* nextWithRowskip(VT*& first, VT*& last, const size_t rowSkip) {
-    for (VT* next = first; first != last; next+=rowSkip) {
+    for (VT* next = first; next != last; next+=rowSkip) {
         if (*next != *first)
             return next;
     }
@@ -151,7 +151,7 @@ template <> struct Order<Frame> {
                 DeduceValueTypeAndExecute<MultiColumnIDSort>::apply(arg->getSchema()[colIdxs[i]], arg, idx, groups, ascending[i], colIdxs[i], ctx);
             }
         }
-
+    
         // efficient last sort pass OR finalizing the groups vector for further use
         size_t colIdx = colIdxs[numColIdxs-1];
         if (groupsRes == nullptr) {

--- a/src/runtime/local/kernels/Order.h
+++ b/src/runtime/local/kernels/Order.h
@@ -23,6 +23,7 @@
 #include <runtime/local/datastructures/ValueTypeCode.h>
 #include <runtime/local/datastructures/ValueTypeUtils.h>
 #include <runtime/local/kernels/ExtractRow.h>
+#include <util/DeduceType.h>
 
 #include <algorithm>
 #include <functional>
@@ -35,7 +36,7 @@
 
 template<class DT>
 struct Order {
-    static void apply(DT *& res, const DT * arg, size_t * colIdxs, size_t numColIdxs, bool * ascending, size_t numAscending, bool returnIdx, DCTX(ctx)) = delete;
+    static void apply(DT *& res, const DT * arg, size_t * colIdxs, size_t numColIdxs, bool * ascending, size_t numAscending, bool returnIdx, DCTX(ctx), std::vector<std::pair<size_t, size_t>> * groupsRes = nullptr) = delete;
 };
 
 // ****************************************************************************
@@ -43,109 +44,167 @@ struct Order {
 // ****************************************************************************
 
 template<class DT>
-void order(DT *& res, const DT * arg, size_t * colIdxs, size_t numColIdxs, bool * ascending, size_t numAscending, bool returnIdx, DCTX(ctx)) {
-    Order<DT>::apply(res, arg, colIdxs, numColIdxs, ascending, numAscending, returnIdx, ctx);
+void order(DT *& res, const DT * arg, size_t * colIdxs, size_t numColIdxs, bool * ascending, size_t numAscending, bool returnIdx, DCTX(ctx), std::vector<std::pair<size_t, size_t>> * groupsRes = nullptr) {
+    Order<DT>::apply(res, arg, colIdxs, numColIdxs, ascending, numAscending, returnIdx, ctx, groupsRes);
 }
 
 // ****************************************************************************
-// (Partial) template specializations for different data/value types
+// Functions called by mulriple template specializations
 // ****************************************************************************
 
-// ----------------------------------------------------------------------------
-// Frame <- Frame
-// ----------------------------------------------------------------------------
+// sorts input idx DenseMatrix within the index ranges in the input groups vector on the values of the input column (column with id colIdx in DenseMatrix arg; id 0 for column matrices)
+template<typename VTIdx, typename VT>
+void columnIDSort(DenseMatrix<VTIdx> *&idx, const DenseMatrix<VT>* arg, size_t colIdx, std::vector<std::pair<VTIdx, VTIdx>> &groups, bool ascending, DCTX(ctx)) {
+    VTIdx * indicies = idx->getValues();
+    const VT * values = arg->getValues();
+    const size_t rowSkip = arg->getRowSkip();
+    auto compare = ascending ?
+        std::function{[&values, rowSkip, colIdx](VTIdx i, VTIdx j) {
+            return values[i * rowSkip + colIdx] < values[j * rowSkip + colIdx];
+        }} :
+        std::function{[&values, rowSkip, colIdx](VTIdx i, VTIdx j) {
+            return values[i * rowSkip + colIdx] > values[j * rowSkip + colIdx];}};
+    for (const auto &group : groups)
+        std::stable_sort(indicies+group.first, indicies+group.second, compare);
+}
+
+template<typename VT>
+VT* nextWithRowskip(VT*& first, VT*& last, const size_t rowSkip) {
+    for (VT* next = first; first != last; next+=rowSkip) {
+        if (*next != *first)
+            return next;
+    }
+    return last;
+}
 
 // scans a column for groups of duplicates (stored as VTIdx pairs forming index ranges)
 // performed only within the index ranges in the input groups vector on the values of the input column (DenseMatrix)
 // replaces the groups in the input vector with the groups found during the scan
 template<typename VTIdx, typename VT>
-void columnGroupScan(std::vector<std::pair<VTIdx, VTIdx>> &groups, DenseMatrix<VT>* col, DCTX(ctx)) {
+void columnGroupScan(std::vector<std::pair<VTIdx, VTIdx>> &groups, DenseMatrix<VT>* col, size_t colIdx, DCTX(ctx)) {
     const size_t numOldGroups = groups.size();
-    const VT * values = col->getValues();
+    VT * values = col->getValues();
+    const size_t rowSkip = col->getRowSkip();
     for (size_t g = 0; g < numOldGroups; g++) {
-        auto first = values + groups[g].first;
-        const auto last = values + groups[g].second;
+        VT * first = values + groups[g].first * rowSkip + colIdx;
+        VT * last = values + groups[g].second * rowSkip + colIdx;
         while (first != last) {
-            const auto next{std::find_if(first + 1, last, [&](const VT& t) {return t != *first;})};
-            if (next - first > 1) {
-                groups.push_back(std::make_pair(first-values, next-values));
-            }
-            first = next;
+            VT * next = nextWithRowskip<VT>(first, last, rowSkip);
+            if ((size_t) (next - first) > rowSkip)
+                groups.push_back(std::make_pair((first-values-colIdx)/rowSkip, (next-values-colIdx)/rowSkip));
+            first = next;   
         }
     }
     groups.erase(groups.begin(),groups.begin()+numOldGroups);
 }
 
-// sorts input idx DenseMatrix within the index ranges in the input groups vector on the values of the input column (DenseMatrix)
-template<typename VTIdx, typename VT>
-void columnIDSort(DenseMatrix<VTIdx> *&idx, const DenseMatrix<VT>* col, std::vector<std::pair<VTIdx, VTIdx>> &groups, bool ascending, DCTX(ctx)) {
-    VTIdx * indicies = idx->getValues();
-    const VT * values = col->getValues();
-    auto compare = ascending ? std::function{[&values](VTIdx i, VTIdx j) {return values[i] < values[j];}}
-                             : std::function{[&values](VTIdx i, VTIdx j) {return values[i] > values[j];}};
-    for (const auto &group : groups)
-        std::stable_sort(indicies+group.first, indicies+group.second, compare);
-}
-
 // sorts IDs inside groups by the key column, reorder the column via a row extraction into a temporary 
 // DenseMatrix and then scan for groups of duplicates to be tie broken by another subsequent key column
 template<typename VTIdx, typename VT>
-void multiColumnIDSort(DenseMatrix<VTIdx> *&idx, const DenseMatrix<VT>* col, std::vector<std::pair<VTIdx, VTIdx>> &groups, bool ascending, DCTX(ctx)){
-    columnIDSort(idx, col, groups, ascending, ctx);
+void multiColumnIDSort(DenseMatrix<VTIdx> *&idx, const DenseMatrix<VT>* col, size_t colIdx, std::vector<std::pair<VTIdx, VTIdx>> &groups, bool ascending, DCTX(ctx)){
+    columnIDSort(idx, col, colIdx, groups, ascending, ctx);
     DenseMatrix<VT> * tmp = nullptr;
     extractRow<DenseMatrix<VT>, DenseMatrix<VT>, VTIdx>(tmp, col, idx, ctx);
-    columnGroupScan(groups, tmp, ctx);
+    columnGroupScan(groups, tmp, colIdx, ctx);
     DataObjectFactory::destroy(tmp);
-} 
+}
+
+// ----------------------------------------------------------------------------
+// Frame <- Frame
+// ----------------------------------------------------------------------------
+
+template<typename VTCol>
+struct ColumnIDSort {
+    static void apply(const Frame * arg, DenseMatrix<size_t> *&idx, std::vector<std::pair<size_t, size_t>> &groups, bool ascending, size_t colIdx, DCTX(ctx)) {
+        columnIDSort(idx, arg->getColumn<VTCol>(colIdx), 0, groups, ascending, ctx);
+    }
+};
+
+// sorts IDs inside groups by the key column, reorder the column via a row extraction into a temporary 
+// DenseMatrix and then scan for groups of duplicates to be tie broken by another subsequent key column
+template<typename VTCol>
+struct MultiColumnIDSort {
+    static void apply(const Frame * arg, DenseMatrix<size_t> *&idx, std::vector<std::pair<size_t, size_t>> &groups, bool ascending, size_t colIdx, DCTX(ctx)) {
+        multiColumnIDSort(idx, arg->getColumn<VTCol>(colIdx), 0, groups, ascending, ctx);
+    }
+};
+
+// ----------------------------------------------------------------------------
+// Frame <- Frame
+// ----------------------------------------------------------------------------
 
 template <> struct Order<Frame> {
-    static void apply(Frame *& res, const Frame * arg, size_t * colIdxs, size_t numColIdxs, bool * ascending, size_t numAscending, bool returnIdx, DCTX(ctx)) {
+    static void apply(Frame *& res, const Frame * arg, size_t * colIdxs, size_t numColIdxs, bool * ascending, size_t numAscending, bool returnIdx, DCTX(ctx), std::vector<std::pair<size_t, size_t>> * groupsRes = nullptr) {
+        size_t numRows = arg->getNumRows();
+        if (arg == nullptr || colIdxs == nullptr || numColIdxs == 0 || ascending == nullptr) {
+            throw std::runtime_error("order-kernel called with invalid arguments");
+        }
+        
+        auto idx = DataObjectFactory::create<DenseMatrix<size_t>>(numRows, 1, false);
+        auto indicies = idx->getValues();
+        std::iota(indicies, indicies+numRows, 0);
+        
+        std::vector<std::pair<size_t, size_t>> groups;
+        groups.push_back(std::make_pair(0, numRows));
+            
+        if (numColIdxs > 1) {
+            for (size_t i = 0; i < numColIdxs-1; i++) {
+                DeduceValueTypeAndExecute<MultiColumnIDSort>::apply(arg->getSchema()[colIdxs[i]], arg, idx, groups, ascending[i], colIdxs[i], ctx);
+            }
+        }
+
+        // efficient last sort pass OR finalizing the groups vector for further use
+        size_t colIdx = colIdxs[numColIdxs-1];
+        if (groupsRes == nullptr) {
+            DeduceValueTypeAndExecute<ColumnIDSort>::apply(arg->getSchema()[colIdx], arg, idx, groups, ascending[numColIdxs-1], colIdx, ctx);
+        } else {
+            DeduceValueTypeAndExecute<MultiColumnIDSort>::apply(arg->getSchema()[colIdx], arg, idx, groups, ascending[numColIdxs-1], colIdx, ctx);
+            if (groups.front().first == 0 && groups.front().second == numRows) {
+                groups.clear();
+            }
+            groupsRes->insert(groupsRes->end(), groups.begin(), groups.end());
+        }
+
+        //applying the final object ID permutation (result of the sorting procedure) to the frame via a row extraction
+        extractRow(res, arg, idx, ctx);
+        DataObjectFactory::destroy(idx);
+    }
+};
+
+// ----------------------------------------------------------------------------
+// DenseMatrix <- DenseMatrix 
+// ----------------------------------------------------------------------------
+template <typename VT>
+struct Order<DenseMatrix<VT>> {
+    static void apply(DenseMatrix<VT> *& res, const DenseMatrix<VT> * arg, size_t * colIdxs, size_t numColIdxs, bool * ascending, size_t numAscending, bool returnIdx, DCTX(ctx), std::vector<std::pair<size_t, size_t>> * groupsRes = nullptr) {
         size_t numRows = arg->getNumRows();
         if (arg == nullptr || colIdxs == nullptr || numColIdxs == 0 || ascending == nullptr) {
             throw std::runtime_error("order-kernel called with invalid arguments");
         }
 
-        size_t colIdx;
         auto idx = DataObjectFactory::create<DenseMatrix<size_t>>(numRows, 1, false);
         auto indicies = idx->getValues();
         std::iota(indicies, indicies+numRows, 0);
         std::vector<std::pair<size_t, size_t>> groups;
         groups.push_back(std::make_pair(0, numRows));
-        
+
         if (numColIdxs > 1) {
             for (size_t i = 0; i < numColIdxs-1; i++) {
-                colIdx = colIdxs[i];
-                switch(arg->getColumnType(colIdx)) {
-                    // TODO Memory leak (getColumn(), see #222).
-                    case ValueTypeCode::F64: multiColumnIDSort(idx, arg->getColumn<double>(colIdx), groups, ascending[i], ctx); break;
-                    case ValueTypeCode::F32: multiColumnIDSort(idx, arg->getColumn<float>(colIdx), groups, ascending[i], ctx); break;
-                    case ValueTypeCode::SI64: multiColumnIDSort(idx, arg->getColumn<int64_t>(colIdx), groups, ascending[i], ctx); break;
-                    case ValueTypeCode::SI32: multiColumnIDSort(idx, arg->getColumn<int32_t>(colIdx), groups, ascending[i], ctx); break;
-                    case ValueTypeCode::SI8 : multiColumnIDSort(idx, arg->getColumn<int8_t>(colIdx), groups, ascending[i], ctx); break;
-                    case ValueTypeCode::UI64: multiColumnIDSort(idx, arg->getColumn<uint64_t>(colIdx), groups, ascending[i], ctx); break;
-                    case ValueTypeCode::UI32: multiColumnIDSort(idx, arg->getColumn<uint32_t>(colIdx), groups, ascending[i], ctx); break;
-                    case ValueTypeCode::UI8 : multiColumnIDSort(idx, arg->getColumn<uint8_t>(colIdx), groups, ascending[i], ctx); break;
-                    default: throw std::runtime_error("unknown value type code");
-                }
+                multiColumnIDSort(idx, arg, colIdxs[i], groups, ascending[i], ctx);
             }
         }
 
-        colIdx = colIdxs[numColIdxs-1];
-        switch(arg->getColumnType(colIdx)) {
-            // TODO Memory leak (getColumn(), see #222).
-            case ValueTypeCode::F64: columnIDSort(idx, arg->getColumn<double>(colIdx), groups, ascending[numColIdxs-1], ctx); break;
-            case ValueTypeCode::F32: columnIDSort(idx, arg->getColumn<float>(colIdx), groups, ascending[numColIdxs-1], ctx); break;
-            case ValueTypeCode::SI64: columnIDSort(idx, arg->getColumn<int64_t>(colIdx), groups, ascending[numColIdxs-1], ctx); break;
-            case ValueTypeCode::SI32: columnIDSort(idx, arg->getColumn<int32_t>(colIdx), groups, ascending[numColIdxs-1], ctx); break; 
-            case ValueTypeCode::SI8 : columnIDSort(idx, arg->getColumn<int8_t>(colIdx), groups, ascending[numColIdxs-1], ctx); break; 
-            case ValueTypeCode::UI64: columnIDSort(idx, arg->getColumn<uint64_t>(colIdx), groups, ascending[numColIdxs-1], ctx); break;
-            case ValueTypeCode::UI32: columnIDSort(idx, arg->getColumn<uint32_t>(colIdx), groups, ascending[numColIdxs-1], ctx); break;
-            case ValueTypeCode::UI8 : columnIDSort(idx, arg->getColumn<uint8_t>(colIdx), groups, ascending[numColIdxs-1], ctx); break;
-            default: throw std::runtime_error("unknown value type code");
+        if (groupsRes == nullptr) {
+            columnIDSort(idx, arg, colIdxs[numColIdxs-1], groups, ascending[numColIdxs-1], ctx);
+        } else {
+            multiColumnIDSort(idx, arg, colIdxs[numColIdxs-1], groups, ascending[numColIdxs-1], ctx);
+            if (groups.front().first == 0 && groups.front().second == numRows) {
+                groups.clear();
+            }
+            groupsRes->insert(groupsRes->end(), groups.begin(), groups.end());
         }
 
-        //applying the final object ID permutation (result of the sorting procedure) to the frame via a row extraction
-        extractRow<Frame, Frame, size_t>(res, arg, idx, ctx);
+        extractRow<DenseMatrix<VT>, DenseMatrix<VT>, size_t>(res, arg, idx, ctx);
         DataObjectFactory::destroy(idx);
     }
 };

--- a/src/runtime/local/kernels/Order.h
+++ b/src/runtime/local/kernels/Order.h
@@ -52,7 +52,7 @@ void order(DT *& res, const DT * arg, size_t * colIdxs, size_t numColIdxs, bool 
 }
 
 // ****************************************************************************
-// Functions called by mulriple template specializations
+// Functions called by multiple template specializations
 // ****************************************************************************
 
 // sorts input idx DenseMatrix within the index ranges in the input groups vector on the values of the input column (column with id colIdx in DenseMatrix arg; id 0 for column matrices)
@@ -112,6 +112,10 @@ void multiColumnIDSort(DenseMatrix<VTIdx> *&idx, const DenseMatrix<VT>* col, siz
     DataObjectFactory::destroy(tmp);
 }
 
+// ****************************************************************************
+// (Partial) template specializations for different data/value types
+// ****************************************************************************
+
 // ----------------------------------------------------------------------------
 // Frame <- Frame
 // ----------------------------------------------------------------------------
@@ -151,7 +155,7 @@ template <> struct Order<Frame> {
                 DeduceValueTypeAndExecute<MultiColumnIDSort>::apply(arg->getSchema()[colIdxs[i]], arg, idx, groups, ascending[i], colIdxs[i], ctx);
             }
         }
-    
+
         // efficient last sort pass OR finalizing the groups vector for further use
         size_t colIdx = colIdxs[numColIdxs-1];
         if (groupsRes == nullptr) {
@@ -173,6 +177,7 @@ template <> struct Order<Frame> {
 // ----------------------------------------------------------------------------
 // DenseMatrix <- DenseMatrix 
 // ----------------------------------------------------------------------------
+
 template <typename VT>
 struct Order<DenseMatrix<VT>> {
     static void apply(DenseMatrix<VT> *& res, const DenseMatrix<VT> * arg, size_t * colIdxs, size_t numColIdxs, bool * ascending, size_t numAscending, bool returnIdx, DCTX(ctx), std::vector<std::pair<size_t, size_t>> * groupsRes = nullptr) {
@@ -182,8 +187,8 @@ struct Order<DenseMatrix<VT>> {
         }
 
         auto idx = DataObjectFactory::create<DenseMatrix<size_t>>(numRows, 1, false);
-        auto indicies = idx->getValues();
-        std::iota(indicies, indicies+numRows, 0);
+        auto indices = idx->getValues();
+        std::iota(indices, indices+numRows, 0);
         std::vector<std::pair<size_t, size_t>> groups;
         groups.push_back(std::make_pair(0, numRows));
 

--- a/src/runtime/local/kernels/kernels.json
+++ b/src/runtime/local/kernels/kernels.json
@@ -2809,7 +2809,10 @@
             ]
         },
         "instantiations": [
-            ["Frame"]
+            ["Frame"],
+            [["DenseMatrix", "double"]],
+            [["DenseMatrix", "float"]],
+            [["DenseMatrix", "int64_t"]]
         ]
     },
     {

--- a/test/runtime/local/kernels/OrderTest.cpp
+++ b/test/runtime/local/kernels/OrderTest.cpp
@@ -118,3 +118,56 @@ TEMPLATE_TEST_CASE("Order", TAG_KERNELS, (Frame)) {
     DataObjectFactory::destroy(exp);
     DataObjectFactory::destroy(res);
 }
+
+TEMPLATE_TEST_CASE("Order - DenseMatrix", TAG_KERNELS, double){ // NOLINT(cert-err58-cpp)
+    using VT = TestType;
+    size_t numKeyCols;
+    size_t colIdxs[4];
+    bool ascending[4];
+
+    DenseMatrix<VT>* argMatrix = genGivenVals<DenseMatrix<VT>>(4, {
+            1, 10, 3, 7, 7, 7,
+            17, 7, 2, 3, 7, 7,
+            7, 7, 1, 2, 3, 7,
+            7, 7, 1, 1, 2, 3,
+        });
+    DenseMatrix<VT>* resMatrix = nullptr;
+    DenseMatrix<VT>* expMatrix = nullptr;
+
+
+    SECTION("single key column, ascending") {
+        expMatrix =  genGivenVals<DenseMatrix<VT>>(4, {
+            7, 7, 1, 1, 2, 3,
+            7, 7, 1, 2, 3, 7,
+            17, 7, 2, 3, 7, 7,
+            1, 10, 3, 7, 7, 7
+        });
+        numKeyCols = 1;
+        colIdxs[0] = 3;
+        ascending[0] = true;
+    }
+    SECTION("four key columns, ascending/descending") {
+        expMatrix =  genGivenVals<DenseMatrix<VT>>(4, {
+            17, 7, 2, 3, 7, 7,
+            7, 7, 1, 1, 2, 3,
+            7, 7, 1, 2, 3, 7,
+            1, 10, 3, 7, 7, 7,
+        });
+        numKeyCols = 4;
+        colIdxs[0] = 1;
+        ascending[0] = true;
+        colIdxs[1] = 0;
+        ascending[1] = false;
+        colIdxs[2] = 2;
+        ascending[2] = false;
+        colIdxs[3] = 3;
+        ascending[3] = true;
+    }
+    
+    order(resMatrix, argMatrix, colIdxs, numKeyCols, ascending, numKeyCols, false, nullptr);
+
+    CHECK(*resMatrix ==*expMatrix);
+    DataObjectFactory::destroy(argMatrix);
+    DataObjectFactory::destroy(resMatrix);
+    DataObjectFactory::destroy(expMatrix);
+}

--- a/test/runtime/local/kernels/OrderTest.cpp
+++ b/test/runtime/local/kernels/OrderTest.cpp
@@ -119,25 +119,25 @@ TEMPLATE_TEST_CASE("Order", TAG_KERNELS, (Frame)) {
     DataObjectFactory::destroy(res);
 }
 
-TEMPLATE_TEST_CASE("Order - DenseMatrix", TAG_KERNELS, double){ // NOLINT(cert-err58-cpp)
-    using VT = TestType;
+TEMPLATE_PRODUCT_TEST_CASE("Order", TAG_KERNELS, (DenseMatrix), (double, float)){ // NOLINT(cert-err58-cpp)
+    using DT = TestType;
     size_t numKeyCols;
     size_t colIdxs[4];
     bool ascending[4];
 
-    DenseMatrix<VT>* argMatrix = nullptr;
-    DenseMatrix<VT>* resMatrix = nullptr;
-    DenseMatrix<VT>* expMatrix = nullptr;
+    DT* argMatrix = nullptr;
+    DT* resMatrix = nullptr;
+    DT* expMatrix = nullptr;
 
 
     SECTION("single key column, ascending") {
-        argMatrix = genGivenVals<DenseMatrix<VT>>(4, {
+        argMatrix = genGivenVals<DT>(4, {
             1, 10, 3, 7, 7, 7,
             17, 7, 2, 3, 7, 7,
             7, 7, 1, 2, 3, 7,
             7, 7, 1, 1, 2, 3,
         });
-        expMatrix =  genGivenVals<DenseMatrix<VT>>(4, {
+        expMatrix =  genGivenVals<DT>(4, {
             7, 7, 1, 1, 2, 3,
             7, 7, 1, 2, 3, 7,
             17, 7, 2, 3, 7, 7,
@@ -148,7 +148,7 @@ TEMPLATE_TEST_CASE("Order - DenseMatrix", TAG_KERNELS, double){ // NOLINT(cert-e
         ascending[0] = true;
     }
     SECTION("four key columns, ascending/descending") {
-        argMatrix = genGivenVals<DenseMatrix<VT>>(20, {
+        argMatrix = genGivenVals<DT>(20, {
             1.1, 1.1, 0, 6,
             -3.1, -2, 0, 3,
             4.4, 4.4, 1, 9,
@@ -170,7 +170,7 @@ TEMPLATE_TEST_CASE("Order - DenseMatrix", TAG_KERNELS, double){ // NOLINT(cert-e
             6.6, 10, 3, 20,
             5.6, -1.1, 0, 14
         });
-        expMatrix = genGivenVals<DenseMatrix<VT>>(20, {
+        expMatrix = genGivenVals<DT>(20, {
             4.4, -15.5, 0, 12,
             6.6, -10, 0, 15,
             2.3, -2.3, 0, 8,
@@ -205,7 +205,7 @@ TEMPLATE_TEST_CASE("Order - DenseMatrix", TAG_KERNELS, double){ // NOLINT(cert-e
     
     order(resMatrix, argMatrix, colIdxs, numKeyCols, ascending, numKeyCols, false, nullptr);
 
-    CHECK(*resMatrix ==*expMatrix);
+    CHECK(*resMatrix == *expMatrix);
     DataObjectFactory::destroy(argMatrix);
     DataObjectFactory::destroy(resMatrix);
     DataObjectFactory::destroy(expMatrix);

--- a/test/runtime/local/kernels/OrderTest.cpp
+++ b/test/runtime/local/kernels/OrderTest.cpp
@@ -125,17 +125,18 @@ TEMPLATE_TEST_CASE("Order - DenseMatrix", TAG_KERNELS, double){ // NOLINT(cert-e
     size_t colIdxs[4];
     bool ascending[4];
 
-    DenseMatrix<VT>* argMatrix = genGivenVals<DenseMatrix<VT>>(4, {
-            1, 10, 3, 7, 7, 7,
-            17, 7, 2, 3, 7, 7,
-            7, 7, 1, 2, 3, 7,
-            7, 7, 1, 1, 2, 3,
-        });
+    DenseMatrix<VT>* argMatrix = nullptr;
     DenseMatrix<VT>* resMatrix = nullptr;
     DenseMatrix<VT>* expMatrix = nullptr;
 
 
     SECTION("single key column, ascending") {
+        argMatrix = genGivenVals<DenseMatrix<VT>>(4, {
+            1, 10, 3, 7, 7, 7,
+            17, 7, 2, 3, 7, 7,
+            7, 7, 1, 2, 3, 7,
+            7, 7, 1, 1, 2, 3,
+        });
         expMatrix =  genGivenVals<DenseMatrix<VT>>(4, {
             7, 7, 1, 1, 2, 3,
             7, 7, 1, 2, 3, 7,
@@ -147,11 +148,49 @@ TEMPLATE_TEST_CASE("Order - DenseMatrix", TAG_KERNELS, double){ // NOLINT(cert-e
         ascending[0] = true;
     }
     SECTION("four key columns, ascending/descending") {
-        expMatrix =  genGivenVals<DenseMatrix<VT>>(4, {
-            17, 7, 2, 3, 7, 7,
-            7, 7, 1, 1, 2, 3,
-            7, 7, 1, 2, 3, 7,
-            1, 10, 3, 7, 7, 7,
+        argMatrix = genGivenVals<DenseMatrix<VT>>(20, {
+            1.1, 1.1, 0, 6,
+            -3.1, -2, 0, 3,
+            4.4, 4.4, 1, 9,
+            -8.8, 2.1, 1, 1,
+            5.6, 1.1, 0, 13,
+            2.3, 2.3, 0, 7,
+            0.3, 0.5, 0, 5,
+            4.4, 4.4, 3, 10,
+            6.6, -10, 0, 15,
+            6.6, 0, 0, 16,
+            -8.8, 2.1, 2, 2,
+            6.6, 10, 1, 17,
+            6.6, 10, 2, 18,
+            4.4, 4.4, 3, 11,
+            -0.3, -0.3, 0, 4,
+            4.4, -15.5, 0, 12,
+            6.6, 10, 3, 19,
+            2.3, -2.3, 0, 8,
+            6.6, 10, 3, 20,
+            5.6, -1.1, 0, 14
+        });
+        expMatrix = genGivenVals<DenseMatrix<VT>>(20, {
+            4.4, -15.5, 0, 12,
+            6.6, -10, 0, 15,
+            2.3, -2.3, 0, 8,
+            -3.1, -2, 0, 3,
+            5.6, -1.1, 0, 14,
+            -0.3, -0.3, 0, 4,
+            6.6, 0, 0, 16,
+            0.3, 0.5, 0, 5,
+            5.6, 1.1, 0, 13,
+            1.1, 1.1, 0, 6,
+            -8.8, 2.1, 2, 2,
+            -8.8, 2.1, 1, 1,
+            2.3, 2.3, 0, 7,
+            4.4, 4.4, 3, 10,
+            4.4, 4.4, 3, 11,
+            4.4, 4.4, 1, 9,
+            6.6, 10, 3, 19,
+            6.6, 10, 3, 20,
+            6.6, 10, 2, 18,
+            6.6, 10, 1, 17
         });
         numKeyCols = 4;
         colIdxs[0] = 1;


### PR DESCRIPTION
* Implements specialization of the order-kernel for DenseMatrix
* Works in the single column and multi-column case
* Slight changes to existing order methods to respect the rowSkip in multi-column matrices
* Builds on the Order Kernel DeduceType Util Refactor from #242
* closes #388