### PR TITLE
[DAPHNE-#389] order-kernel: return indexes instead of ordered data object

### DIFF
--- a/src/ir/daphneir/DaphneInferShapeOpInterface.cpp
+++ b/src/ir/daphneir/DaphneInferShapeOpInterface.cpp
@@ -225,6 +225,27 @@ std::vector<std::pair<ssize_t, ssize_t>> daphne::ReadOp::inferShape() {
     return {{fmd.numRows, fmd.numCols}};
 }
 
+std::vector<std::pair<ssize_t, ssize_t>> daphne::OrderOp::inferShape() {
+    size_t numRows = -1;
+    size_t numCols = -1;
+    bool idxs = false;
+
+    Type t = arg().getType();
+    if(auto mt = t.dyn_cast<daphne::MatrixType>()){
+        numRows = mt.getNumRows();
+        numCols = mt.getNumCols();
+    }
+    if(auto ft = t.dyn_cast<daphne::FrameType>()){
+        numRows = ft.getNumRows();
+        numCols = ft.getNumCols();
+    }
+    if(auto co = returnIdxs().getDefiningOp<mlir::daphne::ConstantOp>()) 
+        idxs = co.value().dyn_cast<mlir::BoolAttr>().getValue();
+    if (idxs)
+        numCols = 1;
+    return {{numRows, numCols}};
+}
+
 // ****************************************************************************
 // Shape inference trait implementations
 // ****************************************************************************

--- a/src/ir/daphneir/DaphneOps.td
+++ b/src/ir/daphneir/DaphneOps.td
@@ -561,7 +561,7 @@ def Daphne_ReverseOp : Daphne_Op<"reverse", [
 
 def Daphne_OrderOp : Daphne_Op<"order", [
     SameVariadicOperandSize,
-    ShapeFromArg
+    DeclareOpInterfaceMethods<InferShapeOpInterface>
 ]> {
     // TODO Maybe colIdxs and ascs should be attributes.
     let arguments = (ins MatrixOrFrame:$arg, Variadic<Size>:$colIdxs, Variadic<BoolScalar>:$ascs, BoolScalar:$returnIdxs);

--- a/src/parser/daphnedsl/DaphneDSLBuiltins.cpp
+++ b/src/parser/daphnedsl/DaphneDSLBuiltins.cpp
@@ -633,8 +633,17 @@ antlrcpp::Any DaphneDSLBuiltins::build(mlir::Location loc, const std::string & f
             colIdxs.push_back(utils.castSizeIf(args[1 + i]));
             ascs.push_back(utils.castBoolIf(args[1 + numCols + i]));
         }
+        mlir::Type retTy;
+        if(auto co = returnIdxs.getDefiningOp<ConstantOp>()) {
+            if(co.value().dyn_cast<mlir::BoolAttr>().getValue())
+                retTy = utils.matrixOfSizeType;
+            else
+                retTy = args[0].getType();
+        }
+        else
+            retTy = utils.unknownType;
         return static_cast<mlir::Value>(builder.create<OrderOp>(
-                loc, args[0].getType(), arg, colIdxs, ascs, returnIdxs
+                loc, retTy, arg, colIdxs, ascs, returnIdxs
         ));
     }
 

--- a/src/runtime/local/kernels/Order.h
+++ b/src/runtime/local/kernels/Order.h
@@ -34,9 +34,9 @@
 // Struct for partial template specialization
 // ****************************************************************************
 
-template<class DT>
+template<class DTRes, class DTArg>
 struct Order {
-    static void apply(DT *& res, const DT * arg, size_t * colIdxs, size_t numColIdxs, bool * ascending, size_t numAscending, bool returnIdx, DCTX(ctx), std::vector<std::pair<size_t, size_t>> * groupsRes = nullptr) = delete;
+    static void apply(DTRes *& res, const DTArg * arg, size_t * colIdxs, size_t numColIdxs, bool * ascending, size_t numAscending, bool returnIdx, DCTX(ctx), std::vector<std::pair<size_t, size_t>> * groupsRes = nullptr) = delete;
 };
 
 // ****************************************************************************
@@ -46,13 +46,13 @@ struct Order {
 // Note that we normally don't pass any arguments after the DaphneContext. In
 // this case it is only okay because groupsRes has a default and is meant to be
 // used only by other kernels, not from DaphneDSL.
-template<class DT>
-void order(DT *& res, const DT * arg, size_t * colIdxs, size_t numColIdxs, bool * ascending, size_t numAscending, bool returnIdx, DCTX(ctx), std::vector<std::pair<size_t, size_t>> * groupsRes = nullptr) {
-    Order<DT>::apply(res, arg, colIdxs, numColIdxs, ascending, numAscending, returnIdx, ctx, groupsRes);
+template<class DTRes, class DTArg>
+void order(DTRes *& res, const DTArg * arg, size_t * colIdxs, size_t numColIdxs, bool * ascending, size_t numAscending, bool returnIdx, DCTX(ctx), std::vector<std::pair<size_t, size_t>> * groupsRes = nullptr) {
+    Order<DTRes,DTArg>::apply(res, arg, colIdxs, numColIdxs, ascending, numAscending, returnIdx, ctx, groupsRes);
 }
 
 // ****************************************************************************
-// Functions called by mulriple template specializations
+// Functions called by multiple template specializations
 // ****************************************************************************
 
 // sorts input idx DenseMatrix within the index ranges in the input groups vector on the values of the input column (column with id colIdx in DenseMatrix arg; id 0 for column matrices)
@@ -113,7 +113,7 @@ void multiColumnIDSort(DenseMatrix<VTIdx> *&idx, const DenseMatrix<VT>* col, siz
 }
 
 // ----------------------------------------------------------------------------
-// Frame <- Frame
+//  Frame order structs
 // ----------------------------------------------------------------------------
 
 template<typename VTCol>
@@ -132,14 +132,10 @@ struct MultiColumnIDSort {
     }
 };
 
-template <> struct Order<Frame> {
-    static void apply(Frame *& res, const Frame * arg, size_t * colIdxs, size_t numColIdxs, bool * ascending, size_t numAscending, bool returnIdx, DCTX(ctx), std::vector<std::pair<size_t, size_t>> * groupsRes = nullptr) {
+struct OrderFrame {
+    static void apply(DenseMatrix<size_t> *& idx, const Frame * arg, size_t * colIdxs, size_t numColIdxs, bool * ascending, size_t numAscending, std::vector<std::pair<size_t, size_t>> * groupsRes, DCTX(ctx)) {
         size_t numRows = arg->getNumRows();
-        if (arg == nullptr || colIdxs == nullptr || numColIdxs == 0 || ascending == nullptr) {
-            throw std::runtime_error("order-kernel called with invalid arguments");
-        }
-        
-        auto idx = DataObjectFactory::create<DenseMatrix<size_t>>(numRows, 1, false);
+        idx = DataObjectFactory::create<DenseMatrix<size_t>>(numRows, 1, false);
         auto indicies = idx->getValues();
         std::iota(indicies, indicies+numRows, 0);
         
@@ -151,7 +147,7 @@ template <> struct Order<Frame> {
                 DeduceValueTypeAndExecute<MultiColumnIDSort>::apply(arg->getSchema()[colIdxs[i]], arg, idx, groups, ascending[i], colIdxs[i], ctx);
             }
         }
-    
+
         // efficient last sort pass OR finalizing the groups vector for further use
         size_t colIdx = colIdxs[numColIdxs-1];
         if (groupsRes == nullptr) {
@@ -163,21 +159,49 @@ template <> struct Order<Frame> {
             }
             groupsRes->insert(groupsRes->end(), groups.begin(), groups.end());
         }
+    }
+};
 
-        //applying the final object ID permutation (result of the sorting procedure) to the frame via a row extraction
+// ----------------------------------------------------------------------------
+// Frame <- Frame 
+// ----------------------------------------------------------------------------
+template <> struct Order<Frame, Frame> {
+    static void apply(Frame *& res, const Frame * arg, size_t * colIdxs, size_t numColIdxs, bool * ascending, size_t numAscending, bool returnIdx, DCTX(ctx), std::vector<std::pair<size_t, size_t>> * groupsRes = nullptr) {
+        if (arg == nullptr || colIdxs == nullptr || numColIdxs == 0 || ascending == nullptr || returnIdx) {
+            throw std::runtime_error("order-kernel called with invalid arguments");
+        }
+        DenseMatrix<size_t>* idx = nullptr;
+        OrderFrame::apply(idx, arg, colIdxs, numColIdxs, ascending, numAscending, groupsRes, ctx);
         extractRow(res, arg, idx, ctx);
         DataObjectFactory::destroy(idx);
     }
 };
 
 // ----------------------------------------------------------------------------
+// DenseMatrix <- Frame 
+// ----------------------------------------------------------------------------
+template <typename VTRes> struct Order<DenseMatrix<VTRes>, Frame> {
+    static void apply(DenseMatrix<VTRes> *& res, const Frame * arg, size_t * colIdxs, size_t numColIdxs, bool * ascending, size_t numAscending, bool returnIdx, DCTX(ctx), std::vector<std::pair<size_t, size_t>> * groupsRes = nullptr) {
+        if (arg == nullptr || colIdxs == nullptr || numColIdxs == 0 || ascending == nullptr || !returnIdx) {
+            throw std::runtime_error("order-kernel called with invalid arguments");
+        }
+        DenseMatrix<size_t>* idx = nullptr;
+        OrderFrame::apply(idx, arg, colIdxs, numColIdxs, ascending, numAscending, groupsRes, ctx);
+        res = idx;
+    }
+};  
+
+// ----------------------------------------------------------------------------
 // DenseMatrix <- DenseMatrix 
 // ----------------------------------------------------------------------------
-template <typename VT>
-struct Order<DenseMatrix<VT>> {
-    static void apply(DenseMatrix<VT> *& res, const DenseMatrix<VT> * arg, size_t * colIdxs, size_t numColIdxs, bool * ascending, size_t numAscending, bool returnIdx, DCTX(ctx), std::vector<std::pair<size_t, size_t>> * groupsRes = nullptr) {
+template <typename VTRes, typename VTArg>
+struct Order<DenseMatrix<VTRes>, DenseMatrix<VTArg>> {
+    static void apply(DenseMatrix<VTRes> *& res, const DenseMatrix<VTArg> * arg, size_t * colIdxs, size_t numColIdxs, bool * ascending, size_t numAscending, bool returnIdx, DCTX(ctx), std::vector<std::pair<size_t, size_t>> * groupsRes = nullptr) {
         size_t numRows = arg->getNumRows();
-        if (arg == nullptr || colIdxs == nullptr || numColIdxs == 0 || ascending == nullptr) {
+        if (arg == nullptr || colIdxs == nullptr || numColIdxs == 0 || ascending == nullptr ||
+            (returnIdx == false && !std::is_same<VTRes, VTArg>::value) || 
+            (returnIdx == true && !std::is_same<VTRes, size_t>::value)
+        ) {
             throw std::runtime_error("order-kernel called with invalid arguments");
         }
 
@@ -203,7 +227,12 @@ struct Order<DenseMatrix<VT>> {
             groupsRes->insert(groupsRes->end(), groups.begin(), groups.end());
         }
 
-        extractRow<DenseMatrix<VT>, DenseMatrix<VT>, size_t>(res, arg, idx, ctx);
-        DataObjectFactory::destroy(idx);
+        if (returnIdx)
+        {
+           res = (DenseMatrix<VTRes>*) idx;
+        } else {
+            extractRow<DenseMatrix<VTArg>, DenseMatrix<VTArg>, size_t>((DenseMatrix<VTArg>*&) res, arg, idx, ctx);
+            DataObjectFactory::destroy(idx);
+        }
     }
 };

--- a/src/runtime/local/kernels/Order.h
+++ b/src/runtime/local/kernels/Order.h
@@ -73,7 +73,7 @@ void columnIDSort(DenseMatrix<VTIdx> *&idx, const DenseMatrix<VT>* arg, size_t c
 
 template<typename VT>
 VT* nextWithRowskip(VT*& first, VT*& last, const size_t rowSkip) {
-    for (VT* next = first; first != last; next+=rowSkip) {
+    for (VT* next = first; next != last; next+=rowSkip) {
         if (*next != *first)
             return next;
     }
@@ -151,7 +151,7 @@ template <> struct Order<Frame> {
                 DeduceValueTypeAndExecute<MultiColumnIDSort>::apply(arg->getSchema()[colIdxs[i]], arg, idx, groups, ascending[i], colIdxs[i], ctx);
             }
         }
-
+    
         // efficient last sort pass OR finalizing the groups vector for further use
         size_t colIdx = colIdxs[numColIdxs-1];
         if (groupsRes == nullptr) {

--- a/src/runtime/local/kernels/Order.h
+++ b/src/runtime/local/kernels/Order.h
@@ -23,6 +23,7 @@
 #include <runtime/local/datastructures/ValueTypeCode.h>
 #include <runtime/local/datastructures/ValueTypeUtils.h>
 #include <runtime/local/kernels/ExtractRow.h>
+#include <util/DeduceType.h>
 
 #include <algorithm>
 #include <functional>
@@ -35,7 +36,7 @@
 
 template<class DT>
 struct Order {
-    static void apply(DT *& res, const DT * arg, size_t * colIdxs, size_t numColIdxs, bool * ascending, size_t numAscending, bool returnIdx, DCTX(ctx)) = delete;
+    static void apply(DT *& res, const DT * arg, size_t * colIdxs, size_t numColIdxs, bool * ascending, size_t numAscending, bool returnIdx, DCTX(ctx), std::vector<std::pair<size_t, size_t>> * groupsRes = nullptr) = delete;
 };
 
 // ****************************************************************************
@@ -43,109 +44,167 @@ struct Order {
 // ****************************************************************************
 
 template<class DT>
-void order(DT *& res, const DT * arg, size_t * colIdxs, size_t numColIdxs, bool * ascending, size_t numAscending, bool returnIdx, DCTX(ctx)) {
-    Order<DT>::apply(res, arg, colIdxs, numColIdxs, ascending, numAscending, returnIdx, ctx);
+void order(DT *& res, const DT * arg, size_t * colIdxs, size_t numColIdxs, bool * ascending, size_t numAscending, bool returnIdx, DCTX(ctx), std::vector<std::pair<size_t, size_t>> * groupsRes = nullptr) {
+    Order<DT>::apply(res, arg, colIdxs, numColIdxs, ascending, numAscending, returnIdx, ctx, groupsRes);
 }
 
 // ****************************************************************************
-// (Partial) template specializations for different data/value types
+// Functions called by mulriple template specializations
 // ****************************************************************************
 
-// ----------------------------------------------------------------------------
-// Frame <- Frame
-// ----------------------------------------------------------------------------
+// sorts input idx DenseMatrix within the index ranges in the input groups vector on the values of the input column (column with id colIdx in DenseMatrix arg; id 0 for column matrices)
+template<typename VTIdx, typename VT>
+void columnIDSort(DenseMatrix<VTIdx> *&idx, const DenseMatrix<VT>* arg, size_t colIdx, std::vector<std::pair<VTIdx, VTIdx>> &groups, bool ascending, DCTX(ctx)) {
+    VTIdx * indicies = idx->getValues();
+    const VT * values = arg->getValues();
+    const size_t rowSkip = arg->getRowSkip();
+    auto compare = ascending ?
+        std::function{[&values, rowSkip, colIdx](VTIdx i, VTIdx j) {
+            return values[i * rowSkip + colIdx] < values[j * rowSkip + colIdx];
+        }} :
+        std::function{[&values, rowSkip, colIdx](VTIdx i, VTIdx j) {
+            return values[i * rowSkip + colIdx] > values[j * rowSkip + colIdx];}};
+    for (const auto &group : groups)
+        std::stable_sort(indicies+group.first, indicies+group.second, compare);
+}
+
+template<typename VT>
+VT* nextWithRowskip(VT*& first, VT*& last, const size_t rowSkip) {
+    for (VT* next = first; first != last; next+=rowSkip) {
+        if (*next != *first)
+            return next;
+    }
+    return last;
+}
 
 // scans a column for groups of duplicates (stored as VTIdx pairs forming index ranges)
 // performed only within the index ranges in the input groups vector on the values of the input column (DenseMatrix)
 // replaces the groups in the input vector with the groups found during the scan
 template<typename VTIdx, typename VT>
-void columnGroupScan(std::vector<std::pair<VTIdx, VTIdx>> &groups, DenseMatrix<VT>* col, DCTX(ctx)) {
+void columnGroupScan(std::vector<std::pair<VTIdx, VTIdx>> &groups, DenseMatrix<VT>* col, size_t colIdx, DCTX(ctx)) {
     const size_t numOldGroups = groups.size();
-    const VT * values = col->getValues();
+    VT * values = col->getValues();
+    const size_t rowSkip = col->getRowSkip();
     for (size_t g = 0; g < numOldGroups; g++) {
-        auto first = values + groups[g].first;
-        const auto last = values + groups[g].second;
+        VT * first = values + groups[g].first * rowSkip + colIdx;
+        VT * last = values + groups[g].second * rowSkip + colIdx;
         while (first != last) {
-            const auto next{std::find_if(first + 1, last, [&](const VT& t) {return t != *first;})};
-            if (next - first > 1) {
-                groups.push_back(std::make_pair(first-values, next-values));
-            }
-            first = next;
+            VT * next = nextWithRowskip<VT>(first, last, rowSkip);
+            if ((size_t) (next - first) > rowSkip)
+                groups.push_back(std::make_pair((first-values-colIdx)/rowSkip, (next-values-colIdx)/rowSkip));
+            first = next;   
         }
     }
     groups.erase(groups.begin(),groups.begin()+numOldGroups);
 }
 
-// sorts input idx DenseMatrix within the index ranges in the input groups vector on the values of the input column (DenseMatrix)
-template<typename VTIdx, typename VT>
-void columnIDSort(DenseMatrix<VTIdx> *&idx, const DenseMatrix<VT>* col, std::vector<std::pair<VTIdx, VTIdx>> &groups, bool ascending, DCTX(ctx)) {
-    VTIdx * indicies = idx->getValues();
-    const VT * values = col->getValues();
-    auto compare = ascending ? std::function{[&values](VTIdx i, VTIdx j) {return values[i] < values[j];}}
-                             : std::function{[&values](VTIdx i, VTIdx j) {return values[i] > values[j];}};
-    for (const auto &group : groups)
-        std::stable_sort(indicies+group.first, indicies+group.second, compare);
-}
-
 // sorts IDs inside groups by the key column, reorder the column via a row extraction into a temporary 
 // DenseMatrix and then scan for groups of duplicates to be tie broken by another subsequent key column
 template<typename VTIdx, typename VT>
-void multiColumnIDSort(DenseMatrix<VTIdx> *&idx, const DenseMatrix<VT>* col, std::vector<std::pair<VTIdx, VTIdx>> &groups, bool ascending, DCTX(ctx)){
-    columnIDSort(idx, col, groups, ascending, ctx);
+void multiColumnIDSort(DenseMatrix<VTIdx> *&idx, const DenseMatrix<VT>* col, size_t colIdx, std::vector<std::pair<VTIdx, VTIdx>> &groups, bool ascending, DCTX(ctx)){
+    columnIDSort(idx, col, colIdx, groups, ascending, ctx);
     DenseMatrix<VT> * tmp = nullptr;
     extractRow<DenseMatrix<VT>, DenseMatrix<VT>, VTIdx>(tmp, col, idx, ctx);
-    columnGroupScan(groups, tmp, ctx);
+    columnGroupScan(groups, tmp, colIdx, ctx);
     DataObjectFactory::destroy(tmp);
-} 
+}
+
+// ----------------------------------------------------------------------------
+// Frame <- Frame
+// ----------------------------------------------------------------------------
+
+template<typename VTCol>
+struct ColumnIDSort {
+    static void apply(const Frame * arg, DenseMatrix<size_t> *&idx, std::vector<std::pair<size_t, size_t>> &groups, bool ascending, size_t colIdx, DCTX(ctx)) {
+        columnIDSort(idx, arg->getColumn<VTCol>(colIdx), 0, groups, ascending, ctx);
+    }
+};
+
+// sorts IDs inside groups by the key column, reorder the column via a row extraction into a temporary 
+// DenseMatrix and then scan for groups of duplicates to be tie broken by another subsequent key column
+template<typename VTCol>
+struct MultiColumnIDSort {
+    static void apply(const Frame * arg, DenseMatrix<size_t> *&idx, std::vector<std::pair<size_t, size_t>> &groups, bool ascending, size_t colIdx, DCTX(ctx)) {
+        multiColumnIDSort(idx, arg->getColumn<VTCol>(colIdx), 0, groups, ascending, ctx);
+    }
+};
+
+// ----------------------------------------------------------------------------
+// Frame <- Frame
+// ----------------------------------------------------------------------------
 
 template <> struct Order<Frame> {
-    static void apply(Frame *& res, const Frame * arg, size_t * colIdxs, size_t numColIdxs, bool * ascending, size_t numAscending, bool returnIdx, DCTX(ctx)) {
+    static void apply(Frame *& res, const Frame * arg, size_t * colIdxs, size_t numColIdxs, bool * ascending, size_t numAscending, bool returnIdx, DCTX(ctx), std::vector<std::pair<size_t, size_t>> * groupsRes = nullptr) {
+        size_t numRows = arg->getNumRows();
+        if (arg == nullptr || colIdxs == nullptr || numColIdxs == 0 || ascending == nullptr) {
+            throw std::runtime_error("order-kernel called with invalid arguments");
+        }
+        
+        auto idx = DataObjectFactory::create<DenseMatrix<size_t>>(numRows, 1, false);
+        auto indicies = idx->getValues();
+        std::iota(indicies, indicies+numRows, 0);
+        
+        std::vector<std::pair<size_t, size_t>> groups;
+        groups.push_back(std::make_pair(0, numRows));
+            
+        if (numColIdxs > 1) {
+            for (size_t i = 0; i < numColIdxs-1; i++) {
+                DeduceValueTypeAndExecute<MultiColumnIDSort>::apply(arg->getSchema()[colIdxs[i]], arg, idx, groups, ascending[i], colIdxs[i], ctx);
+            }
+        }
+
+        // efficient last sort pass OR finalizing the groups vector for further use
+        size_t colIdx = colIdxs[numColIdxs-1];
+        if (groupsRes == nullptr) {
+            DeduceValueTypeAndExecute<ColumnIDSort>::apply(arg->getSchema()[colIdx], arg, idx, groups, ascending[numColIdxs-1], colIdx, ctx);
+        } else {
+            DeduceValueTypeAndExecute<MultiColumnIDSort>::apply(arg->getSchema()[colIdx], arg, idx, groups, ascending[numColIdxs-1], colIdx, ctx);
+            if (groups.front().first == 0 && groups.front().second == numRows) {
+                groups.clear();
+            }
+            groupsRes->insert(groupsRes->end(), groups.begin(), groups.end());
+        }
+
+        //applying the final object ID permutation (result of the sorting procedure) to the frame via a row extraction
+        extractRow(res, arg, idx, ctx);
+        DataObjectFactory::destroy(idx);
+    }
+};
+
+// ----------------------------------------------------------------------------
+// DenseMatrix <- DenseMatrix 
+// ----------------------------------------------------------------------------
+template <typename VT>
+struct Order<DenseMatrix<VT>> {
+    static void apply(DenseMatrix<VT> *& res, const DenseMatrix<VT> * arg, size_t * colIdxs, size_t numColIdxs, bool * ascending, size_t numAscending, bool returnIdx, DCTX(ctx), std::vector<std::pair<size_t, size_t>> * groupsRes = nullptr) {
         size_t numRows = arg->getNumRows();
         if (arg == nullptr || colIdxs == nullptr || numColIdxs == 0 || ascending == nullptr) {
             throw std::runtime_error("order-kernel called with invalid arguments");
         }
 
-        size_t colIdx;
         auto idx = DataObjectFactory::create<DenseMatrix<size_t>>(numRows, 1, false);
         auto indicies = idx->getValues();
         std::iota(indicies, indicies+numRows, 0);
         std::vector<std::pair<size_t, size_t>> groups;
         groups.push_back(std::make_pair(0, numRows));
-        
+
         if (numColIdxs > 1) {
             for (size_t i = 0; i < numColIdxs-1; i++) {
-                colIdx = colIdxs[i];
-                switch(arg->getColumnType(colIdx)) {
-                    // TODO Memory leak (getColumn(), see #222).
-                    case ValueTypeCode::F64: multiColumnIDSort(idx, arg->getColumn<double>(colIdx), groups, ascending[i], ctx); break;
-                    case ValueTypeCode::F32: multiColumnIDSort(idx, arg->getColumn<float>(colIdx), groups, ascending[i], ctx); break;
-                    case ValueTypeCode::SI64: multiColumnIDSort(idx, arg->getColumn<int64_t>(colIdx), groups, ascending[i], ctx); break;
-                    case ValueTypeCode::SI32: multiColumnIDSort(idx, arg->getColumn<int32_t>(colIdx), groups, ascending[i], ctx); break;
-                    case ValueTypeCode::SI8 : multiColumnIDSort(idx, arg->getColumn<int8_t>(colIdx), groups, ascending[i], ctx); break;
-                    case ValueTypeCode::UI64: multiColumnIDSort(idx, arg->getColumn<uint64_t>(colIdx), groups, ascending[i], ctx); break;
-                    case ValueTypeCode::UI32: multiColumnIDSort(idx, arg->getColumn<uint32_t>(colIdx), groups, ascending[i], ctx); break;
-                    case ValueTypeCode::UI8 : multiColumnIDSort(idx, arg->getColumn<uint8_t>(colIdx), groups, ascending[i], ctx); break;
-                    default: throw std::runtime_error("unknown value type code");
-                }
+                multiColumnIDSort(idx, arg, colIdxs[i], groups, ascending[i], ctx);
             }
         }
 
-        colIdx = colIdxs[numColIdxs-1];
-        switch(arg->getColumnType(colIdx)) {
-            // TODO Memory leak (getColumn(), see #222).
-            case ValueTypeCode::F64: columnIDSort(idx, arg->getColumn<double>(colIdx), groups, ascending[numColIdxs-1], ctx); break;
-            case ValueTypeCode::F32: columnIDSort(idx, arg->getColumn<float>(colIdx), groups, ascending[numColIdxs-1], ctx); break;
-            case ValueTypeCode::SI64: columnIDSort(idx, arg->getColumn<int64_t>(colIdx), groups, ascending[numColIdxs-1], ctx); break;
-            case ValueTypeCode::SI32: columnIDSort(idx, arg->getColumn<int32_t>(colIdx), groups, ascending[numColIdxs-1], ctx); break; 
-            case ValueTypeCode::SI8 : columnIDSort(idx, arg->getColumn<int8_t>(colIdx), groups, ascending[numColIdxs-1], ctx); break; 
-            case ValueTypeCode::UI64: columnIDSort(idx, arg->getColumn<uint64_t>(colIdx), groups, ascending[numColIdxs-1], ctx); break;
-            case ValueTypeCode::UI32: columnIDSort(idx, arg->getColumn<uint32_t>(colIdx), groups, ascending[numColIdxs-1], ctx); break;
-            case ValueTypeCode::UI8 : columnIDSort(idx, arg->getColumn<uint8_t>(colIdx), groups, ascending[numColIdxs-1], ctx); break;
-            default: throw std::runtime_error("unknown value type code");
+        if (groupsRes == nullptr) {
+            columnIDSort(idx, arg, colIdxs[numColIdxs-1], groups, ascending[numColIdxs-1], ctx);
+        } else {
+            multiColumnIDSort(idx, arg, colIdxs[numColIdxs-1], groups, ascending[numColIdxs-1], ctx);
+            if (groups.front().first == 0 && groups.front().second == numRows) {
+                groups.clear();
+            }
+            groupsRes->insert(groupsRes->end(), groups.begin(), groups.end());
         }
 
-        //applying the final object ID permutation (result of the sorting procedure) to the frame via a row extraction
-        extractRow<Frame, Frame, size_t>(res, arg, idx, ctx);
+        extractRow<DenseMatrix<VT>, DenseMatrix<VT>, size_t>(res, arg, idx, ctx);
         DataObjectFactory::destroy(idx);
     }
 };

--- a/src/runtime/local/kernels/kernels.json
+++ b/src/runtime/local/kernels/kernels.json
@@ -1180,6 +1180,7 @@
             [["DenseMatrix", "int64_t"]],
             [["DenseMatrix", "uint8_t"]],
             [["DenseMatrix", "bool"]],
+            [["DenseMatrix", "size_t"]],
             [["CSRMatrix", "double"]],
             [["CSRMatrix", "float"]],
             [["CSRMatrix", "int64_t"]],
@@ -2778,17 +2779,21 @@
             "returnType": "void",
             "templateParams": [
                 {
-                    "name": "DT",
+                    "name": "DTRes",
+                    "isDataType": true
+                },
+                {
+                    "name": "DTArg",
                     "isDataType": true
                 }
             ],
             "runtimeParams": [
                 {
-                    "type": "DT *&",
+                    "type": "DTRes *&",
                     "name": "res"
                 },
                 {
-                    "type": "const DT *",
+                    "type": "const DTArg *",
                     "name": "arg"
                 },
                 {
@@ -2816,10 +2821,14 @@
             ]
         },
         "instantiations": [
-            ["Frame"],
-            [["DenseMatrix", "double"]],
-            [["DenseMatrix", "float"]],
-            [["DenseMatrix", "int64_t"]]
+            ["Frame", "Frame"],
+            [["DenseMatrix", "size_t"], "Frame"],
+            [["DenseMatrix", "double"], ["DenseMatrix", "double"]],
+            [["DenseMatrix", "size_t"], ["DenseMatrix", "double"]],
+            [["DenseMatrix", "float"], ["DenseMatrix", "float"]],
+            [["DenseMatrix", "size_t"], ["DenseMatrix", "float"]],
+            [["DenseMatrix", "int64_t"], ["DenseMatrix", "int64_t"]],
+            [["DenseMatrix", "size_t"], ["DenseMatrix", "int64_t"]]
         ]
     },
     {

--- a/test/runtime/local/kernels/OrderTest.cpp
+++ b/test/runtime/local/kernels/OrderTest.cpp
@@ -30,7 +30,7 @@ TEMPLATE_TEST_CASE("Order", TAG_KERNELS, (Frame)) {
     using VT0 = double;
     using VT1 = float;
     using VT2 = int64_t;
-    using VT3 = uint32_t;
+    using VT3 = size_t;
 
     size_t numRows = 20;
 
@@ -39,13 +39,14 @@ TEMPLATE_TEST_CASE("Order", TAG_KERNELS, (Frame)) {
     auto c1 = genGivenVals<DenseMatrix<VT1>>(numRows, { 1.1, -2, 4.4, 2.1, 1.1, 2.3, 0.5, 4.4, -10, 0, 2.1,
                                                         10, 10, 4.4, -0.3, -15.5, 10, -2.3, 10, -1.1 });
     auto c2 = genGivenVals<DenseMatrix<VT2>>(numRows, { 0, 0, 1, 1, 0, 0, 0, 3, 0, 0, 2, 1, 2, 3, 0, 0, 3, 0, 3, 0 });
-    auto c3 = genGivenVals<DenseMatrix<VT3>>(numRows, { 6, 3, 9, 1, 13, 7, 5, 10, 15, 16, 2, 17, 18, 11, 4, 12, 19, 8, 20, 14 });
+    auto c3 = genGivenVals<DenseMatrix<VT3>>(numRows, { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20 });
     
     std::vector<Structure *> colsArg = {c0, c1, c2, c3};
     auto arg = DataObjectFactory::create<Frame>(colsArg, nullptr);
     DataObjectFactory::destroy(c0, c1, c1, c2);
     Frame* exp{};
     Frame* res{};
+    DenseMatrix<size_t>* resIdxs  = nullptr;
     size_t numKeyCols;
     size_t colIdxs[4];
     bool ascending[4];
@@ -60,21 +61,22 @@ TEMPLATE_TEST_CASE("Order", TAG_KERNELS, (Frame)) {
         c1Exp = genGivenVals<DenseMatrix<VT1>>(numRows, { 2.1, 2.1, -2, -0.3, 0.5, 1.1, 2.3, -2.3, 4.4, 4.4,
                                                                4.4, -15.5, 1.1, -1.1, -10, 0, 10, 10, 10, 10 });
         c2Exp = genGivenVals<DenseMatrix<VT2>>(numRows, { 1, 2, 0, 0, 0, 0, 0, 0, 1, 3, 3, 0, 0, 0, 0, 0, 1, 2, 3, 3 });
-        c3Exp = genGivenVals<DenseMatrix<VT3>>(numRows, { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20 });
+        c3Exp = genGivenVals<DenseMatrix<VT3>>(numRows, { 3, 10, 1, 14, 6, 0, 5, 17, 2, 7, 13, 15, 4, 19, 8, 9 , 11, 12, 16, 18 });
         numKeyCols = 1;
         colIdxs[0] = 0;
         ascending[0] = true;
     }
     SECTION("single key column, descending") {
         c0Exp = genGivenVals<DenseMatrix<VT0>>(numRows, { 6.6, 6.6, 6.6, 6.6, 4.4, 4.4, 4.4, 2.3, -8.8, -8.8, 
-                                                               1.1, 5.6, 0.3, 6.6,-0.3, 5.6, -3.1, 2.3, 6.6, 4.4 });
+                                                               1.1, 5.6, 0.3, 6.6, -0.3, 5.6, -3.1, 2.3, 6.6, 4.4 });
         c1Exp = genGivenVals<DenseMatrix<VT1>>(numRows, { 10, 10, 10, 10, 4.4, 4.4, 4.4, 2.3, 2.1, 2.1, 1.1,
                                                                1.1, 0.5, 0, -0.3, -1.1, -2, -2.3, -10, -15.5 });
         c2Exp = genGivenVals<DenseMatrix<VT2>>(numRows, { 1, 2, 3, 3, 1, 3, 3, 0, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 });
-        c3Exp = genGivenVals<DenseMatrix<VT3>>(numRows, { 17, 18, 19, 20, 9, 10, 11, 7, 1, 2, 6, 13, 5, 16, 4, 14, 3, 8, 15, 12 });  
+        c3Exp = genGivenVals<DenseMatrix<VT3>>(numRows, { 11, 12, 16, 18, 2, 7, 13, 5, 3, 10, 0, 4, 6, 9, 14, 19, 1, 17, 8, 15 });
         numKeyCols = 1;
         colIdxs[0] = 1;
         ascending[0] = false;
+        
     }
     SECTION("two key columns, ascending/descending") {
         c0Exp = genGivenVals<DenseMatrix<VT0>>(numRows, { -8.8, -8.8, -3.1, -0.3, 0.3, 1.1, 2.3, 2.3, 4.4, 4.4,
@@ -82,7 +84,7 @@ TEMPLATE_TEST_CASE("Order", TAG_KERNELS, (Frame)) {
         c1Exp = genGivenVals<DenseMatrix<VT1>>(numRows, { 2.1, 2.1, -2, -0.3, 0.5, 1.1, 2.3, -2.3, 4.4, 4.4,
                                                                4.4, -15.5, 1.1, -1.1, 10, 10, 10, 10, -10, 0 });
         c2Exp = genGivenVals<DenseMatrix<VT2>>(numRows, { 2, 1, 0, 0, 0, 0, 0, 0, 3, 3, 1, 0, 0, 0, 3, 3, 2, 1, 0, 0 });
-        c3Exp = genGivenVals<DenseMatrix<VT3>>(numRows, { 2, 1, 3, 4, 5, 6, 7, 8, 10, 11, 9, 12, 13, 14, 19, 20, 18, 17, 15, 16 });
+        c3Exp = genGivenVals<DenseMatrix<VT3>>(numRows, { 10, 3, 1, 14, 6, 0, 5, 17, 7, 13, 2, 15, 4, 19, 16, 18, 12, 11, 8, 9 });
         numKeyCols = 2;
         colIdxs[0] = 0;
         ascending[0] = true;
@@ -95,7 +97,7 @@ TEMPLATE_TEST_CASE("Order", TAG_KERNELS, (Frame)) {
         c1Exp = genGivenVals<DenseMatrix<VT1>>(numRows, { -15.5, -10, -2.3, -2, -1.1, -0.3, 0, 0.5, 1.1, 1.1, 
                                                                 2.1, 2.1, 2.3, 4.4, 4.4, 4.4, 10, 10, 10, 10 });
         c2Exp = genGivenVals<DenseMatrix<VT2>>(numRows, {  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 1, 0, 3, 3, 1, 3, 3, 2, 1 });
-        c3Exp = genGivenVals<DenseMatrix<VT3>>(numRows, { 12, 15, 8, 3, 14, 4, 16, 5, 13, 6, 2, 1, 7, 10, 11, 9, 19, 20, 18, 17 });
+        c3Exp = genGivenVals<DenseMatrix<VT3>>(numRows, { 15, 8, 17, 1, 19, 14, 9, 6, 4, 0, 10, 3, 5, 7, 13, 2, 16, 18, 12, 11 });
         numKeyCols = 4;
         colIdxs[0] = 1;
         ascending[0] = true;
@@ -109,11 +111,15 @@ TEMPLATE_TEST_CASE("Order", TAG_KERNELS, (Frame)) {
 
     std::vector<Structure *> colsExp = {c0Exp, c1Exp, c2Exp, c3Exp};
     exp = DataObjectFactory::create<Frame>(colsExp, nullptr);
-    DataObjectFactory::destroy(c0Exp, c1Exp, c2Exp, c3Exp);
+    DataObjectFactory::destroy(c0Exp, c1Exp, c2Exp);
     
     order(res, arg, colIdxs, numKeyCols, ascending, numKeyCols, false, nullptr);
+    order(resIdxs, arg, colIdxs, numKeyCols, ascending, numKeyCols, true, nullptr);
+    
     CHECK(*res == *exp);
-        
+    CHECK(*resIdxs == *c3Exp);
+    DataObjectFactory::destroy(c3Exp);
+
     DataObjectFactory::destroy(arg);
     DataObjectFactory::destroy(exp);
     DataObjectFactory::destroy(res);
@@ -128,7 +134,8 @@ TEMPLATE_TEST_CASE("Order - DenseMatrix", TAG_KERNELS, double){ // NOLINT(cert-e
     DenseMatrix<VT>* argMatrix = nullptr;
     DenseMatrix<VT>* resMatrix = nullptr;
     DenseMatrix<VT>* expMatrix = nullptr;
-
+    DenseMatrix<size_t>* resIdxs = nullptr;
+    DenseMatrix<size_t>* expIdxs = nullptr;
 
     SECTION("single key column, ascending") {
         argMatrix = genGivenVals<DenseMatrix<VT>>(4, {
@@ -143,6 +150,7 @@ TEMPLATE_TEST_CASE("Order - DenseMatrix", TAG_KERNELS, double){ // NOLINT(cert-e
             17, 7, 2, 3, 7, 7,
             1, 10, 3, 7, 7, 7
         });
+        expIdxs = genGivenVals<DenseMatrix<size_t>>(4, { 3, 2, 1, 0});
         numKeyCols = 1;
         colIdxs[0] = 3;
         ascending[0] = true;
@@ -192,6 +200,8 @@ TEMPLATE_TEST_CASE("Order - DenseMatrix", TAG_KERNELS, double){ // NOLINT(cert-e
             6.6, 10, 2, 18,
             6.6, 10, 1, 17
         });
+        expIdxs = genGivenVals<DenseMatrix<size_t>>(20, { 15, 8, 17, 1, 19, 14, 9, 6, 4, 0,
+                                                          10, 3, 5, 7, 13, 2, 16, 18, 12, 11 });
         numKeyCols = 4;
         colIdxs[0] = 1;
         ascending[0] = true;
@@ -200,13 +210,18 @@ TEMPLATE_TEST_CASE("Order - DenseMatrix", TAG_KERNELS, double){ // NOLINT(cert-e
         colIdxs[2] = 2;
         ascending[2] = false;
         colIdxs[3] = 3;
-        ascending[3] = true;
+        ascending[3] = true;   
     }
     
     order(resMatrix, argMatrix, colIdxs, numKeyCols, ascending, numKeyCols, false, nullptr);
+    order(resIdxs, argMatrix, colIdxs, numKeyCols, ascending, numKeyCols, true, nullptr);
 
-    CHECK(*resMatrix ==*expMatrix);
+    CHECK(*resMatrix == *expMatrix);
+    CHECK(*resIdxs == *expIdxs);
+
     DataObjectFactory::destroy(argMatrix);
     DataObjectFactory::destroy(resMatrix);
     DataObjectFactory::destroy(expMatrix);
+    DataObjectFactory::destroy(resIdxs);
+    DataObjectFactory::destroy(expIdxs);
 }

--- a/test/runtime/local/kernels/OrderTest.cpp
+++ b/test/runtime/local/kernels/OrderTest.cpp
@@ -118,3 +118,56 @@ TEMPLATE_TEST_CASE("Order", TAG_KERNELS, (Frame)) {
     DataObjectFactory::destroy(exp);
     DataObjectFactory::destroy(res);
 }
+
+TEMPLATE_TEST_CASE("Order - DenseMatrix", TAG_KERNELS, double){ // NOLINT(cert-err58-cpp)
+    using VT = TestType;
+    size_t numKeyCols;
+    size_t colIdxs[4];
+    bool ascending[4];
+
+    DenseMatrix<VT>* argMatrix = genGivenVals<DenseMatrix<VT>>(4, {
+            1, 10, 3, 7, 7, 7,
+            17, 7, 2, 3, 7, 7,
+            7, 7, 1, 2, 3, 7,
+            7, 7, 1, 1, 2, 3,
+        });
+    DenseMatrix<VT>* resMatrix = nullptr;
+    DenseMatrix<VT>* expMatrix = nullptr;
+
+
+    SECTION("single key column, ascending") {
+        expMatrix =  genGivenVals<DenseMatrix<VT>>(4, {
+            7, 7, 1, 1, 2, 3,
+            7, 7, 1, 2, 3, 7,
+            17, 7, 2, 3, 7, 7,
+            1, 10, 3, 7, 7, 7
+        });
+        numKeyCols = 1;
+        colIdxs[0] = 3;
+        ascending[0] = true;
+    }
+    SECTION("four key columns, ascending/descending") {
+        expMatrix =  genGivenVals<DenseMatrix<VT>>(4, {
+            17, 7, 2, 3, 7, 7,
+            7, 7, 1, 1, 2, 3,
+            7, 7, 1, 2, 3, 7,
+            1, 10, 3, 7, 7, 7,
+        });
+        numKeyCols = 4;
+        colIdxs[0] = 1;
+        ascending[0] = true;
+        colIdxs[1] = 0;
+        ascending[1] = false;
+        colIdxs[2] = 2;
+        ascending[2] = false;
+        colIdxs[3] = 3;
+        ascending[3] = true;
+    }
+    
+    order(resMatrix, argMatrix, colIdxs, numKeyCols, ascending, numKeyCols, false, nullptr);
+
+    CHECK(*resMatrix ==*expMatrix);
+    DataObjectFactory::destroy(argMatrix);
+    DataObjectFactory::destroy(resMatrix);
+    DataObjectFactory::destroy(expMatrix);
+}

--- a/test/runtime/local/kernels/OrderTest.cpp
+++ b/test/runtime/local/kernels/OrderTest.cpp
@@ -210,7 +210,7 @@ TEMPLATE_PRODUCT_TEST_CASE("Order", TAG_KERNELS, (DenseMatrix), (double, float))
         colIdxs[2] = 2;
         ascending[2] = false;
         colIdxs[3] = 3;
-        ascending[3] = true;   
+        ascending[3] = true;
     }
     
     order(resMatrix, argMatrix, colIdxs, numKeyCols, ascending, numKeyCols, false, nullptr);

--- a/test/runtime/local/kernels/OrderTest.cpp
+++ b/test/runtime/local/kernels/OrderTest.cpp
@@ -125,17 +125,18 @@ TEMPLATE_TEST_CASE("Order - DenseMatrix", TAG_KERNELS, double){ // NOLINT(cert-e
     size_t colIdxs[4];
     bool ascending[4];
 
-    DenseMatrix<VT>* argMatrix = genGivenVals<DenseMatrix<VT>>(4, {
-            1, 10, 3, 7, 7, 7,
-            17, 7, 2, 3, 7, 7,
-            7, 7, 1, 2, 3, 7,
-            7, 7, 1, 1, 2, 3,
-        });
+    DenseMatrix<VT>* argMatrix = nullptr;
     DenseMatrix<VT>* resMatrix = nullptr;
     DenseMatrix<VT>* expMatrix = nullptr;
 
 
     SECTION("single key column, ascending") {
+        argMatrix = genGivenVals<DenseMatrix<VT>>(4, {
+            1, 10, 3, 7, 7, 7,
+            17, 7, 2, 3, 7, 7,
+            7, 7, 1, 2, 3, 7,
+            7, 7, 1, 1, 2, 3,
+        });
         expMatrix =  genGivenVals<DenseMatrix<VT>>(4, {
             7, 7, 1, 1, 2, 3,
             7, 7, 1, 2, 3, 7,
@@ -147,11 +148,49 @@ TEMPLATE_TEST_CASE("Order - DenseMatrix", TAG_KERNELS, double){ // NOLINT(cert-e
         ascending[0] = true;
     }
     SECTION("four key columns, ascending/descending") {
-        expMatrix =  genGivenVals<DenseMatrix<VT>>(4, {
-            17, 7, 2, 3, 7, 7,
-            7, 7, 1, 1, 2, 3,
-            7, 7, 1, 2, 3, 7,
-            1, 10, 3, 7, 7, 7,
+        argMatrix = genGivenVals<DenseMatrix<VT>>(20, {
+            1.1, 1.1, 0, 6,
+            -3.1, -2, 0, 3,
+            4.4, 4.4, 1, 9,
+            -8.8, 2.1, 1, 1,
+            5.6, 1.1, 0, 13,
+            2.3, 2.3, 0, 7,
+            0.3, 0.5, 0, 5,
+            4.4, 4.4, 3, 10,
+            6.6, -10, 0, 15,
+            6.6, 0, 0, 16,
+            -8.8, 2.1, 2, 2,
+            6.6, 10, 1, 17,
+            6.6, 10, 2, 18,
+            4.4, 4.4, 3, 11,
+            -0.3, -0.3, 0, 4,
+            4.4, -15.5, 0, 12,
+            6.6, 10, 3, 19,
+            2.3, -2.3, 0, 8,
+            6.6, 10, 3, 20,
+            5.6, -1.1, 0, 14
+        });
+        expMatrix = genGivenVals<DenseMatrix<VT>>(20, {
+            4.4, -15.5, 0, 12,
+            6.6, -10, 0, 15,
+            2.3, -2.3, 0, 8,
+            -3.1, -2, 0, 3,
+            5.6, -1.1, 0, 14,
+            -0.3, -0.3, 0, 4,
+            6.6, 0, 0, 16,
+            0.3, 0.5, 0, 5,
+            5.6, 1.1, 0, 13,
+            1.1, 1.1, 0, 6,
+            -8.8, 2.1, 2, 2,
+            -8.8, 2.1, 1, 1,
+            2.3, 2.3, 0, 7,
+            4.4, 4.4, 3, 10,
+            4.4, 4.4, 3, 11,
+            4.4, 4.4, 1, 9,
+            6.6, 10, 3, 19,
+            6.6, 10, 3, 20,
+            6.6, 10, 2, 18,
+            6.6, 10, 1, 17
         });
         numKeyCols = 4;
         colIdxs[0] = 1;


### PR DESCRIPTION
* implements returning the index matrix from the OrderOp if a boolean flag is set
* shape inference adaptation (to include the case mentioned above)
* builds on #388 