### PR TITLE
[DAPHNE-#399] Aggregation kernels can return different value types

### DIFF
--- a/src/runtime/local/kernels/AggAll.h
+++ b/src/runtime/local/kernels/AggAll.h
@@ -60,10 +60,10 @@ struct AggAll<VTRes, DenseMatrix<VTArg>> {
         
         const VTArg * valuesArg = arg->getValues();
 
-        EwBinaryScaFuncPtr<VTRes, VTArg, VTArg> func;
+        EwBinaryScaFuncPtr<VTRes, VTRes, VTArg> func;
         VTRes agg;
         if (AggOpCodeUtils::isPureBinaryReduction(opCode)) {
-            func = getEwBinaryScaFuncPtr<VTRes, VTArg, VTArg>(AggOpCodeUtils::getBinaryOpCode(opCode));
+            func = getEwBinaryScaFuncPtr<VTRes, VTRes, VTArg>(AggOpCodeUtils::getBinaryOpCode(opCode));
             agg = AggOpCodeUtils::template getNeutral<VTRes>(opCode);
         }
         else {
@@ -72,7 +72,7 @@ struct AggAll<VTRes, DenseMatrix<VTArg>> {
             // does not take the same path for doing the summation, and is less
             // efficient.
             // for MEAN and STDDDEV, we need to sum
-            func = getEwBinaryScaFuncPtr<VTRes, VTArg, VTArg>(AggOpCodeUtils::getBinaryOpCode(AggOpCode::SUM));
+            func = getEwBinaryScaFuncPtr<VTRes, VTRes, VTArg>(AggOpCodeUtils::getBinaryOpCode(AggOpCode::SUM));
             agg = VTRes(0);
         }
 
@@ -101,7 +101,7 @@ struct AggAll<VTRes, DenseMatrix<VTArg>> {
 
 template<typename VTRes, typename VTArg>
 struct AggAll<VTRes, CSRMatrix<VTArg>> {
-    static VTRes aggArray(const VTArg * values, size_t numNonZeros, size_t numCells, EwBinaryScaFuncPtr<VTRes, VTArg, VTArg> func, bool isSparseSafe, VTRes neutral, DCTX(ctx)) {
+    static VTRes aggArray(const VTArg * values, size_t numNonZeros, size_t numCells, EwBinaryScaFuncPtr<VTRes, VTRes, VTArg> func, bool isSparseSafe, VTRes neutral, DCTX(ctx)) {
         if(numNonZeros) {
             VTRes agg = values[0];
             for(size_t i = 1; i < numNonZeros; i++)
@@ -119,7 +119,7 @@ struct AggAll<VTRes, CSRMatrix<VTArg>> {
     static VTRes apply(AggOpCode opCode, const CSRMatrix<VTArg> * arg, DCTX(ctx)) {
         if(AggOpCodeUtils::isPureBinaryReduction(opCode)) {
 
-            EwBinaryScaFuncPtr<VTRes, VTArg, VTArg> func = getEwBinaryScaFuncPtr<VTRes, VTArg, VTArg>(AggOpCodeUtils::getBinaryOpCode(opCode));
+            EwBinaryScaFuncPtr<VTRes, VTRes, VTArg> func = getEwBinaryScaFuncPtr<VTRes, VTRes, VTArg>(AggOpCodeUtils::getBinaryOpCode(opCode));
             
             return aggArray(
                     arg->getValues(0),
@@ -132,7 +132,7 @@ struct AggAll<VTRes, CSRMatrix<VTArg>> {
             );
         }
         else { // The op-code is either MEAN or STDDEV.
-            EwBinaryScaFuncPtr<VTRes, VTArg, VTArg> func = getEwBinaryScaFuncPtr<VTRes, VTArg, VTArg>(AggOpCodeUtils::getBinaryOpCode(AggOpCode::SUM));            
+            EwBinaryScaFuncPtr<VTRes, VTRes, VTArg> func = getEwBinaryScaFuncPtr<VTRes, VTRes, VTArg>(AggOpCodeUtils::getBinaryOpCode(AggOpCode::SUM));            
             auto agg = aggArray(
                 arg->getValues(0),
                 arg->getNumNonZeros(),

--- a/src/runtime/local/kernels/AggAll.h
+++ b/src/runtime/local/kernels/AggAll.h
@@ -30,18 +30,18 @@
 // Struct for partial template specialization
 // ****************************************************************************
 
-template<class DT>
+template<typename VTRes, class DTArg>
 struct AggAll {
-    static typename DT::VT apply(AggOpCode opCode, const DT * arg, DCTX(ctx)) = delete;
+    static VTRes apply(AggOpCode opCode, const DTArg * arg, DCTX(ctx)) = delete;
 };
 
 // ****************************************************************************
 // Convenience function
 // ****************************************************************************
 
-template<class DT>
-typename DT::VT aggAll(AggOpCode opCode, const DT * arg, DCTX(ctx)) {
-    return AggAll<DT>::apply(opCode, arg, ctx);
+template<typename VTRes, class DTArg>
+VTRes aggAll(AggOpCode opCode, const DTArg * arg, DCTX(ctx)) {
+    return AggAll<VTRes, DTArg>::apply(opCode, arg, ctx);
 }
 
 // ****************************************************************************
@@ -52,19 +52,19 @@ typename DT::VT aggAll(AggOpCode opCode, const DT * arg, DCTX(ctx)) {
 // scalar <- DenseMatrix
 // ----------------------------------------------------------------------------
 
-template<typename VT>
-struct AggAll<DenseMatrix<VT>> {
-    static VT apply(AggOpCode opCode, const DenseMatrix<VT> * arg, DCTX(ctx)) {
+template<typename VTRes, typename VTArg>
+struct AggAll<VTRes, DenseMatrix<VTArg>> {
+    static VTRes apply(AggOpCode opCode, const DenseMatrix<VTArg> * arg, DCTX(ctx)) {
         const size_t numRows = arg->getNumRows();
         const size_t numCols = arg->getNumCols();
         
-        const VT * valuesArg = arg->getValues();
+        const VTArg * valuesArg = arg->getValues();
 
-        EwBinaryScaFuncPtr<VT, VT, VT> func;
-        VT agg;
+        EwBinaryScaFuncPtr<VTRes, VTArg, VTArg> func;
+        VTRes agg;
         if (AggOpCodeUtils::isPureBinaryReduction(opCode)) {
-            func = getEwBinaryScaFuncPtr<VT, VT, VT>(AggOpCodeUtils::getBinaryOpCode(opCode));
-            agg = AggOpCodeUtils::template getNeutral<VT>(opCode);
+            func = getEwBinaryScaFuncPtr<VTRes, VTArg, VTArg>(AggOpCodeUtils::getBinaryOpCode(opCode));
+            agg = AggOpCodeUtils::template getNeutral<VTRes>(opCode);
         }
         else {
             // TODO Setting the function pointer yields the correct result.
@@ -72,8 +72,8 @@ struct AggAll<DenseMatrix<VT>> {
             // does not take the same path for doing the summation, and is less
             // efficient.
             // for MEAN and STDDDEV, we need to sum
-            func = getEwBinaryScaFuncPtr<VT, VT, VT>(AggOpCodeUtils::getBinaryOpCode(AggOpCode::SUM));
-            agg = VT(0);
+            func = getEwBinaryScaFuncPtr<VTRes, VTArg, VTArg>(AggOpCodeUtils::getBinaryOpCode(AggOpCode::SUM));
+            agg = VTRes(0);
         }
 
         for(size_t r = 0; r < numRows; r++) {
@@ -99,11 +99,11 @@ struct AggAll<DenseMatrix<VT>> {
 // scalar <- CSRMatrix
 // ----------------------------------------------------------------------------
 
-template<typename VT>
-struct AggAll<CSRMatrix<VT>> {
-    static VT aggArray(const VT * values, size_t numNonZeros, size_t numCells, EwBinaryScaFuncPtr<VT, VT, VT> func, bool isSparseSafe, VT neutral, DCTX(ctx)) {
+template<typename VTRes, typename VTArg>
+struct AggAll<VTRes, CSRMatrix<VTArg>> {
+    static VTRes aggArray(const VTArg * values, size_t numNonZeros, size_t numCells, EwBinaryScaFuncPtr<VTRes, VTArg, VTArg> func, bool isSparseSafe, VTRes neutral, DCTX(ctx)) {
         if(numNonZeros) {
-            VT agg = values[0];
+            VTRes agg = values[0];
             for(size_t i = 1; i < numNonZeros; i++)
                 agg = func(agg, values[i], ctx);
 
@@ -116,10 +116,10 @@ struct AggAll<CSRMatrix<VT>> {
             return func(neutral, 0, ctx);
     }
     
-    static VT apply(AggOpCode opCode, const CSRMatrix<VT> * arg, DCTX(ctx)) {
+    static VTRes apply(AggOpCode opCode, const CSRMatrix<VTArg> * arg, DCTX(ctx)) {
         if(AggOpCodeUtils::isPureBinaryReduction(opCode)) {
 
-            EwBinaryScaFuncPtr<VT, VT, VT> func = getEwBinaryScaFuncPtr<VT, VT, VT>(AggOpCodeUtils::getBinaryOpCode(opCode));
+            EwBinaryScaFuncPtr<VTRes, VTArg, VTArg> func = getEwBinaryScaFuncPtr<VTRes, VTArg, VTArg>(AggOpCodeUtils::getBinaryOpCode(opCode));
             
             return aggArray(
                     arg->getValues(0),
@@ -127,19 +127,19 @@ struct AggAll<CSRMatrix<VT>> {
                     arg->getNumRows() * arg->getNumCols(),
                     func,
                     AggOpCodeUtils::isSparseSafe(opCode),
-                    AggOpCodeUtils::template getNeutral<VT>(opCode),
+                    AggOpCodeUtils::template getNeutral<VTRes>(opCode),
                     ctx
             );
         }
         else { // The op-code is either MEAN or STDDEV.
-            EwBinaryScaFuncPtr<VT, VT, VT> func = getEwBinaryScaFuncPtr<VT, VT, VT>(AggOpCodeUtils::getBinaryOpCode(AggOpCode::SUM));            
+            EwBinaryScaFuncPtr<VTRes, VTArg, VTArg> func = getEwBinaryScaFuncPtr<VTRes, VTArg, VTArg>(AggOpCodeUtils::getBinaryOpCode(AggOpCode::SUM));            
             auto agg = aggArray(
                 arg->getValues(0),
                 arg->getNumNonZeros(),
                 arg->getNumRows() * arg->getNumCols(),
                 func,
                 true,
-                VT(0),
+                VTRes(0),
                 ctx
             );
             if (opCode == AggOpCode::MEAN)

--- a/src/runtime/local/kernels/AggAll.h
+++ b/src/runtime/local/kernels/AggAll.h
@@ -60,10 +60,10 @@ struct AggAll<VTRes, DenseMatrix<VTArg>> {
         
         const VTArg * valuesArg = arg->getValues();
 
-        EwBinaryScaFuncPtr<VTRes, VTRes, VTArg> func;
+        EwBinaryScaFuncPtr<VTRes, VTRes, VTRes> func;
         VTRes agg;
         if (AggOpCodeUtils::isPureBinaryReduction(opCode)) {
-            func = getEwBinaryScaFuncPtr<VTRes, VTRes, VTArg>(AggOpCodeUtils::getBinaryOpCode(opCode));
+            func = getEwBinaryScaFuncPtr<VTRes, VTRes, VTRes>(AggOpCodeUtils::getBinaryOpCode(opCode));
             agg = AggOpCodeUtils::template getNeutral<VTRes>(opCode);
         }
         else {
@@ -72,13 +72,13 @@ struct AggAll<VTRes, DenseMatrix<VTArg>> {
             // does not take the same path for doing the summation, and is less
             // efficient.
             // for MEAN and STDDDEV, we need to sum
-            func = getEwBinaryScaFuncPtr<VTRes, VTRes, VTArg>(AggOpCodeUtils::getBinaryOpCode(AggOpCode::SUM));
+            func = getEwBinaryScaFuncPtr<VTRes, VTRes, VTRes>(AggOpCodeUtils::getBinaryOpCode(AggOpCode::SUM));
             agg = VTRes(0);
         }
 
         for(size_t r = 0; r < numRows; r++) {
             for(size_t c = 0; c < numCols; c++)
-                agg = func(agg, valuesArg[c], ctx);
+                agg = func(agg, static_cast<VTRes>(valuesArg[c]), ctx);
             valuesArg += arg->getRowSkip();
         }
         if (AggOpCodeUtils::isPureBinaryReduction(opCode))
@@ -101,11 +101,11 @@ struct AggAll<VTRes, DenseMatrix<VTArg>> {
 
 template<typename VTRes, typename VTArg>
 struct AggAll<VTRes, CSRMatrix<VTArg>> {
-    static VTRes aggArray(const VTArg * values, size_t numNonZeros, size_t numCells, EwBinaryScaFuncPtr<VTRes, VTRes, VTArg> func, bool isSparseSafe, VTRes neutral, DCTX(ctx)) {
+    static VTRes aggArray(const VTArg * values, size_t numNonZeros, size_t numCells, EwBinaryScaFuncPtr<VTRes, VTRes, VTRes> func, bool isSparseSafe, VTRes neutral, DCTX(ctx)) {
         if(numNonZeros) {
-            VTRes agg = values[0];
+            VTRes agg = static_cast<VTRes>(values[0]);
             for(size_t i = 1; i < numNonZeros; i++)
-                agg = func(agg, values[i], ctx);
+                agg = func(agg, static_cast<VTRes>(values[i]), ctx);
 
             if(!isSparseSafe && numNonZeros < numCells)
                 agg = func(agg, 0, ctx);
@@ -119,7 +119,7 @@ struct AggAll<VTRes, CSRMatrix<VTArg>> {
     static VTRes apply(AggOpCode opCode, const CSRMatrix<VTArg> * arg, DCTX(ctx)) {
         if(AggOpCodeUtils::isPureBinaryReduction(opCode)) {
 
-            EwBinaryScaFuncPtr<VTRes, VTRes, VTArg> func = getEwBinaryScaFuncPtr<VTRes, VTRes, VTArg>(AggOpCodeUtils::getBinaryOpCode(opCode));
+            EwBinaryScaFuncPtr<VTRes, VTRes, VTRes> func = getEwBinaryScaFuncPtr<VTRes, VTRes, VTRes>(AggOpCodeUtils::getBinaryOpCode(opCode));
             
             return aggArray(
                     arg->getValues(0),
@@ -132,7 +132,7 @@ struct AggAll<VTRes, CSRMatrix<VTArg>> {
             );
         }
         else { // The op-code is either MEAN or STDDEV.
-            EwBinaryScaFuncPtr<VTRes, VTRes, VTArg> func = getEwBinaryScaFuncPtr<VTRes, VTRes, VTArg>(AggOpCodeUtils::getBinaryOpCode(AggOpCode::SUM));            
+            EwBinaryScaFuncPtr<VTRes, VTRes, VTRes> func = getEwBinaryScaFuncPtr<VTRes, VTRes, VTRes>(AggOpCodeUtils::getBinaryOpCode(AggOpCode::SUM));            
             auto agg = aggArray(
                 arg->getValues(0),
                 arg->getNumNonZeros(),

--- a/src/runtime/local/kernels/AggCol.h
+++ b/src/runtime/local/kernels/AggCol.h
@@ -67,25 +67,25 @@ struct AggCol<DenseMatrix<VTRes>, DenseMatrix<VTArg>> {
         const VTArg * valuesArg = arg->getValues();
         VTRes * valuesRes = res->getValues();
         
-        EwBinaryScaFuncPtr<VTRes, VTRes, VTArg> func;
+        EwBinaryScaFuncPtr<VTRes, VTRes, VTRes> func;
         if(AggOpCodeUtils::isPureBinaryReduction(opCode))
-            func = getEwBinaryScaFuncPtr<VTRes, VTRes, VTArg>(AggOpCodeUtils::getBinaryOpCode(opCode));
+            func = getEwBinaryScaFuncPtr<VTRes, VTRes, VTRes>(AggOpCodeUtils::getBinaryOpCode(opCode));
         else
             // TODO Setting the function pointer yields the correct result.
             // However, since MEAN and STDDEV are not sparse-safe, the program
             // does not take the same path for doing the summation, and is less
             // efficient.
             // for MEAN and STDDDEV, we need to sum
-            func = getEwBinaryScaFuncPtr<VTRes, VTRes, VTArg>(AggOpCodeUtils::getBinaryOpCode(AggOpCode::SUM));
+            func = getEwBinaryScaFuncPtr<VTRes, VTRes, VTRes>(AggOpCodeUtils::getBinaryOpCode(AggOpCode::SUM));
 
         // memcpy(valuesRes, valuesArg, numCols * sizeof(VTRes));
         // Can't memcpy because we might have different result type
         for (size_t c = 0; c < numCols; c++)
-            valuesRes[c] = (VTRes)valuesArg[c];
+            valuesRes[c] = static_cast<VTRes>(valuesArg[c]);
         for(size_t r = 1; r < numRows; r++) {
             valuesArg += arg->getRowSkip();
             for(size_t c = 0; c < numCols; c++)
-                valuesRes[c] = func(valuesRes[c], valuesArg[c], ctx);
+                valuesRes[c] = func(valuesRes[c], static_cast<VTRes>(valuesArg[c]), ctx);
         }
         
         if(AggOpCodeUtils::isPureBinaryReduction(opCode))
@@ -105,7 +105,7 @@ struct AggCol<DenseMatrix<VTRes>, DenseMatrix<VTArg>> {
 
         for(size_t r = 0; r < numRows; r++) {
             for(size_t c = 0; c < numCols; c++) {
-                VTRes val = valuesArg[c] - valuesRes[c];
+                VTRes val = static_cast<VTRes>(valuesArg[c]) - valuesRes[c];
                 valuesT[c] = valuesT[c] + val * val;
             }
             valuesArg += arg->getRowSkip();
@@ -138,16 +138,16 @@ struct AggCol<DenseMatrix<VTRes>, CSRMatrix<VTArg>> {
         
         VTRes * valuesRes = res->getValues();
         
-        EwBinaryScaFuncPtr<VTRes, VTRes, VTArg> func;
+        EwBinaryScaFuncPtr<VTRes, VTRes, VTRes> func;
         if(AggOpCodeUtils::isPureBinaryReduction(opCode))
-            func = getEwBinaryScaFuncPtr<VTRes, VTRes, VTArg>(AggOpCodeUtils::getBinaryOpCode(opCode));
+            func = getEwBinaryScaFuncPtr<VTRes, VTRes, VTRes>(AggOpCodeUtils::getBinaryOpCode(opCode));
         else
             // TODO Setting the function pointer yields the correct result.
             // However, since MEAN and STDDEV are not sparse-safe, the program
             // does not take the same path for doing the summation, and is less
             // efficient.
             // for MEAN and STDDDEV, we need to sum
-            func = getEwBinaryScaFuncPtr<VTRes, VTRes, VTArg>(AggOpCodeUtils::getBinaryOpCode(AggOpCode::SUM));
+            func = getEwBinaryScaFuncPtr<VTRes, VTRes, VTRes>(AggOpCodeUtils::getBinaryOpCode(AggOpCode::SUM));
 
         const VTArg * valuesArg = arg->getValues(0);
         const size_t * colIdxsArg = arg->getColIdxs(0);
@@ -157,7 +157,7 @@ struct AggCol<DenseMatrix<VTRes>, CSRMatrix<VTArg>> {
         if(AggOpCodeUtils::isSparseSafe(opCode)) {
             for(size_t i = 0; i < numNonZeros; i++) {
                 const size_t colIdx = colIdxsArg[i];
-                valuesRes[colIdx] = func(valuesRes[colIdx], valuesArg[i], ctx);
+                valuesRes[colIdx] = func(valuesRes[colIdx], static_cast<VTRes>(valuesArg[i]), ctx);
             }
         }
         else {
@@ -166,19 +166,19 @@ struct AggCol<DenseMatrix<VTRes>, CSRMatrix<VTArg>> {
             const size_t numNonZerosFirstRowArg = arg->getNumNonZeros(0);
             for(size_t i = 0; i < numNonZerosFirstRowArg; i++) {
                 size_t colIdx = colIdxsArg[i];
-                valuesRes[colIdx] = valuesArg[i];
+                valuesRes[colIdx] = static_cast<VTRes>(valuesArg[i]);
                 hist[colIdx]++;
             }
 
             if(arg->getNumRows() > 1) {
                 for(size_t i = numNonZerosFirstRowArg; i < numNonZeros; i++) {
                     const size_t colIdx = colIdxsArg[i];
-                    valuesRes[colIdx] = func(valuesRes[colIdx], valuesArg[i], ctx);
+                    valuesRes[colIdx] = func(valuesRes[colIdx], static_cast<VTRes>(valuesArg[i]), ctx);
                     hist[colIdx]++;
                 }
                 for(size_t c = 0; c < numCols; c++)
                     if(hist[c] < numRows)
-                        valuesRes[c] = func(valuesRes[c], 0, ctx);
+                        valuesRes[c] = func(valuesRes[c], VTRes(0), ctx);
             }
             
             delete[] hist;
@@ -201,7 +201,7 @@ struct AggCol<DenseMatrix<VTRes>, CSRMatrix<VTArg>> {
         size_t * nnzCol = new size_t[numCols](); // initialized to zeros
         for(size_t i = 0; i < numNonZeros; i++) {
             const size_t colIdx = colIdxsArg[i];
-            VTRes val = valuesArg[i] - valuesRes[colIdx];
+            VTRes val = static_cast<VTRes>(valuesArg[i]) - valuesRes[colIdx];
             valuesT[colIdx] = valuesT[colIdx] + val * val;
             nnzCol[colIdx]++;
         }

--- a/src/runtime/local/kernels/AggCol.h
+++ b/src/runtime/local/kernels/AggCol.h
@@ -55,31 +55,33 @@ void aggCol(AggOpCode opCode, DTRes *& res, const DTArg * arg, DCTX(ctx)) {
 // DenseMatrix <- DenseMatrix
 // ----------------------------------------------------------------------------
 
-template<typename VT>
-struct AggCol<DenseMatrix<VT>, DenseMatrix<VT>> {
-    static void apply(AggOpCode opCode, DenseMatrix<VT> *& res, const DenseMatrix<VT> * arg, DCTX(ctx)) {
+template<typename VTRes, typename VTArg>
+struct AggCol<DenseMatrix<VTRes>, DenseMatrix<VTArg>> {
+    static void apply(AggOpCode opCode, DenseMatrix<VTRes> *& res, const DenseMatrix<VTArg> * arg, DCTX(ctx)) {
         const size_t numRows = arg->getNumRows();
         const size_t numCols = arg->getNumCols();
         
         if(res == nullptr)
-            res = DataObjectFactory::create<DenseMatrix<VT>>(1, numCols, false);
+            res = DataObjectFactory::create<DenseMatrix<VTRes>>(1, numCols, false);
         
-        const VT * valuesArg = arg->getValues();
-        VT * valuesRes = res->getValues();
+        const VTArg * valuesArg = arg->getValues();
+        VTRes * valuesRes = res->getValues();
         
-        EwBinaryScaFuncPtr<VT, VT, VT> func;
+        EwBinaryScaFuncPtr<VTRes, VTArg, VTArg> func;
         if(AggOpCodeUtils::isPureBinaryReduction(opCode))
-            func = getEwBinaryScaFuncPtr<VT, VT, VT>(AggOpCodeUtils::getBinaryOpCode(opCode));
+            func = getEwBinaryScaFuncPtr<VTRes, VTArg, VTArg>(AggOpCodeUtils::getBinaryOpCode(opCode));
         else
             // TODO Setting the function pointer yields the correct result.
             // However, since MEAN and STDDEV are not sparse-safe, the program
             // does not take the same path for doing the summation, and is less
             // efficient.
             // for MEAN and STDDDEV, we need to sum
-            func = getEwBinaryScaFuncPtr<VT, VT, VT>(AggOpCodeUtils::getBinaryOpCode(AggOpCode::SUM));
+            func = getEwBinaryScaFuncPtr<VTRes, VTArg, VTArg>(AggOpCodeUtils::getBinaryOpCode(AggOpCode::SUM));
 
-        memcpy(valuesRes, valuesArg, numCols * sizeof(VT));
-        
+        // memcpy(valuesRes, valuesArg, numCols * sizeof(VTRes));
+        // Can't memcpy because we might have different result type
+        for (size_t c = 0; c < numCols; c++)
+            valuesRes[c] = (VTRes)valuesArg[c];
         for(size_t r = 1; r < numRows; r++) {
             valuesArg += arg->getRowSkip();
             for(size_t c = 0; c < numCols; c++)
@@ -97,13 +99,13 @@ struct AggCol<DenseMatrix<VT>, DenseMatrix<VT>> {
         if(opCode != AggOpCode::STDDEV)
             return;
 
-        auto tmp = DataObjectFactory::create<DenseMatrix<VT>>(1, numCols, true);
-        VT * valuesT = tmp->getValues();
+        auto tmp = DataObjectFactory::create<DenseMatrix<VTRes>>(1, numCols, true);
+        VTRes * valuesT = tmp->getValues();
         valuesArg = arg->getValues();
 
         for(size_t r = 0; r < numRows; r++) {
             for(size_t c = 0; c < numCols; c++) {
-                VT val = valuesArg[c] - valuesRes[c];
+                VTRes val = valuesArg[c] - valuesRes[c];
                 valuesT[c] = valuesT[c] + val * val;
             }
             valuesArg += arg->getRowSkip();
@@ -116,8 +118,8 @@ struct AggCol<DenseMatrix<VT>, DenseMatrix<VT>> {
 
         // TODO We could avoid copying by returning tmp and destroying res. But
         // that might be wrong if res was not nullptr initially.
-        memcpy(valuesRes, valuesT, numCols * sizeof(VT));
-        DataObjectFactory::destroy<DenseMatrix<VT>>(tmp);
+        memcpy(valuesRes, valuesT, numCols * sizeof(VTRes));
+        DataObjectFactory::destroy<DenseMatrix<VTRes>>(tmp);
     }
 };
 
@@ -125,29 +127,29 @@ struct AggCol<DenseMatrix<VT>, DenseMatrix<VT>> {
 // DenseMatrix <- CSRMatrix
 // ----------------------------------------------------------------------------
 
-template<typename VT>
-struct AggCol<DenseMatrix<VT>, CSRMatrix<VT>> {
-    static void apply(AggOpCode opCode, DenseMatrix<VT> *& res, const CSRMatrix<VT> * arg, DCTX(ctx)) {
+template<typename VTRes, typename VTArg>
+struct AggCol<DenseMatrix<VTRes>, CSRMatrix<VTArg>> {
+    static void apply(AggOpCode opCode, DenseMatrix<VTRes> *& res, const CSRMatrix<VTArg> * arg, DCTX(ctx)) {
         const size_t numRows = arg->getNumRows();
         const size_t numCols = arg->getNumCols();
         
         if(res == nullptr)
-            res = DataObjectFactory::create<DenseMatrix<VT>>(1, numCols, true);
+            res = DataObjectFactory::create<DenseMatrix<VTRes>>(1, numCols, true);
         
-        VT * valuesRes = res->getValues();
+        VTRes * valuesRes = res->getValues();
         
-        EwBinaryScaFuncPtr<VT, VT, VT> func;
+        EwBinaryScaFuncPtr<VTRes, VTArg, VTArg> func;
         if(AggOpCodeUtils::isPureBinaryReduction(opCode))
-            func = getEwBinaryScaFuncPtr<VT, VT, VT>(AggOpCodeUtils::getBinaryOpCode(opCode));
+            func = getEwBinaryScaFuncPtr<VTRes, VTArg, VTArg>(AggOpCodeUtils::getBinaryOpCode(opCode));
         else
             // TODO Setting the function pointer yields the correct result.
             // However, since MEAN and STDDEV are not sparse-safe, the program
             // does not take the same path for doing the summation, and is less
             // efficient.
             // for MEAN and STDDDEV, we need to sum
-            func = getEwBinaryScaFuncPtr<VT, VT, VT>(AggOpCodeUtils::getBinaryOpCode(AggOpCode::SUM));
+            func = getEwBinaryScaFuncPtr<VTRes, VTArg, VTArg>(AggOpCodeUtils::getBinaryOpCode(AggOpCode::SUM));
 
-        const VT * valuesArg = arg->getValues(0);
+        const VTArg * valuesArg = arg->getValues(0);
         const size_t * colIdxsArg = arg->getColIdxs(0);
         
         const size_t numNonZeros = arg->getNumNonZeros();
@@ -193,13 +195,13 @@ struct AggCol<DenseMatrix<VT>, CSRMatrix<VT>> {
         if(opCode != AggOpCode::STDDEV)
             return;
 
-        auto tmp = DataObjectFactory::create<DenseMatrix<VT>>(1, numCols, true);
-        VT * valuesT = tmp->getValues();
+        auto tmp = DataObjectFactory::create<DenseMatrix<VTRes>>(1, numCols, true);
+        VTRes * valuesT = tmp->getValues();
 
         size_t * nnzCol = new size_t[numCols](); // initialized to zeros
         for(size_t i = 0; i < numNonZeros; i++) {
             const size_t colIdx = colIdxsArg[i];
-            VT val = valuesArg[i] - valuesRes[colIdx];
+            VTRes val = valuesArg[i] - valuesRes[colIdx];
             valuesT[colIdx] = valuesT[colIdx] + val * val;
             nnzCol[colIdx]++;
         }
@@ -216,8 +218,8 @@ struct AggCol<DenseMatrix<VT>, CSRMatrix<VT>> {
 
         // TODO We could avoid copying by returning tmp and destroying res. But
         // that might be wrong if res was not nullptr initially.
-        memcpy(valuesRes, valuesT, numCols * sizeof(VT));
-        DataObjectFactory::destroy<DenseMatrix<VT>>(tmp);
+        memcpy(valuesRes, valuesT, numCols * sizeof(VTRes));
+        DataObjectFactory::destroy<DenseMatrix<VTRes>>(tmp);
 
     }
 };

--- a/src/runtime/local/kernels/AggCol.h
+++ b/src/runtime/local/kernels/AggCol.h
@@ -67,16 +67,16 @@ struct AggCol<DenseMatrix<VTRes>, DenseMatrix<VTArg>> {
         const VTArg * valuesArg = arg->getValues();
         VTRes * valuesRes = res->getValues();
         
-        EwBinaryScaFuncPtr<VTRes, VTArg, VTArg> func;
+        EwBinaryScaFuncPtr<VTRes, VTRes, VTArg> func;
         if(AggOpCodeUtils::isPureBinaryReduction(opCode))
-            func = getEwBinaryScaFuncPtr<VTRes, VTArg, VTArg>(AggOpCodeUtils::getBinaryOpCode(opCode));
+            func = getEwBinaryScaFuncPtr<VTRes, VTRes, VTArg>(AggOpCodeUtils::getBinaryOpCode(opCode));
         else
             // TODO Setting the function pointer yields the correct result.
             // However, since MEAN and STDDEV are not sparse-safe, the program
             // does not take the same path for doing the summation, and is less
             // efficient.
             // for MEAN and STDDDEV, we need to sum
-            func = getEwBinaryScaFuncPtr<VTRes, VTArg, VTArg>(AggOpCodeUtils::getBinaryOpCode(AggOpCode::SUM));
+            func = getEwBinaryScaFuncPtr<VTRes, VTRes, VTArg>(AggOpCodeUtils::getBinaryOpCode(AggOpCode::SUM));
 
         // memcpy(valuesRes, valuesArg, numCols * sizeof(VTRes));
         // Can't memcpy because we might have different result type
@@ -138,16 +138,16 @@ struct AggCol<DenseMatrix<VTRes>, CSRMatrix<VTArg>> {
         
         VTRes * valuesRes = res->getValues();
         
-        EwBinaryScaFuncPtr<VTRes, VTArg, VTArg> func;
+        EwBinaryScaFuncPtr<VTRes, VTRes, VTArg> func;
         if(AggOpCodeUtils::isPureBinaryReduction(opCode))
-            func = getEwBinaryScaFuncPtr<VTRes, VTArg, VTArg>(AggOpCodeUtils::getBinaryOpCode(opCode));
+            func = getEwBinaryScaFuncPtr<VTRes, VTRes, VTArg>(AggOpCodeUtils::getBinaryOpCode(opCode));
         else
             // TODO Setting the function pointer yields the correct result.
             // However, since MEAN and STDDEV are not sparse-safe, the program
             // does not take the same path for doing the summation, and is less
             // efficient.
             // for MEAN and STDDDEV, we need to sum
-            func = getEwBinaryScaFuncPtr<VTRes, VTArg, VTArg>(AggOpCodeUtils::getBinaryOpCode(AggOpCode::SUM));
+            func = getEwBinaryScaFuncPtr<VTRes, VTRes, VTArg>(AggOpCodeUtils::getBinaryOpCode(AggOpCode::SUM));
 
         const VTArg * valuesArg = arg->getValues(0);
         const size_t * colIdxsArg = arg->getColIdxs(0);

--- a/src/runtime/local/kernels/AggRow.h
+++ b/src/runtime/local/kernels/AggRow.h
@@ -95,21 +95,21 @@ struct AggRow<DenseMatrix<VTRes>, DenseMatrix<VTArg>> {
             }
         }
         else {
-            EwBinaryScaFuncPtr<VTRes, VTRes, VTArg> func;    
+            EwBinaryScaFuncPtr<VTRes, VTRes, VTRes> func;    
             if(AggOpCodeUtils::isPureBinaryReduction(opCode))
-                func = getEwBinaryScaFuncPtr<VTRes, VTRes, VTArg>(AggOpCodeUtils::getBinaryOpCode(opCode));
+                func = getEwBinaryScaFuncPtr<VTRes, VTRes, VTRes>(AggOpCodeUtils::getBinaryOpCode(opCode));
             else
                 // TODO Setting the function pointer yields the correct result.
                 // However, since MEAN and STDDEV are not sparse-safe, the program
                 // does not take the same path for doing the summation, and is less
                 // efficient.
                 // for MEAN and STDDDEV, we need to sum
-                func = getEwBinaryScaFuncPtr<VTRes, VTRes, VTArg>(AggOpCodeUtils::getBinaryOpCode(AggOpCode::SUM));
+                func = getEwBinaryScaFuncPtr<VTRes, VTRes, VTRes>(AggOpCodeUtils::getBinaryOpCode(AggOpCode::SUM));
 
             for(size_t r = 0; r < numRows; r++) {
                 VTRes agg = static_cast<VTRes>(*valuesArg);
                 for(size_t c = 1; c < numCols; c++)
-                    agg = func(agg, valuesArg[c], ctx);
+                    agg = func(agg, static_cast<VTRes>(valuesArg[c]), ctx);
                 *valuesRes = static_cast<VTRes>(agg);
                 valuesArg += arg->getRowSkip();
                 valuesRes += res->getRowSkip();
@@ -151,7 +151,7 @@ struct AggRow<DenseMatrix<VTRes>, CSRMatrix<VTArg>> {
         
         if (AggOpCodeUtils::isPureBinaryReduction(opCode)) {
         
-            EwBinaryScaFuncPtr<VTRes, VTRes, VTArg> func = getEwBinaryScaFuncPtr<VTRes, VTRes, VTArg>(AggOpCodeUtils::getBinaryOpCode(opCode));
+            EwBinaryScaFuncPtr<VTRes, VTRes, VTRes> func = getEwBinaryScaFuncPtr<VTRes, VTRes, VTRes>(AggOpCodeUtils::getBinaryOpCode(opCode));
 
             const bool isSparseSafe = AggOpCodeUtils::isSparseSafe(opCode);
             const VTRes neutral = AggOpCodeUtils::template getNeutral<VTRes>(opCode);
@@ -173,7 +173,7 @@ struct AggRow<DenseMatrix<VTRes>, CSRMatrix<VTArg>> {
             // get sum for each row
             const VTRes neutral = VTRes(0);
             const bool isSparseSafe = true;
-            EwBinaryScaFuncPtr<VTRes, VTRes, VTArg> func = getEwBinaryScaFuncPtr<VTRes, VTRes, VTArg>(AggOpCodeUtils::getBinaryOpCode(AggOpCode::SUM));
+            EwBinaryScaFuncPtr<VTRes, VTRes, VTRes> func = getEwBinaryScaFuncPtr<VTRes, VTRes, VTRes>(AggOpCodeUtils::getBinaryOpCode(AggOpCode::SUM));
             for (size_t r = 0; r < numRows; r++){
                 *valuesRes = AggAll<VTRes, CSRMatrix<VTArg>>::aggArray(
                     arg->getValues(r),

--- a/src/runtime/local/kernels/AggRow.h
+++ b/src/runtime/local/kernels/AggRow.h
@@ -95,16 +95,16 @@ struct AggRow<DenseMatrix<VTRes>, DenseMatrix<VTArg>> {
             }
         }
         else {
-            EwBinaryScaFuncPtr<VTRes, VTArg, VTArg> func;    
+            EwBinaryScaFuncPtr<VTRes, VTRes, VTArg> func;    
             if(AggOpCodeUtils::isPureBinaryReduction(opCode))
-                func = getEwBinaryScaFuncPtr<VTRes, VTArg, VTArg>(AggOpCodeUtils::getBinaryOpCode(opCode));
+                func = getEwBinaryScaFuncPtr<VTRes, VTRes, VTArg>(AggOpCodeUtils::getBinaryOpCode(opCode));
             else
                 // TODO Setting the function pointer yields the correct result.
                 // However, since MEAN and STDDEV are not sparse-safe, the program
                 // does not take the same path for doing the summation, and is less
                 // efficient.
                 // for MEAN and STDDDEV, we need to sum
-                func = getEwBinaryScaFuncPtr<VTRes, VTArg, VTArg>(AggOpCodeUtils::getBinaryOpCode(AggOpCode::SUM));
+                func = getEwBinaryScaFuncPtr<VTRes, VTRes, VTArg>(AggOpCodeUtils::getBinaryOpCode(AggOpCode::SUM));
 
             for(size_t r = 0; r < numRows; r++) {
                 VTRes agg = static_cast<VTRes>(*valuesArg);
@@ -151,7 +151,7 @@ struct AggRow<DenseMatrix<VTRes>, CSRMatrix<VTArg>> {
         
         if (AggOpCodeUtils::isPureBinaryReduction(opCode)) {
         
-            EwBinaryScaFuncPtr<VTRes, VTArg, VTArg> func = getEwBinaryScaFuncPtr<VTRes, VTArg, VTArg>(AggOpCodeUtils::getBinaryOpCode(opCode));
+            EwBinaryScaFuncPtr<VTRes, VTRes, VTArg> func = getEwBinaryScaFuncPtr<VTRes, VTRes, VTArg>(AggOpCodeUtils::getBinaryOpCode(opCode));
 
             const bool isSparseSafe = AggOpCodeUtils::isSparseSafe(opCode);
             const VTRes neutral = AggOpCodeUtils::template getNeutral<VTRes>(opCode);
@@ -173,7 +173,7 @@ struct AggRow<DenseMatrix<VTRes>, CSRMatrix<VTArg>> {
             // get sum for each row
             const VTRes neutral = VTRes(0);
             const bool isSparseSafe = true;
-            EwBinaryScaFuncPtr<VTRes, VTArg, VTArg> func = getEwBinaryScaFuncPtr<VTRes, VTArg, VTArg>(AggOpCodeUtils::getBinaryOpCode(AggOpCode::SUM));
+            EwBinaryScaFuncPtr<VTRes, VTRes, VTArg> func = getEwBinaryScaFuncPtr<VTRes, VTRes, VTArg>(AggOpCodeUtils::getBinaryOpCode(AggOpCode::SUM));
             for (size_t r = 0; r < numRows; r++){
                 *valuesRes = AggAll<VTRes, CSRMatrix<VTArg>>::aggArray(
                     arg->getValues(r),

--- a/src/runtime/local/kernels/AggRow.h
+++ b/src/runtime/local/kernels/AggRow.h
@@ -54,63 +54,63 @@ void aggRow(AggOpCode opCode, DTRes *& res, const DTArg * arg, DCTX(ctx)) {
 // DenseMatrix <- DenseMatrix
 // ----------------------------------------------------------------------------
 
-template<typename VT>
-struct AggRow<DenseMatrix<VT>, DenseMatrix<VT>> {
-    static void apply(AggOpCode opCode, DenseMatrix<VT> *& res, const DenseMatrix<VT> * arg, DCTX(ctx)) {
+template<typename VTRes, typename VTArg>
+struct AggRow<DenseMatrix<VTRes>, DenseMatrix<VTArg>> {
+    static void apply(AggOpCode opCode, DenseMatrix<VTRes> *& res, const DenseMatrix<VTArg> * arg, DCTX(ctx)) {
         const size_t numRows = arg->getNumRows();
         const size_t numCols = arg->getNumCols();
         
         if(res == nullptr)
-            res = DataObjectFactory::create<DenseMatrix<VT>>(numRows, 1, false);
+            res = DataObjectFactory::create<DenseMatrix<VTRes>>(numRows, 1, false);
         
-        const VT * valuesArg = arg->getValues();
-        VT * valuesRes = res->getValues();
+        const VTArg * valuesArg = arg->getValues();
+        VTRes * valuesRes = res->getValues();
         
         if(opCode == AggOpCode::IDXMIN) {
             for(size_t r = 0; r < numRows; r++) {
-                VT minVal = valuesArg[0];
+                VTRes minVal = valuesArg[0];
                 size_t minValIdx = 0;
                 for(size_t c = 1; c < numCols; c++)
                     if(valuesArg[c] < minVal) {
                         minVal = valuesArg[c];
                         minValIdx = c;
                     }
-                *valuesRes = static_cast<VT>(minValIdx);
+                *valuesRes = static_cast<VTRes>(minValIdx);
                 valuesArg += arg->getRowSkip();
                 valuesRes += res->getRowSkip();
             }
         }
         else if(opCode == AggOpCode::IDXMAX) {
             for(size_t r = 0; r < numRows; r++) {
-                VT maxVal = valuesArg[0];
+                VTArg maxVal = valuesArg[0];
                 size_t maxValIdx = 0;
                 for(size_t c = 1; c < numCols; c++)
                     if(valuesArg[c] > maxVal) {
                         maxVal = valuesArg[c];
                         maxValIdx = c;
                     }
-                *valuesRes = static_cast<VT>(maxValIdx);
+                *valuesRes = static_cast<VTRes>(maxValIdx);
                 valuesArg += arg->getRowSkip();
                 valuesRes += res->getRowSkip();
             }
         }
         else {
-            EwBinaryScaFuncPtr<VT, VT, VT> func;    
+            EwBinaryScaFuncPtr<VTRes, VTArg, VTArg> func;    
             if(AggOpCodeUtils::isPureBinaryReduction(opCode))
-                func = getEwBinaryScaFuncPtr<VT, VT, VT>(AggOpCodeUtils::getBinaryOpCode(opCode));
+                func = getEwBinaryScaFuncPtr<VTRes, VTArg, VTArg>(AggOpCodeUtils::getBinaryOpCode(opCode));
             else
                 // TODO Setting the function pointer yields the correct result.
                 // However, since MEAN and STDDEV are not sparse-safe, the program
                 // does not take the same path for doing the summation, and is less
                 // efficient.
                 // for MEAN and STDDDEV, we need to sum
-                func = getEwBinaryScaFuncPtr<VT, VT, VT>(AggOpCodeUtils::getBinaryOpCode(AggOpCode::SUM));
+                func = getEwBinaryScaFuncPtr<VTRes, VTArg, VTArg>(AggOpCodeUtils::getBinaryOpCode(AggOpCode::SUM));
 
             for(size_t r = 0; r < numRows; r++) {
-                VT agg = *valuesArg;
+                VTArg agg = *valuesArg;
                 for(size_t c = 1; c < numCols; c++)
                     agg = func(agg, valuesArg[c], ctx);
-                *valuesRes = agg;
+                *valuesRes = static_cast<VTRes>(agg);
                 valuesArg += arg->getRowSkip();
                 valuesRes += res->getRowSkip();
             }
@@ -138,26 +138,26 @@ struct AggRow<DenseMatrix<VT>, DenseMatrix<VT>> {
 // DenseMatrix <- CSRMatrix
 // ----------------------------------------------------------------------------
 
-template<typename VT>
-struct AggRow<DenseMatrix<VT>, CSRMatrix<VT>> {
-    static void apply(AggOpCode opCode, DenseMatrix<VT> *& res, const CSRMatrix<VT> * arg, DCTX(ctx)) {
+template<typename VTRes, typename VTArg>
+struct AggRow<DenseMatrix<VTRes>, CSRMatrix<VTArg>> {
+    static void apply(AggOpCode opCode, DenseMatrix<VTRes> *& res, const CSRMatrix<VTArg> * arg, DCTX(ctx)) {
         const size_t numCols = arg->getNumCols();
         const size_t numRows = arg->getNumRows();
         
         if(res == nullptr)
-            res = DataObjectFactory::create<DenseMatrix<VT>>(numRows, 1, false);
+            res = DataObjectFactory::create<DenseMatrix<VTRes>>(numRows, 1, false);
         
-        VT * valuesRes = res->getValues();
+        VTRes * valuesRes = res->getValues();
         
         if (AggOpCodeUtils::isPureBinaryReduction(opCode)) {
         
-            EwBinaryScaFuncPtr<VT, VT, VT> func = getEwBinaryScaFuncPtr<VT, VT, VT>(AggOpCodeUtils::getBinaryOpCode(opCode));
+            EwBinaryScaFuncPtr<VTRes, VTArg, VTArg> func = getEwBinaryScaFuncPtr<VTRes, VTArg, VTArg>(AggOpCodeUtils::getBinaryOpCode(opCode));
 
             const bool isSparseSafe = AggOpCodeUtils::isSparseSafe(opCode);
-            const VT neutral = AggOpCodeUtils::template getNeutral<VT>(opCode);
+            const VTRes neutral = AggOpCodeUtils::template getNeutral<VTRes>(opCode);
         
             for(size_t r = 0; r < numRows; r++) {
-                *valuesRes = AggAll<CSRMatrix<VT>>::aggArray(
+                *valuesRes = AggAll<VTRes, CSRMatrix<VTArg>>::aggArray(
                         arg->getValues(r),
                         arg->getNumNonZeros(r),
                         numCols,
@@ -171,11 +171,11 @@ struct AggRow<DenseMatrix<VT>, CSRMatrix<VT>> {
         }
         else { // The op-code is either MEAN or STDDEV
             // get sum for each row
-            const VT neutral = VT(0);
+            const VTRes neutral = VTRes(0);
             const bool isSparseSafe = true;
-            EwBinaryScaFuncPtr<VT, VT, VT> func = getEwBinaryScaFuncPtr<VT, VT, VT>(AggOpCodeUtils::getBinaryOpCode(AggOpCode::SUM));
+            EwBinaryScaFuncPtr<VTRes, VTArg, VTArg> func = getEwBinaryScaFuncPtr<VTRes, VTArg, VTArg>(AggOpCodeUtils::getBinaryOpCode(AggOpCode::SUM));
             for (size_t r = 0; r < numRows; r++){
-                *valuesRes = AggAll<CSRMatrix<VT>>::aggArray(
+                *valuesRes = AggAll<VTRes, CSRMatrix<VTArg>>::aggArray(
                     arg->getValues(r),
                     arg->getNumNonZeros(r),
                     numCols,

--- a/src/runtime/local/kernels/AggRow.h
+++ b/src/runtime/local/kernels/AggRow.h
@@ -68,7 +68,7 @@ struct AggRow<DenseMatrix<VTRes>, DenseMatrix<VTArg>> {
         
         if(opCode == AggOpCode::IDXMIN) {
             for(size_t r = 0; r < numRows; r++) {
-                VTRes minVal = valuesArg[0];
+                VTArg minVal = valuesArg[0];
                 size_t minValIdx = 0;
                 for(size_t c = 1; c < numCols; c++)
                     if(valuesArg[c] < minVal) {
@@ -107,7 +107,7 @@ struct AggRow<DenseMatrix<VTRes>, DenseMatrix<VTArg>> {
                 func = getEwBinaryScaFuncPtr<VTRes, VTArg, VTArg>(AggOpCodeUtils::getBinaryOpCode(AggOpCode::SUM));
 
             for(size_t r = 0; r < numRows; r++) {
-                VTArg agg = *valuesArg;
+                VTRes agg = static_cast<VTRes>(*valuesArg);
                 for(size_t c = 1; c < numCols; c++)
                     agg = func(agg, valuesArg[c], ctx);
                 *valuesRes = static_cast<VTRes>(agg);

--- a/src/runtime/local/kernels/EwBinarySca.h
+++ b/src/runtime/local/kernels/EwBinarySca.h
@@ -141,8 +141,8 @@ MAKE_EW_BINARY_SCA(BinaryOpCode::LE , lhs <= rhs)
 MAKE_EW_BINARY_SCA(BinaryOpCode::GT , lhs >  rhs)
 MAKE_EW_BINARY_SCA(BinaryOpCode::GE , lhs >= rhs)
 // Min/max.
-MAKE_EW_BINARY_SCA(BinaryOpCode::MIN, std::min(lhs, rhs))
-MAKE_EW_BINARY_SCA(BinaryOpCode::MAX, std::max(lhs, rhs))
+MAKE_EW_BINARY_SCA(BinaryOpCode::MIN, std::min<double>(lhs, rhs))
+MAKE_EW_BINARY_SCA(BinaryOpCode::MAX, std::max<double>(lhs, rhs))
 // Logical.
 MAKE_EW_BINARY_SCA(BinaryOpCode::AND, lhs && rhs)
 MAKE_EW_BINARY_SCA(BinaryOpCode::OR , lhs || rhs)

--- a/src/runtime/local/kernels/EwBinarySca.h
+++ b/src/runtime/local/kernels/EwBinarySca.h
@@ -57,8 +57,20 @@ using EwBinaryScaFuncPtr = VTRes (*)(VTLhs, VTRhs, DCTX());
  */
 template<typename VTRes, typename VTLhs, typename VTRhs>
 EwBinaryScaFuncPtr<VTRes, VTLhs, VTRhs> getEwBinaryScaFuncPtr(BinaryOpCode opCode) {
-    switch (opCode) {
 #define MAKE_CASE(opCode) case opCode: return &EwBinarySca<opCode, VTRes, VTLhs, VTRhs>::apply;
+    // For now we support only homogeneous inputs for min/max.
+    // If we have the same time, instantiate for min/max
+    if constexpr(std::is_same_v<VTLhs, VTRhs>) {
+        switch (opCode) {
+            // Min/max.
+            MAKE_CASE(BinaryOpCode::MIN)
+            MAKE_CASE(BinaryOpCode::MAX)
+            default:
+                ; // do nothing
+        }
+    }
+    // Here we instantiate everything else and throw on error if we have heterogeneous instantiation for min/max
+    switch (opCode) {
         // Arithmetic.
         MAKE_CASE(BinaryOpCode::ADD)
         MAKE_CASE(BinaryOpCode::SUB)
@@ -74,13 +86,15 @@ EwBinaryScaFuncPtr<VTRes, VTLhs, VTRhs> getEwBinaryScaFuncPtr(BinaryOpCode opCod
         MAKE_CASE(BinaryOpCode::LE)
         MAKE_CASE(BinaryOpCode::GT)
         MAKE_CASE(BinaryOpCode::GE)
-        // Min/max.
-        MAKE_CASE(BinaryOpCode::MIN)
-        MAKE_CASE(BinaryOpCode::MAX)
         // Logical.
         MAKE_CASE(BinaryOpCode::AND)
         MAKE_CASE(BinaryOpCode::OR)
 #undef MAKE_CASE
+        // homogeneous value types: this is unreachable
+        // heterogeneous value types: we throw an error for min/max
+        case BinaryOpCode::MIN: 
+        case BinaryOpCode::MAX: 
+            throw std::runtime_error("min/max do not support heterogeneous inputs");
         default:
             throw std::runtime_error("unknown BinaryOpCode");
     }
@@ -141,8 +155,8 @@ MAKE_EW_BINARY_SCA(BinaryOpCode::LE , lhs <= rhs)
 MAKE_EW_BINARY_SCA(BinaryOpCode::GT , lhs >  rhs)
 MAKE_EW_BINARY_SCA(BinaryOpCode::GE , lhs >= rhs)
 // Min/max.
-MAKE_EW_BINARY_SCA(BinaryOpCode::MIN, std::min<double>(lhs, rhs)) // TODO remove <double> again
-MAKE_EW_BINARY_SCA(BinaryOpCode::MAX, std::max<double>(lhs, rhs)) // TODO remove <double> again
+MAKE_EW_BINARY_SCA(BinaryOpCode::MIN, std::min(lhs, rhs))
+MAKE_EW_BINARY_SCA(BinaryOpCode::MAX, std::max(lhs, rhs))
 // Logical.
 MAKE_EW_BINARY_SCA(BinaryOpCode::AND, lhs && rhs)
 MAKE_EW_BINARY_SCA(BinaryOpCode::OR , lhs || rhs)

--- a/src/runtime/local/kernels/EwBinarySca.h
+++ b/src/runtime/local/kernels/EwBinarySca.h
@@ -141,8 +141,8 @@ MAKE_EW_BINARY_SCA(BinaryOpCode::LE , lhs <= rhs)
 MAKE_EW_BINARY_SCA(BinaryOpCode::GT , lhs >  rhs)
 MAKE_EW_BINARY_SCA(BinaryOpCode::GE , lhs >= rhs)
 // Min/max.
-MAKE_EW_BINARY_SCA(BinaryOpCode::MIN, std::min<double>(lhs, rhs))
-MAKE_EW_BINARY_SCA(BinaryOpCode::MAX, std::max<double>(lhs, rhs))
+MAKE_EW_BINARY_SCA(BinaryOpCode::MIN, std::min<double>(lhs, rhs)) // TODO remove <double> again
+MAKE_EW_BINARY_SCA(BinaryOpCode::MAX, std::max<double>(lhs, rhs)) // TODO remove <double> again
 // Logical.
 MAKE_EW_BINARY_SCA(BinaryOpCode::AND, lhs && rhs)
 MAKE_EW_BINARY_SCA(BinaryOpCode::OR , lhs || rhs)

--- a/src/runtime/local/kernels/EwBinarySca.h
+++ b/src/runtime/local/kernels/EwBinarySca.h
@@ -57,20 +57,8 @@ using EwBinaryScaFuncPtr = VTRes (*)(VTLhs, VTRhs, DCTX());
  */
 template<typename VTRes, typename VTLhs, typename VTRhs>
 EwBinaryScaFuncPtr<VTRes, VTLhs, VTRhs> getEwBinaryScaFuncPtr(BinaryOpCode opCode) {
-#define MAKE_CASE(opCode) case opCode: return &EwBinarySca<opCode, VTRes, VTLhs, VTRhs>::apply;
-    // For now we support only homogeneous inputs for min/max.
-    // If we have the same time, instantiate for min/max
-    if constexpr(std::is_same_v<VTLhs, VTRhs>) {
-        switch (opCode) {
-            // Min/max.
-            MAKE_CASE(BinaryOpCode::MIN)
-            MAKE_CASE(BinaryOpCode::MAX)
-            default:
-                ; // do nothing
-        }
-    }
-    // Here we instantiate everything else and throw on error if we have heterogeneous instantiation for min/max
     switch (opCode) {
+#define MAKE_CASE(opCode) case opCode: return &EwBinarySca<opCode, VTRes, VTLhs, VTRhs>::apply;
         // Arithmetic.
         MAKE_CASE(BinaryOpCode::ADD)
         MAKE_CASE(BinaryOpCode::SUB)
@@ -86,15 +74,13 @@ EwBinaryScaFuncPtr<VTRes, VTLhs, VTRhs> getEwBinaryScaFuncPtr(BinaryOpCode opCod
         MAKE_CASE(BinaryOpCode::LE)
         MAKE_CASE(BinaryOpCode::GT)
         MAKE_CASE(BinaryOpCode::GE)
+        // Min/max.
+        MAKE_CASE(BinaryOpCode::MIN)
+        MAKE_CASE(BinaryOpCode::MAX)
         // Logical.
         MAKE_CASE(BinaryOpCode::AND)
         MAKE_CASE(BinaryOpCode::OR)
 #undef MAKE_CASE
-        // homogeneous value types: this is unreachable
-        // heterogeneous value types: we throw an error for min/max
-        case BinaryOpCode::MIN: 
-        case BinaryOpCode::MAX: 
-            throw std::runtime_error("min/max do not support heterogeneous inputs");
         default:
             throw std::runtime_error("unknown BinaryOpCode");
     }

--- a/src/runtime/local/kernels/kernels.json
+++ b/src/runtime/local/kernels/kernels.json
@@ -3,10 +3,14 @@
         "kernelTemplate": {
             "header": "AggAll.h",
             "opName": "aggAll",
-            "returnType": "typename DT::VT",
+            "returnType": "VTRes",
             "templateParams": [
                 {
-                    "name": "DT",
+                    "name": "VTRes",
+                    "isDataType": false
+                },
+                {
+                    "name": "DTArg",
                     "isDataType": true
                 }
             ],
@@ -16,17 +20,21 @@
                     "name": "opCode"
                 },
                 {
-                    "type": "const DT *",
+                    "type": "const DTArg *",
                     "name": "arg"
                 }
             ]
         },
         "instantiations": [
-            [["DenseMatrix", "float"]],
-            [["DenseMatrix", "double"]],
-            [["DenseMatrix", "int64_t"]],
-            [["CSRMatrix", "double"]],
-            [["CSRMatrix", "int64_t"]]
+            ["float", ["DenseMatrix", "float"]],
+            ["double", ["DenseMatrix", "double"]],
+            ["int64_t", ["DenseMatrix", "int64_t"]],
+            ["double", ["DenseMatrix", "int64_t"]],
+            ["float", ["DenseMatrix", "int64_t"]],
+            ["double", ["CSRMatrix", "double"]],
+            ["int64_t", ["CSRMatrix", "int64_t"]],
+            ["double", ["CSRMatrix", "int64_t"]],
+            ["float", ["CSRMatrix", "int64_t"]]
         ],
         "opCodes": ["SUM", "MIN", "MAX", "MEAN"]
     },
@@ -76,8 +84,12 @@
                     [["DenseMatrix", "double"], ["DenseMatrix", "double"]],
                     [["DenseMatrix", "float"], ["DenseMatrix", "float"]],
                     [["DenseMatrix", "int64_t"], ["DenseMatrix", "int64_t"]],
+                    [["DenseMatrix", "double"], ["DenseMatrix", "int64_t"]],
+                    [["DenseMatrix", "float"], ["DenseMatrix", "int64_t"]],
                     [["DenseMatrix", "double"], ["CSRMatrix", "double"]],
-                    [["DenseMatrix", "int64_t"], ["CSRMatrix", "int64_t"]]
+                    [["DenseMatrix", "int64_t"], ["CSRMatrix", "int64_t"]],
+                    [["DenseMatrix", "double"], ["CSRMatrix", "int64_t"]],
+                    [["DenseMatrix", "float"], ["CSRMatrix", "int64_t"]]
                 ],
                 "opCodes": ["SUM", "MIN", "MAX", "MEAN", "STDDEV"]
             }
@@ -117,11 +129,15 @@
             [["DenseMatrix", "float"], ["DenseMatrix", "float"]],
             [["DenseMatrix", "double"], ["DenseMatrix", "double"]],
             [["DenseMatrix", "int64_t"], ["DenseMatrix", "int64_t"]],
+            [["DenseMatrix", "float"], ["DenseMatrix", "int64_t"]],
+            [["DenseMatrix", "double"], ["DenseMatrix", "int64_t"]],
             [["DenseMatrix", "uint8_t"], ["DenseMatrix", "uint8_t"]],
             [["DenseMatrix", "size_t"], ["DenseMatrix", "size_t"]],
 
             [["DenseMatrix", "double"], ["CSRMatrix", "double"]],
-            [["DenseMatrix", "int64_t"], ["CSRMatrix", "int64_t"]]
+            [["DenseMatrix", "int64_t"], ["CSRMatrix", "int64_t"]],
+            [["DenseMatrix", "float"], ["CSRMatrix", "int64_t"]],
+            [["DenseMatrix", "double"], ["CSRMatrix", "int64_t"]]
         ],
         "opCodes": ["SUM", "MIN", "MAX", "MEAN", "IDXMIN", "IDXMAX"]
     },

--- a/test/runtime/local/kernels/AggAllTest.cpp
+++ b/test/runtime/local/kernels/AggAllTest.cpp
@@ -37,27 +37,32 @@ void checkAggAll(AggOpCode opCode, const DTArg * arg, VTRes exp) {
     CHECK(res == exp);
 }
 
-TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("sum"), TAG_KERNELS, (DATA_TYPES), (VALUE_TYPES)) {
-    using DT = TestType;
-    
-    auto m0 = genGivenVals<DT>(3, {
-        0, 0, 0, 0,
-        0, 0, 0, 0,
-        0, 0, 0, 0,
-    });
-    auto m1 = genGivenVals<DT>(3, {
-        3, 0, 2, 0,
-        0, 0, 1, 1,
-        2, 5, 0, 0,
-    });
-    
-    checkAggAll(AggOpCode::SUM, m0, 0);
-    checkAggAll(AggOpCode::SUM, m1, 14);
-    
-    DataObjectFactory::destroy(m0);
-    DataObjectFactory::destroy(m1);
+// The value types of argument and result could be different, so we need to
+// test various combinations.
+#define SUM_TEST_CASE(VTRes) TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("sum - result value type: " #VTRes), TAG_KERNELS, (DATA_TYPES), (VALUE_TYPES)) { \
+    using DTArg = TestType; \
+     \
+    auto m0 = genGivenVals<DTArg>(3, { \
+        0, 0, 0, 0, \
+        0, 0, 0, 0, \
+        0, 0, 0, 0, \
+    }); \
+    auto m1 = genGivenVals<DTArg>(3, { \
+        3, 0, 2, 0, \
+        0, 0, 1, 1, \
+        2, 5, 0, 0, \
+    }); \
+     \
+    checkAggAll(AggOpCode::SUM, m0, (VTRes)0); \
+    checkAggAll(AggOpCode::SUM, m1, (VTRes)14); \
+     \
+    DataObjectFactory::destroy(m0); \
+    DataObjectFactory::destroy(m1); \
 }
+SUM_TEST_CASE(int64_t)
+SUM_TEST_CASE(double)
 
+// The value types of argument and result can be assumed to be the same.
 TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("min"), TAG_KERNELS, (DATA_TYPES), (VALUE_TYPES)) {
     using DT = TestType;
     
@@ -86,6 +91,7 @@ TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("min"), TAG_KERNELS, (DATA_TYPES), (VALUE_T
     DataObjectFactory::destroy(m2);
 }
 
+// The value types of argument and result can be assumed to be the same.
 TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("max"), TAG_KERNELS, (DATA_TYPES), (VALUE_TYPES)) {
     using DT = TestType;
     
@@ -115,34 +121,34 @@ TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("max"), TAG_KERNELS, (DATA_TYPES), (VALUE_T
     DataObjectFactory::destroy(m2);
 }
 
-
-#define MEAN_TEST_CASE(ResultType) TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("mean - result type: " #ResultType), TAG_KERNELS, (DATA_TYPES), (VALUE_TYPES)) { \
-    using DT = TestType;  \
+// The value types of argument and result could be different, so we need to
+// test various combinations.
+#define MEAN_TEST_CASE(VTRes) TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("mean - result value type: " #VTRes), TAG_KERNELS, (DATA_TYPES), (VALUE_TYPES)) { \
+    using DTArg = TestType;  \
      \
-    auto m0 = genGivenVals<DT>(3, { \
+    auto m0 = genGivenVals<DTArg>(3, { \
         0, 0, 0, 0, \
         0, 0, 0, 0, \
         0, 0, 0, 0, \
     }); \
-    auto m1 = genGivenVals<DT>(3, { \
+    auto m1 = genGivenVals<DTArg>(3, { \
         1, 6, 3, 9, \
         2, 2, 8, 9, \
         4, 4, 5, 4, \
     }); \
-    auto m2 = genGivenVals<DT>(3, { \
+    auto m2 = genGivenVals<DTArg>(3, { \
         4, 0, 0, 9, \
         0, 6, 0, 0, \
         0, 0, 5, 0, \
     }); \
      \
-    checkAggAll(AggOpCode::MEAN, m0, (ResultType)0); \
-    checkAggAll(AggOpCode::MEAN, m1, (ResultType)4.75); \
-    checkAggAll(AggOpCode::MEAN, m2, (ResultType)2); \
+    checkAggAll(AggOpCode::MEAN, m0, (VTRes)0); \
+    checkAggAll(AggOpCode::MEAN, m1, (VTRes)4.75); \
+    checkAggAll(AggOpCode::MEAN, m2, (VTRes)2); \
      \
     DataObjectFactory::destroy(m0); \
     DataObjectFactory::destroy(m1); \
     DataObjectFactory::destroy(m2); \
-} \
-
+}
 MEAN_TEST_CASE(int64_t);
 MEAN_TEST_CASE(double);

--- a/test/runtime/local/kernels/AggAllTest.cpp
+++ b/test/runtime/local/kernels/AggAllTest.cpp
@@ -82,9 +82,10 @@ TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("min"), TAG_KERNELS, (DATA_TYPES), (VALUE_T
         0, 0, 5, 0,
     });
     
-    checkAggAll(AggOpCode::MIN, m0, 0);
-    checkAggAll(AggOpCode::MIN, m1, 2);
-    checkAggAll(AggOpCode::MIN, m2, 0);
+    // In case of min the result type is the same as the input type
+    checkAggAll(AggOpCode::MIN, m0, (typename DT::VT)0);
+    checkAggAll(AggOpCode::MIN, m1, (typename DT::VT)2);
+    checkAggAll(AggOpCode::MIN, m2, (typename DT::VT)0);
     
     DataObjectFactory::destroy(m0);
     DataObjectFactory::destroy(m1);

--- a/test/runtime/local/kernels/AggAllTest.cpp
+++ b/test/runtime/local/kernels/AggAllTest.cpp
@@ -31,9 +31,9 @@
 #define DATA_TYPES DenseMatrix, CSRMatrix
 #define VALUE_TYPES double, uint32_t
 
-template<class DT>
-void checkAggAll(AggOpCode opCode, const DT * arg, typename DT::VT exp) {
-    typename DT::VT res = aggAll<DT>(opCode, arg, nullptr);
+template<typename VTRes, class DTArg>
+void checkAggAll(AggOpCode opCode, const DTArg * arg, VTRes exp) {
+    VTRes res = aggAll<VTRes, DTArg>(opCode, arg, nullptr);
     CHECK(res == exp);
 }
 
@@ -104,10 +104,11 @@ TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("max"), TAG_KERNELS, (DATA_TYPES), (VALUE_T
         0, 2, 0, 0,
         0, 0, 5, 0,
     });
-    
-    checkAggAll(AggOpCode::MAX, m0, 0);
-    checkAggAll(AggOpCode::MAX, m1, 9);
-    checkAggAll(AggOpCode::MAX, m2, 9);
+
+    // In case of max the result type is the same as the input type
+    checkAggAll(AggOpCode::MAX, m0, (typename DT::VT)0);
+    checkAggAll(AggOpCode::MAX, m1, (typename DT::VT)9);
+    checkAggAll(AggOpCode::MAX, m2, (typename DT::VT)9);
     
     DataObjectFactory::destroy(m0);
     DataObjectFactory::destroy(m1);
@@ -124,7 +125,7 @@ TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("mean"), TAG_KERNELS, (DATA_TYPES), (VALUE_
         0, 0, 0, 0,
     });
     auto m1 = genGivenVals<DT>(3, {
-        4, 6, 3, 9,
+        1, 6, 3, 9,
         2, 2, 8, 9,
         4, 4, 5, 4,
     });
@@ -134,9 +135,9 @@ TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("mean"), TAG_KERNELS, (DATA_TYPES), (VALUE_
         0, 0, 5, 0,
     });
     
-    checkAggAll(AggOpCode::MEAN, m0, 0);
-    checkAggAll(AggOpCode::MEAN, m1, 5);
-    checkAggAll(AggOpCode::MEAN, m2, 2);
+    checkAggAll(AggOpCode::MEAN, m0, (typename DT::VT)0);
+    checkAggAll(AggOpCode::MEAN, m1, (typename DT::VT)4.75);
+    checkAggAll(AggOpCode::MEAN, m2, (typename DT::VT)2);
     
     DataObjectFactory::destroy(m0);
     DataObjectFactory::destroy(m1);

--- a/test/runtime/local/kernels/AggAllTest.cpp
+++ b/test/runtime/local/kernels/AggAllTest.cpp
@@ -116,30 +116,33 @@ TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("max"), TAG_KERNELS, (DATA_TYPES), (VALUE_T
 }
 
 
-TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("mean"), TAG_KERNELS, (DATA_TYPES), (VALUE_TYPES)) {
-    using DT = TestType;
-    
-    auto m0 = genGivenVals<DT>(3, {
-        0, 0, 0, 0,
-        0, 0, 0, 0,
-        0, 0, 0, 0,
-    });
-    auto m1 = genGivenVals<DT>(3, {
-        1, 6, 3, 9,
-        2, 2, 8, 9,
-        4, 4, 5, 4,
-    });
-    auto m2 = genGivenVals<DT>(3, {
-        4, 0, 0, 9,
-        0, 6, 0, 0,
-        0, 0, 5, 0,
-    });
-    
-    checkAggAll(AggOpCode::MEAN, m0, (typename DT::VT)0);
-    checkAggAll(AggOpCode::MEAN, m1, (typename DT::VT)4.75);
-    checkAggAll(AggOpCode::MEAN, m2, (typename DT::VT)2);
-    
-    DataObjectFactory::destroy(m0);
-    DataObjectFactory::destroy(m1);
-    DataObjectFactory::destroy(m2);
-}
+#define MEAN_TEST_CASE(ResultType) TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("mean - result type: " #ResultType), TAG_KERNELS, (DATA_TYPES), (VALUE_TYPES)) { \
+    using DT = TestType;  \
+     \
+    auto m0 = genGivenVals<DT>(3, { \
+        0, 0, 0, 0, \
+        0, 0, 0, 0, \
+        0, 0, 0, 0, \
+    }); \
+    auto m1 = genGivenVals<DT>(3, { \
+        1, 6, 3, 9, \
+        2, 2, 8, 9, \
+        4, 4, 5, 4, \
+    }); \
+    auto m2 = genGivenVals<DT>(3, { \
+        4, 0, 0, 9, \
+        0, 6, 0, 0, \
+        0, 0, 5, 0, \
+    }); \
+     \
+    checkAggAll(AggOpCode::MEAN, m0, (ResultType)0); \
+    checkAggAll(AggOpCode::MEAN, m1, (ResultType)4.75); \
+    checkAggAll(AggOpCode::MEAN, m2, (ResultType)2); \
+     \
+    DataObjectFactory::destroy(m0); \
+    DataObjectFactory::destroy(m1); \
+    DataObjectFactory::destroy(m2); \
+} \
+
+MEAN_TEST_CASE(int64_t);
+MEAN_TEST_CASE(double);

--- a/test/runtime/local/kernels/AggColTest.cpp
+++ b/test/runtime/local/kernels/AggColTest.cpp
@@ -38,32 +38,37 @@ void checkAggCol(AggOpCode opCode, const DTArg * arg, const DTRes * exp) {
     CHECK(*res == *exp);
 }
 
-TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("sum"), TAG_KERNELS, (DATA_TYPES), (VALUE_TYPES)) {
-    using DTArg = TestType;
-    using DTRes = DenseMatrix<typename DTArg::VT>;
-    
-    auto m0 = genGivenVals<DTArg>(3, {
-        0, 0, 0, 0,
-        0, 0, 0, 0,
-        0, 0, 0, 0,
-    });
-    auto m0exp = genGivenVals<DTRes>(1, {0, 0, 0, 0});
-    auto m1 = genGivenVals<DTArg>(3, {
-        3, 0, 2, 0,
-        0, 0, 1, 1,
-        2, 5, 0, 0,
-    });
-    auto m1exp = genGivenVals<DTRes>(1, {5, 5, 3, 1});
-    
-    checkAggCol(AggOpCode::SUM, m0, m0exp);
-    checkAggCol(AggOpCode::SUM, m1, m1exp);
-    
-    DataObjectFactory::destroy(m0);
-    DataObjectFactory::destroy(m0exp);
-    DataObjectFactory::destroy(m1);
-    DataObjectFactory::destroy(m1exp);
+// The value types of argument and result could be different, so we need to
+// test various combinations.
+#define SUM_TEST_CASE(VTRes) TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("sum - result value type: " #VTRes), TAG_KERNELS, (DATA_TYPES), (VALUE_TYPES)) { \
+    using DTArg = TestType; \
+    using DTRes = DenseMatrix<VTRes>; \
+     \
+    auto m0 = genGivenVals<DTArg>(3, { \
+        0, 0, 0, 0, \
+        0, 0, 0, 0, \
+        0, 0, 0, 0, \
+    }); \
+    auto m0exp = genGivenVals<DTRes>(1, {0, 0, 0, 0}); \
+    auto m1 = genGivenVals<DTArg>(3, { \
+        3, 0, 2, 0, \
+        0, 0, 1, 1, \
+        2, 5, 0, 0, \
+    }); \
+    auto m1exp = genGivenVals<DTRes>(1, {5, 5, 3, 1}); \
+     \
+    checkAggCol(AggOpCode::SUM, m0, m0exp); \
+    checkAggCol(AggOpCode::SUM, m1, m1exp); \
+     \
+    DataObjectFactory::destroy(m0); \
+    DataObjectFactory::destroy(m0exp); \
+    DataObjectFactory::destroy(m1); \
+    DataObjectFactory::destroy(m1exp); \
 }
+SUM_TEST_CASE(int64_t)
+SUM_TEST_CASE(double)
 
+// The value types of argument and result can be assumed to be the same.
 TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("min"), TAG_KERNELS, (DATA_TYPES), (VALUE_TYPES)) {
     using DTArg = TestType;
     using DTRes = DenseMatrix<typename DTArg::VT>;
@@ -99,6 +104,7 @@ TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("min"), TAG_KERNELS, (DATA_TYPES), (VALUE_T
     DataObjectFactory::destroy(m2exp);
 }
 
+// The value types of argument and result can be assumed to be the same.
 TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("max"), TAG_KERNELS, (DATA_TYPES), (VALUE_TYPES)) {
     using DTArg = TestType;
     using DTRes = DenseMatrix<typename DTArg::VT>;
@@ -134,9 +140,11 @@ TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("max"), TAG_KERNELS, (DATA_TYPES), (VALUE_T
     DataObjectFactory::destroy(m2exp);
 }
 
-#define MEAN_TEST_CASE(resultType) TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("mean - result type: " #ResultType), TAG_KERNELS, (DATA_TYPES), (int64_t, double)) { \
+// The value types of argument and result could be different, so we need to
+// test various combinations.
+#define MEAN_TEST_CASE(VTRes) TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("mean - result value type: " #VTRes), TAG_KERNELS, (DATA_TYPES), (int64_t, double)) { \
     using DTArg = TestType; \
-    using DTRes = DenseMatrix<ResultType>; \
+    using DTRes = DenseMatrix<VTRes>; \
      \
     auto m0 = genGivenVals<DTArg>(3, { \
         0, 0, 0, 0, \
@@ -150,7 +158,7 @@ TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("max"), TAG_KERNELS, (DATA_TYPES), (VALUE_T
         3, 1, 0,  0, \
         3, 1, 5, -1, \
     }); \
-    auto m2exp = genGivenVals<DTRes>(1, {(ResultType)2.0, (ResultType)2.0, (ResultType)2.5, (ResultType)0.25}); \
+    auto m2exp = genGivenVals<DTRes>(1, {(VTRes)2.0, (VTRes)2.0, (VTRes)2.5, (VTRes)0.25}); \
     \
     checkAggCol(AggOpCode::MEAN, m0, m0exp); \
     checkAggCol(AggOpCode::MEAN, m2, m2exp); \
@@ -159,14 +167,15 @@ TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("max"), TAG_KERNELS, (DATA_TYPES), (VALUE_T
     DataObjectFactory::destroy(m0exp); \
     DataObjectFactory::destroy(m2); \
     DataObjectFactory::destroy(m2exp); \
-} 
-
+}
 MEAN_TEST_CASE(int64_t);
 MEAN_TEST_CASE(double);
 
-#define STDDEV_TEST_CASE(ResultType) TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("stddev - result type: " #ResultType), TAG_KERNELS, (DATA_TYPES), (int64_t, double)) { \
+// The value types of argument and result could be different, so we need to
+// test various combinations.
+#define STDDEV_TEST_CASE(VTRes) TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("stddev - result value type: " #VTRes), TAG_KERNELS, (DATA_TYPES), (int64_t, double)) { \
     using DTArg = TestType; \
-    using DTRes = DenseMatrix<ResultType>; \
+    using DTRes = DenseMatrix<VTRes>; \
      \
     auto m0 = genGivenVals<DTArg>(3, { \
         0, 0, 0, 0, \
@@ -180,7 +189,7 @@ MEAN_TEST_CASE(double);
         3, 1, 0,  0, \
         3, 1, 5, -1, \
     }); \
-    auto m2exp = genGivenVals<DTRes>(1, {(ResultType)1, (ResultType)1, (ResultType)2.5, (ResultType)1.6393596310755}); \
+    auto m2exp = genGivenVals<DTRes>(1, {1, 1, (VTRes)2.5, (VTRes)1.6393596310755}); \
      \
     checkAggCol(AggOpCode::STDDEV, m0, m0exp); \
     checkAggCol(AggOpCode::STDDEV, m2, m2exp); \
@@ -189,7 +198,6 @@ MEAN_TEST_CASE(double);
     DataObjectFactory::destroy(m0exp); \
     DataObjectFactory::destroy(m2); \
     DataObjectFactory::destroy(m2exp); \
-} \
-
+}
 STDDEV_TEST_CASE(int64_t);
 STDDEV_TEST_CASE(double);

--- a/test/runtime/local/kernels/AggColTest.cpp
+++ b/test/runtime/local/kernels/AggColTest.cpp
@@ -134,70 +134,62 @@ TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("max"), TAG_KERNELS, (DATA_TYPES), (VALUE_T
     DataObjectFactory::destroy(m2exp);
 }
 
-TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("mean"), TAG_KERNELS, (DATA_TYPES), (int64_t, double)) {
-    using DTArg = TestType;
-    using VT = typename DTArg::VT;
-    using DTRes = DenseMatrix<VT>;
-    
-    auto m0 = genGivenVals<DTArg>(3, {
-        0, 0, 0, 0,
-        0, 0, 0, 0,
-        0, 0, 0, 0,
-    });
-    auto m0exp = genGivenVals<DTRes>(1, {0, 0, 0, 0});
-    auto m2 = genGivenVals<DTArg>(4, {
-        1, 3, 0, -1,
-        1, 3, 5,  3,
-        3, 1, 0,  0,
-        3, 1, 5, -1,
-    });
-    auto m2exp = genGivenVals<DTRes>(1, {VT(2.0), VT(2.0), VT(2.5), VT(0.25)});
-    
-    // Test case integer matrix -> double results. Maybe move this to seperate TEST_CASE_TEMPLATE ?
-    auto m3 = genGivenVals<DTArg>(4, {
-        1, 3, 0, -1,
-        1, 3, 5,  3,
-        3, 1, 0,  0,
-        3, 1, 5, -1,
-    });
-    auto m3exp = genGivenVals<DenseMatrix<double>>(1, {2.0, 2.0, 2.5, 0.25});
-    
-    checkAggCol(AggOpCode::MEAN, m0, m0exp);
-    checkAggCol(AggOpCode::MEAN, m2, m2exp);
-    checkAggCol(AggOpCode::MEAN, m3, m3exp);
-    
-    DataObjectFactory::destroy(m0);
-    DataObjectFactory::destroy(m0exp);
-    DataObjectFactory::destroy(m2);
-    DataObjectFactory::destroy(m2exp);
-    DataObjectFactory::destroy(m3);
-    DataObjectFactory::destroy(m3exp);
-}
+#define MEAN_TEST_CASE(resultType) TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("mean - result type: " #ResultType), TAG_KERNELS, (DATA_TYPES), (int64_t, double)) { \
+    using DTArg = TestType; \
+    using DTRes = DenseMatrix<ResultType>; \
+     \
+    auto m0 = genGivenVals<DTArg>(3, { \
+        0, 0, 0, 0, \
+        0, 0, 0, 0, \
+        0, 0, 0, 0, \
+    }); \
+    auto m0exp = genGivenVals<DTRes>(1, {0, 0, 0, 0}); \
+    auto m2 = genGivenVals<DTArg>(4, { \
+        1, 3, 0, -1, \
+        1, 3, 5,  3, \
+        3, 1, 0,  0, \
+        3, 1, 5, -1, \
+    }); \
+    auto m2exp = genGivenVals<DTRes>(1, {(ResultType)2.0, (ResultType)2.0, (ResultType)2.5, (ResultType)0.25}); \
+    \
+    checkAggCol(AggOpCode::MEAN, m0, m0exp); \
+    checkAggCol(AggOpCode::MEAN, m2, m2exp); \
+     \
+    DataObjectFactory::destroy(m0); \
+    DataObjectFactory::destroy(m0exp); \
+    DataObjectFactory::destroy(m2); \
+    DataObjectFactory::destroy(m2exp); \
+} 
 
-TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("stddev"), TAG_KERNELS, (DATA_TYPES), (int64_t, double)) {
-    using DTArg = TestType;
-    using VT = typename DTArg::VT;
-    using DTRes = DenseMatrix<VT>;
-    
-    auto m0 = genGivenVals<DTArg>(3, {
-        0, 0, 0, 0,
-        0, 0, 0, 0,
-        0, 0, 0, 0,
-    });
-    auto m0exp = genGivenVals<DTRes>(1, {0, 0, 0, 0});
-    auto m2 = genGivenVals<DTArg>(4, {
-        1, 3, 0, -1,
-        1, 3, 5,  3,
-        3, 1, 0,  0,
-        3, 1, 5, -1,
-    });
-    auto m2exp = genGivenVals<DTRes>(1, {1, 1, VT(2.5), VT(1.6393596310755)});
-    
-    checkAggCol(AggOpCode::STDDEV, m0, m0exp);
-    checkAggCol(AggOpCode::STDDEV, m2, m2exp);
-    
-    DataObjectFactory::destroy(m0);
-    DataObjectFactory::destroy(m0exp);
-    DataObjectFactory::destroy(m2);
-    DataObjectFactory::destroy(m2exp);
-}
+MEAN_TEST_CASE(int64_t);
+MEAN_TEST_CASE(double);
+
+#define STDDEV_TEST_CASE(ResultType) TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("stddev - result type: " #ResultType), TAG_KERNELS, (DATA_TYPES), (int64_t, double)) { \
+    using DTArg = TestType; \
+    using DTRes = DenseMatrix<ResultType>; \
+     \
+    auto m0 = genGivenVals<DTArg>(3, { \
+        0, 0, 0, 0, \
+        0, 0, 0, 0, \
+        0, 0, 0, 0, \
+    }); \
+    auto m0exp = genGivenVals<DTRes>(1, {0, 0, 0, 0}); \
+    auto m2 = genGivenVals<DTArg>(4, { \
+        1, 3, 0, -1, \
+        1, 3, 5,  3, \
+        3, 1, 0,  0, \
+        3, 1, 5, -1, \
+    }); \
+    auto m2exp = genGivenVals<DTRes>(1, {(ResultType)1, (ResultType)1, (ResultType)2.5, (ResultType)1.6393596310755}); \
+     \
+    checkAggCol(AggOpCode::STDDEV, m0, m0exp); \
+    checkAggCol(AggOpCode::STDDEV, m2, m2exp); \
+     \
+    DataObjectFactory::destroy(m0); \
+    DataObjectFactory::destroy(m0exp); \
+    DataObjectFactory::destroy(m2); \
+    DataObjectFactory::destroy(m2exp); \
+} \
+
+STDDEV_TEST_CASE(int64_t);
+STDDEV_TEST_CASE(double);

--- a/test/runtime/local/kernels/AggColTest.cpp
+++ b/test/runtime/local/kernels/AggColTest.cpp
@@ -151,15 +151,27 @@ TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("mean"), TAG_KERNELS, (DATA_TYPES), (int64_
         3, 1, 0,  0,
         3, 1, 5, -1,
     });
-    auto m2exp = genGivenVals<DTRes>(1, {2, 2, VT(2.5), VT(0.25)});
+    auto m2exp = genGivenVals<DTRes>(1, {VT(2.0), VT(2.0), VT(2.5), VT(0.25)});
+    
+    // Test case integer matrix -> double results. Maybe move this to seperate TEST_CASE_TEMPLATE ?
+    auto m3 = genGivenVals<DTArg>(4, {
+        1, 3, 0, -1,
+        1, 3, 5,  3,
+        3, 1, 0,  0,
+        3, 1, 5, -1,
+    });
+    auto m3exp = genGivenVals<DenseMatrix<double>>(1, {2.0, 2.0, 2.5, 0.25});
     
     checkAggCol(AggOpCode::MEAN, m0, m0exp);
     checkAggCol(AggOpCode::MEAN, m2, m2exp);
+    checkAggCol(AggOpCode::MEAN, m3, m3exp);
     
     DataObjectFactory::destroy(m0);
     DataObjectFactory::destroy(m0exp);
     DataObjectFactory::destroy(m2);
     DataObjectFactory::destroy(m2exp);
+    DataObjectFactory::destroy(m3);
+    DataObjectFactory::destroy(m3exp);
 }
 
 TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("stddev"), TAG_KERNELS, (DATA_TYPES), (int64_t, double)) {

--- a/test/runtime/local/kernels/AggRowTest.cpp
+++ b/test/runtime/local/kernels/AggRowTest.cpp
@@ -214,13 +214,23 @@ TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("mean"), TAG_KERNELS, (DATA_TYPES), (VALUE_
     auto m2 = genGivenVals<DTArg>(3, {
         4, 0, 0, 8,
         0, 4, 0, 0,
-        0, 0, 8, 0,
+        0, 0, 7, 0,
     });
-    auto m2exp = genGivenVals<DTRes>(3, {3, 1, 2});
+    auto m2exp = genGivenVals<DTRes>(3, {3, 1, typename DTArg::VT(1.75)});
+
+    // Test case integer matrix -> double results.
+    // Maybe move this to seperate TEST_CASE_TEMPLATE ?
+    auto m3 = genGivenVals<DTArg>(3, {
+        5, 7, 1, 9,
+        2, 5, 7, 1,
+        7, 1, 5, 4,
+    });
+    auto m3exp = genGivenVals<DenseMatrix<double>>(3, {5.5, 3.75, 4.25});
     
     checkAggRow(AggOpCode::MEAN, m0, m0exp);
     checkAggRow(AggOpCode::MEAN, m1, m1exp);
     checkAggRow(AggOpCode::MEAN, m2, m2exp);
+    checkAggRow(AggOpCode::MEAN, m3, m3exp);
     
-    DataObjectFactory::destroy(m0, m0exp, m1, m1exp, m2, m2exp);
+    DataObjectFactory::destroy(m0, m0exp, m1, m1exp, m2, m2exp, m3, m3exp);
 }

--- a/test/runtime/local/kernels/AggRowTest.cpp
+++ b/test/runtime/local/kernels/AggRowTest.cpp
@@ -38,32 +38,37 @@ void checkAggRow(AggOpCode opCode, const DTArg * arg, const DTRes * exp) {
     CHECK(*res == *exp);
 }
 
-TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("sum"), TAG_KERNELS, (DATA_TYPES), (VALUE_TYPES)) {
-    using DTArg = TestType;
-    using DTRes = DenseMatrix<typename DTArg::VT>;
-    
-    auto m0 = genGivenVals<DTArg>(3, {
-        0, 0, 0, 0,
-        0, 0, 0, 0,
-        0, 0, 0, 0,
-    });
-    auto m0exp = genGivenVals<DTRes>(3, {0, 0, 0});
-    auto m1 = genGivenVals<DTArg>(3, {
-        3, 0, 2, 0,
-        0, 0, 1, 1,
-        2, 5, 0, 0,
-    });
-    auto m1exp = genGivenVals<DTRes>(3, {5, 2, 7});
-    
-    checkAggRow(AggOpCode::SUM, m0, m0exp);
-    checkAggRow(AggOpCode::SUM, m1, m1exp);
-    
-    DataObjectFactory::destroy(m0);
-    DataObjectFactory::destroy(m0exp);
-    DataObjectFactory::destroy(m1);
-    DataObjectFactory::destroy(m1exp);
+// The value types of argument and result could be different, so we need to
+// test various combinations.
+#define SUM_TEST_CASE(VTRes) TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("sum - result value type: " #VTRes), TAG_KERNELS, (DATA_TYPES), (VALUE_TYPES)) { \
+    using DTArg = TestType; \
+    using DTRes = DenseMatrix<VTRes>; \
+     \
+    auto m0 = genGivenVals<DTArg>(3, { \
+        0, 0, 0, 0, \
+        0, 0, 0, 0, \
+        0, 0, 0, 0, \
+    }); \
+    auto m0exp = genGivenVals<DTRes>(3, {0, 0, 0}); \
+    auto m1 = genGivenVals<DTArg>(3, { \
+        3, 0, 2, 0, \
+        0, 0, 1, 1, \
+        2, 5, 0, 0, \
+    }); \
+    auto m1exp = genGivenVals<DTRes>(3, {5, 2, 7}); \
+     \
+    checkAggRow(AggOpCode::SUM, m0, m0exp); \
+    checkAggRow(AggOpCode::SUM, m1, m1exp); \
+     \
+    DataObjectFactory::destroy(m0); \
+    DataObjectFactory::destroy(m0exp); \
+    DataObjectFactory::destroy(m1); \
+    DataObjectFactory::destroy(m1exp); \
 }
+SUM_TEST_CASE(int64_t)
+SUM_TEST_CASE(double)
 
+// The value types of argument and result can be assumed to be the same.
 TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("min"), TAG_KERNELS, (DATA_TYPES), (VALUE_TYPES)) {
     using DTArg = TestType;
     using DTRes = DenseMatrix<typename DTArg::VT>;
@@ -99,6 +104,7 @@ TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("min"), TAG_KERNELS, (DATA_TYPES), (VALUE_T
     DataObjectFactory::destroy(m2exp);
 }
 
+// The value types of argument and result can be assumed to be the same.
 TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("max"), TAG_KERNELS, (DATA_TYPES), (VALUE_TYPES)) {
     using DTArg = TestType;
     using DTRes = DenseMatrix<typename DTArg::VT>;
@@ -134,6 +140,7 @@ TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("max"), TAG_KERNELS, (DATA_TYPES), (VALUE_T
     DataObjectFactory::destroy(m2exp);
 }
 
+// The value types of argument and result can be assumed to be size_t.
 TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("idxmin"), TAG_KERNELS, (DenseMatrix), (VALUE_TYPES)) {
     using DTArg = TestType;
     using DTRes = DenseMatrix<size_t>;
@@ -164,6 +171,7 @@ TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("idxmin"), TAG_KERNELS, (DenseMatrix), (VAL
     DataObjectFactory::destroy(m0, m0exp, m1, m1exp, m2, m2exp);
 }
 
+// The value types of argument and result can be assumed to be size_t.
 TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("idxmax"), TAG_KERNELS, (DenseMatrix), (VALUE_TYPES)) {
     using DTArg = TestType;
     using DTRes = DenseMatrix<size_t>;
@@ -194,10 +202,11 @@ TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("idxmax"), TAG_KERNELS, (DenseMatrix), (VAL
     DataObjectFactory::destroy(m0, m0exp, m1, m1exp, m2, m2exp);
 }
 
-
-#define MEAN_TEST_CASE(ResultType) TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("mean - result type: " #ResultType), TAG_KERNELS, (DATA_TYPES), (VALUE_TYPES)) { \
+// The value types of argument and result could be different, so we need to
+// test various combinations.
+#define MEAN_TEST_CASE(VTRes) TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("mean - result value type: " #VTRes), TAG_KERNELS, (DATA_TYPES), (VALUE_TYPES)) { \
     using DTArg = TestType; \
-    using DTRes = DenseMatrix<ResultType>; \
+    using DTRes = DenseMatrix<VTRes>; \
      \
     auto m0 = genGivenVals<DTArg>(3, { \
         0, 0, 0, 0, \
@@ -216,14 +225,14 @@ TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("idxmax"), TAG_KERNELS, (DenseMatrix), (VAL
         0, 4, 0, 0, \
         0, 0, 7, 0, \
     }); \
-    auto m2exp = genGivenVals<DTRes>(3, {(ResultType)3, (ResultType)1, (ResultType)1.75}); \
+    auto m2exp = genGivenVals<DTRes>(3, {3, 1, (VTRes)1.75}); \
  \
     auto m3 = genGivenVals<DTArg>(3, { \
         5, 7, 1, 9, \
         2, 5, 7, 1, \
         7, 1, 5, 4, \
     }); \
-    auto m3exp = genGivenVals<DTRes>(3, {(ResultType)5.5, (ResultType)3.75, (ResultType)4.25}); \
+    auto m3exp = genGivenVals<DTRes>(3, {(VTRes)5.5, (VTRes)3.75, (VTRes)4.25}); \
      \
     checkAggRow(AggOpCode::MEAN, m0, m0exp); \
     checkAggRow(AggOpCode::MEAN, m1, m1exp); \
@@ -231,7 +240,6 @@ TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("idxmax"), TAG_KERNELS, (DenseMatrix), (VAL
     checkAggRow(AggOpCode::MEAN, m3, m3exp); \
      \
     DataObjectFactory::destroy(m0, m0exp, m1, m1exp, m2, m2exp, m3, m3exp); \
-} \
-
+}
 MEAN_TEST_CASE(int64_t);
 MEAN_TEST_CASE(double);

--- a/test/runtime/local/kernels/AggRowTest.cpp
+++ b/test/runtime/local/kernels/AggRowTest.cpp
@@ -140,7 +140,7 @@ TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("max"), TAG_KERNELS, (DATA_TYPES), (VALUE_T
     DataObjectFactory::destroy(m2exp);
 }
 
-// The value types of argument and result can be assumed to be size_t.
+// The value type of the result can be assumed to be size_t.
 TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("idxmin"), TAG_KERNELS, (DenseMatrix), (VALUE_TYPES)) {
     using DTArg = TestType;
     using DTRes = DenseMatrix<size_t>;
@@ -171,7 +171,7 @@ TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("idxmin"), TAG_KERNELS, (DenseMatrix), (VAL
     DataObjectFactory::destroy(m0, m0exp, m1, m1exp, m2, m2exp);
 }
 
-// The value types of argument and result can be assumed to be size_t.
+// The value type of the result can be assumed to be size_t.
 TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("idxmax"), TAG_KERNELS, (DenseMatrix), (VALUE_TYPES)) {
     using DTArg = TestType;
     using DTRes = DenseMatrix<size_t>;

--- a/test/runtime/local/kernels/AggRowTest.cpp
+++ b/test/runtime/local/kernels/AggRowTest.cpp
@@ -136,7 +136,7 @@ TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("max"), TAG_KERNELS, (DATA_TYPES), (VALUE_T
 
 TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("idxmin"), TAG_KERNELS, (DenseMatrix), (VALUE_TYPES)) {
     using DTArg = TestType;
-    using DTRes = DenseMatrix<typename DTArg::VT>;
+    using DTRes = DenseMatrix<size_t>;
     
     auto m0 = genGivenVals<DTArg>(3, {
         0, 0, 0, 0,
@@ -166,7 +166,7 @@ TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("idxmin"), TAG_KERNELS, (DenseMatrix), (VAL
 
 TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("idxmax"), TAG_KERNELS, (DenseMatrix), (VALUE_TYPES)) {
     using DTArg = TestType;
-    using DTRes = DenseMatrix<typename DTArg::VT>;
+    using DTRes = DenseMatrix<size_t>;
     
     auto m0 = genGivenVals<DTArg>(3, {
         0, 0, 0, 0,
@@ -195,42 +195,43 @@ TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("idxmax"), TAG_KERNELS, (DenseMatrix), (VAL
 }
 
 
-TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("mean"), TAG_KERNELS, (DATA_TYPES), (VALUE_TYPES)) {
-    using DTArg = TestType;
-    using DTRes = DenseMatrix<typename DTArg::VT>;
-    
-    auto m0 = genGivenVals<DTArg>(3, {
-        0, 0, 0, 0,
-        0, 0, 0, 0,
-        0, 0, 0, 0,
-    });
-    auto m0exp = genGivenVals<DTRes>(3, {0, 0, 0});
-    auto m1 = genGivenVals<DTArg>(3, {
-        5, 7, 3, 9,
-        2, 5, 0, 1,
-        7, 4, 5, 4,
-    });
-    auto m1exp = genGivenVals<DTRes>(3, {6, 2, 5});
-    auto m2 = genGivenVals<DTArg>(3, {
-        4, 0, 0, 8,
-        0, 4, 0, 0,
-        0, 0, 7, 0,
-    });
-    auto m2exp = genGivenVals<DTRes>(3, {3, 1, typename DTArg::VT(1.75)});
+#define MEAN_TEST_CASE(ResultType) TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("mean - result type: " #ResultType), TAG_KERNELS, (DATA_TYPES), (VALUE_TYPES)) { \
+    using DTArg = TestType; \
+    using DTRes = DenseMatrix<ResultType>; \
+     \
+    auto m0 = genGivenVals<DTArg>(3, { \
+        0, 0, 0, 0, \
+        0, 0, 0, 0, \
+        0, 0, 0, 0, \
+    }); \
+    auto m0exp = genGivenVals<DTRes>(3, {0, 0, 0}); \
+    auto m1 = genGivenVals<DTArg>(3, { \
+        5, 7, 3, 9, \
+        2, 5, 0, 1, \
+        7, 4, 5, 4, \
+    }); \
+    auto m1exp = genGivenVals<DTRes>(3, {6, 2, 5}); \
+    auto m2 = genGivenVals<DTArg>(3, { \
+        4, 0, 0, 8, \
+        0, 4, 0, 0, \
+        0, 0, 7, 0, \
+    }); \
+    auto m2exp = genGivenVals<DTRes>(3, {(ResultType)3, (ResultType)1, (ResultType)1.75}); \
+ \
+    auto m3 = genGivenVals<DTArg>(3, { \
+        5, 7, 1, 9, \
+        2, 5, 7, 1, \
+        7, 1, 5, 4, \
+    }); \
+    auto m3exp = genGivenVals<DTRes>(3, {(ResultType)5.5, (ResultType)3.75, (ResultType)4.25}); \
+     \
+    checkAggRow(AggOpCode::MEAN, m0, m0exp); \
+    checkAggRow(AggOpCode::MEAN, m1, m1exp); \
+    checkAggRow(AggOpCode::MEAN, m2, m2exp); \
+    checkAggRow(AggOpCode::MEAN, m3, m3exp); \
+     \
+    DataObjectFactory::destroy(m0, m0exp, m1, m1exp, m2, m2exp, m3, m3exp); \
+} \
 
-    // Test case integer matrix -> double results.
-    // Maybe move this to seperate TEST_CASE_TEMPLATE ?
-    auto m3 = genGivenVals<DTArg>(3, {
-        5, 7, 1, 9,
-        2, 5, 7, 1,
-        7, 1, 5, 4,
-    });
-    auto m3exp = genGivenVals<DenseMatrix<double>>(3, {5.5, 3.75, 4.25});
-    
-    checkAggRow(AggOpCode::MEAN, m0, m0exp);
-    checkAggRow(AggOpCode::MEAN, m1, m1exp);
-    checkAggRow(AggOpCode::MEAN, m2, m2exp);
-    checkAggRow(AggOpCode::MEAN, m3, m3exp);
-    
-    DataObjectFactory::destroy(m0, m0exp, m1, m1exp, m2, m2exp, m3, m3exp);
-}
+MEAN_TEST_CASE(int64_t);
+MEAN_TEST_CASE(double);


### PR DESCRIPTION
`AggAll.h`, `AggCol.h` and `AggRow.h` used to return the same value type as the argument. In case of some aggregations (i.e. mean, stddev) that did not make much sense for integer arguments where the result will probably be floating point value. With this PR:

- Extended these template kernels to support different return types
- Added some test cases.

Note that these kernels still support aggregation of type `DenseMatrix<int> -> int`, but we end up with losing precision (in case of `mean`). The floating-point result is **not rounded** to the closest integer, but it is **converted**. We can support rounding if we want to. But imo if the user needs that, then it makes more sense to me, to use a rounding function on the floating type result.

Closes #399.