### PR TITLE
[DAPHNE-#403]: CLI args for explaining/printing the IR at various points

### DIFF
--- a/src/api/cli/daphne.cpp
+++ b/src/api/cli/daphne.cpp
@@ -155,12 +155,14 @@ main(int argc, char** argv)
     llvm::cl::list<Explains> explainArgList(
         "explain", cat(daphneOptions),
         llvm::cl::desc("Available explainations:"),
-        llvm::cl::values(clEnumVal(kernels, "KERNELS"), clEnumVal(llvm, "LLVM"),
-                         clEnumVal(parsing, "PARSING"),
-                         clEnumVal(property_inference, "PROPERT INFERENCE"),
-                         clEnumVal(sql, "SQL"),
-                         clEnumVal(vectorized, "VECTORIZED"),
-                         clEnumVal(obj_ref_mgnt, "OBJ REF MGNT")),
+        llvm::cl::values(
+            clEnumVal(kernels, "Show DaphneIR after kernel lowering"),
+            clEnumVal(llvm, "Show DaphneIR after llvm lowering"),
+            clEnumVal(parsing, "Show DaphneIR after parsing"),
+            clEnumVal(property_inference, "Show DaphneIR after property inference"),
+            clEnumVal(sql, "Show DaphneIR after SQL parsing"),
+            clEnumVal(vectorized, "Show DaphneIR after vectorization"),
+            clEnumVal(obj_ref_mgnt, "Show DaphneIR after managing object references")),
         CommaSeparated);
 
     llvm::cl::list<string> scriptArgs1(

--- a/src/api/cli/daphne.cpp
+++ b/src/api/cli/daphne.cpp
@@ -142,7 +142,7 @@ main(int argc, char** argv)
             desc("The directory containing kernel libraries")
     );
 
-    enum Explains {
+    enum ExplainArgs {
       kernels,
       llvm,
       parsing,
@@ -152,7 +152,7 @@ main(int argc, char** argv)
       obj_ref_mgnt
     };
 
-    llvm::cl::list<Explains> explainArgList(
+    llvm::cl::list<ExplainArgs> explainArgList(
         "explain", cat(daphneOptions),
         llvm::cl::desc("Available explainations:"),
         llvm::cl::values(


### PR DESCRIPTION
Implements simple mapping from CLI arguments to [DaphneUserConfig](https://github.com/daphne-eu/daphne/blob/main/src/api/cli/DaphneUserConfig.h)s various `explain_...` members using a `llvm::cl::list`.

- adds the `ExplainArgs` enum containing all the available `--explain` arguments