### PR TITLE
[DAPHNE-#415]: Kernels for DenseMatrix of strings

### DIFF
--- a/src/parser/daphnedsl/DaphneDSLVisitor.h
+++ b/src/parser/daphnedsl/DaphneDSLVisitor.h
@@ -20,6 +20,7 @@
 #include <parser/daphnedsl/DaphneDSLBuiltins.h>
 #include <parser/ParserUtils.h>
 #include <parser/ScopedSymbolTable.h>
+#include <runtime/local/datastructures/DenseMatrix.h>
 
 #include "antlr4-runtime.h"
 #include "DaphneDSLGrammarParser.h"
@@ -95,6 +96,9 @@ class DaphneDSLVisitor : public DaphneDSLGrammarVisitor {
     
     template<class InsertAxOp, class NumAxOp>
     mlir::Value applyLeftIndexing(mlir::Location loc, mlir::Value arg, mlir::Value ins, antlrcpp::Any ax, bool allowLabel);
+
+    template<typename VT>
+    DenseMatrix<VT>* getDenseMatForMatrixConstant(mlir::Type valueType, DaphneDSLGrammarParser::MatrixLiteralExprContext * ctx);
 
 public:
     DaphneDSLVisitor(

--- a/src/runtime/local/datastructures/DenseMatrix.h
+++ b/src/runtime/local/datastructures/DenseMatrix.h
@@ -515,29 +515,28 @@ public:
         return getValues()[pos(rowIdx, colIdx)];
     }
 
-    void set(size_t rowIdx, size_t colIdx, const char* value) override {
-        auto vals = getValues();
+    void set(size_t rowIdx, size_t colIdx, const char* stringToSet) override {
         size_t currentPos = pos(rowIdx, colIdx);
-        auto currentVal = vals[currentPos];
+        auto currentVal = values[currentPos];
         size_t currentSize = strBuf.get()->getSize();
-        int32_t diff = strlen(value) - strlen(currentVal);
+        const size_t valueLength = strlen(stringToSet);
+        int32_t diff = valueLength - strlen(currentVal);
 
         if(currentSize + diff > strBuf->capacity){
-            strBuf.get()->expandStringBuffer(currentSize + diff, vals, numRows, rowSkip, getNumItems());
-            currentVal = vals[currentPos];
+            strBuf.get()->expandStringBuffer(currentSize + diff, values.get(), numRows, rowSkip, getNumItems());
+            currentVal = values[currentPos];
         }
-
         if(diff && (currentPos + 1 < getStrBuf()->numCells)) {
             const char* from = values[currentPos + 1];
             const char* to = from + diff;
             size_t length = strBuf->currentTop - from;
             memmove(const_cast<char*>(to), from, length);
         }
-        memcpy(const_cast<char*>(currentVal), value, strlen(value) + 1);
+        memcpy(const_cast<char*>(currentVal), stringToSet, valueLength + 1);
 
         if(diff){
             for(size_t offset = currentPos + 1; offset < getStrBuf()->numCells; offset++)
-                vals[offset] += diff; 
+                values[offset] += diff; 
         }
 
         strBuf->currentTop += diff;

--- a/src/runtime/local/kernels/AggOpCode.h
+++ b/src/runtime/local/kernels/AggOpCode.h
@@ -45,7 +45,7 @@ struct AggOpCodeUtils {
             case AggOpCode::STDDEV:
                 return false;
             default:
-                throw std::runtime_error("unsupported AggOpCode");
+                throw std::runtime_error("unsupported pure binary reduction AggOpCode");
         }
     }
     

--- a/src/runtime/local/kernels/AggRow.h
+++ b/src/runtime/local/kernels/AggRow.h
@@ -54,82 +54,105 @@ void aggRow(AggOpCode opCode, DTRes *& res, const DTArg * arg, DCTX(ctx)) {
 // DenseMatrix <- DenseMatrix
 // ----------------------------------------------------------------------------
 
-template<typename VT>
-struct AggRow<DenseMatrix<VT>, DenseMatrix<VT>> {
-    static void apply(AggOpCode opCode, DenseMatrix<VT> *& res, const DenseMatrix<VT> * arg, DCTX(ctx)) {
+template<typename VTRes, typename VTArg>
+struct AggRow<DenseMatrix<VTRes>, DenseMatrix<VTArg>> {
+    static void apply(AggOpCode opCode, DenseMatrix<VTRes> *& res, const DenseMatrix<VTArg> * arg, [[maybe_unused]]DCTX(ctx)) {
         const size_t numRows = arg->getNumRows();
         const size_t numCols = arg->getNumCols();
         
         if(res == nullptr)
-            res = DataObjectFactory::create<DenseMatrix<VT>>(numRows, 1, false);
+            res = DataObjectFactory::create<DenseMatrix<VTRes>>(numRows, 1, false);
         
-        const VT * valuesArg = arg->getValues();
-        VT * valuesRes = res->getValues();
-        
-        if(opCode == AggOpCode::IDXMIN) {
-            for(size_t r = 0; r < numRows; r++) {
-                VT minVal = valuesArg[0];
-                size_t minValIdx = 0;
-                for(size_t c = 1; c < numCols; c++)
-                    if(valuesArg[c] < minVal) {
-                        minVal = valuesArg[c];
-                        minValIdx = c;
+        const VTArg * valuesArg = arg->getValues();
+        VTRes * valuesRes = res->getValues();
+        // if <int, char> -> do not compile past this
+        if constexpr(!std::is_same_v<VTRes, StringScalarType>)
+        {
+            if(opCode == AggOpCode::IDXMIN) {
+                for(size_t r = 0; r < numRows; r++) {
+                    VTArg minVal = valuesArg[0];
+                    size_t minValIdx = 0;
+                    for(size_t c = 1; c < numCols; c++){
+                        bool lessThan = false;
+                        if constexpr(std::is_same_v<VTArg, StringScalarType>)
+                            lessThan = (strcmp(valuesArg[c], minVal) < 0);
+                        else
+                            lessThan = (valuesArg[c] < minVal);
+                        if(lessThan){
+                            minVal = valuesArg[c];
+                            minValIdx = c;
+                        }
                     }
-                *valuesRes = static_cast<VT>(minValIdx);
-                valuesArg += arg->getRowSkip();
-                valuesRes += res->getRowSkip();
+                    *valuesRes = static_cast<VTRes>(minValIdx);
+                    valuesArg += arg->getRowSkip();
+                    valuesRes += res->getRowSkip();
+                }
+                return;
+            }
+            else if(opCode == AggOpCode::IDXMAX) {
+                for(size_t r = 0; r < numRows; r++) {
+                    VTArg maxVal = valuesArg[0];
+                    size_t maxValIdx = 0;
+                    for(size_t c = 1; c < numCols; c++){
+                        bool greaterThan = false;
+                        if constexpr(std::is_same_v<VTArg, StringScalarType>)
+                            greaterThan = (strcmp(valuesArg[c], maxVal) > 0);
+                        else
+                            greaterThan = (valuesArg[c] > maxVal);
+                        if(greaterThan) {
+                            maxVal = valuesArg[c];
+                            maxValIdx = c;
+                        }
+                    }
+                    *valuesRes = static_cast<VTRes>(maxValIdx);
+                    valuesArg += arg->getRowSkip();
+                    valuesRes += res->getRowSkip();
+                }
+                return;
             }
         }
-        else if(opCode == AggOpCode::IDXMAX) {
-            for(size_t r = 0; r < numRows; r++) {
-                VT maxVal = valuesArg[0];
-                size_t maxValIdx = 0;
-                for(size_t c = 1; c < numCols; c++)
-                    if(valuesArg[c] > maxVal) {
-                        maxVal = valuesArg[c];
-                        maxValIdx = c;
-                    }
-                *valuesRes = static_cast<VT>(maxValIdx);
-                valuesArg += arg->getRowSkip();
-                valuesRes += res->getRowSkip();
-            }
-        }
-        else {
-            EwBinaryScaFuncPtr<VT, VT, VT> func;    
+        if constexpr(!std::is_same_v<VTArg, StringScalarType> || std::is_same_v<VTRes, StringScalarType>){
+            EwBinaryScaFuncPtr<VTRes, VTArg, VTArg> func;    
             if(AggOpCodeUtils::isPureBinaryReduction(opCode))
-                func = getEwBinaryScaFuncPtr<VT, VT, VT>(AggOpCodeUtils::getBinaryOpCode(opCode));
+                func = getEwBinaryScaFuncPtr<VTRes, VTArg, VTArg>(AggOpCodeUtils::getBinaryOpCode(opCode));
             else
                 // TODO Setting the function pointer yields the correct result.
                 // However, since MEAN and STDDEV are not sparse-safe, the program
                 // does not take the same path for doing the summation, and is less
                 // efficient.
                 // for MEAN and STDDDEV, we need to sum
-                func = getEwBinaryScaFuncPtr<VT, VT, VT>(AggOpCodeUtils::getBinaryOpCode(AggOpCode::SUM));
+                func = getEwBinaryScaFuncPtr<VTRes, VTArg, VTArg>(AggOpCodeUtils::getBinaryOpCode(AggOpCode::SUM));
 
             for(size_t r = 0; r < numRows; r++) {
-                VT agg = *valuesArg;
+                VTRes agg = *valuesArg;
                 for(size_t c = 1; c < numCols; c++)
                     agg = func(agg, valuesArg[c], ctx);
-                *valuesRes = agg;
+                if constexpr(std::is_same_v<VTArg, StringScalarType>)
+                    res->set(r, 0, agg);
+                else
+                    *valuesRes = agg;
                 valuesArg += arg->getRowSkip();
                 valuesRes += res->getRowSkip();
             }
 
             if(AggOpCodeUtils::isPureBinaryReduction(opCode))
                 return;
-
-            // The op-code is either MEAN or STDDEV
-            valuesRes = res->getValues();
-            for(size_t r = 0; r < numRows; r++) {
-                *valuesRes = (*valuesRes) / numCols;
-                valuesRes += res->getRowSkip();
-            }
-            if(opCode == AggOpCode::MEAN)
+            if constexpr(std::is_same_v<VTArg, StringScalarType>)
                 return;
-            
-            // else op-code is STDDEV
-            // TODO STDDEV
-            throw std::runtime_error("unsupported AggOpCode in AggRow for DenseMatrix");
+            else{
+                // The op-code is either MEAN or STDDEV
+                valuesRes = res->getValues();
+                for(size_t r = 0; r < numRows; r++) {
+                    *valuesRes = (*valuesRes) / numCols;
+                    valuesRes += res->getRowSkip();
+                }
+                if(opCode == AggOpCode::MEAN)
+                    return;
+                
+                // else op-code is STDDEV
+                // TODO STDDEV
+                throw std::runtime_error("unsupported AggOpCode in AggRow for DenseMatrix");
+            }
         }
     }
 };

--- a/src/runtime/local/kernels/BinaryOpCode.h
+++ b/src/runtime/local/kernels/BinaryOpCode.h
@@ -42,6 +42,11 @@ enum class BinaryOpCode {
     AND,
     OR,
 
+    // String-only.
+    CONCAT,
+    LIKE,
+    
+
     ISSYM,
 };
 

--- a/src/runtime/local/kernels/EwBinaryMat.h
+++ b/src/runtime/local/kernels/EwBinaryMat.h
@@ -76,10 +76,10 @@ struct EwBinaryMat<DenseMatrix<VTres>, DenseMatrix<VTlhs>, DenseMatrix<VTrhs>> {
             for(size_t r = 0; r < numRowsLhs; r++) {
                 for(size_t c = 0; c < numColsLhs; c++){
                     if constexpr(std::is_same_v<VTres, StringScalarType>){
-                        auto temporaryString = func(valuesLhs[c], valuesRhs[c], ctx);
-                        res->set(r,c, temporaryString);
+                        auto stringPtr = func(valuesLhs[c], valuesRhs[c], ctx);
+                        res->set(r,c, stringPtr);
                         if(opCode == BinaryOpCode::CONCAT)
-                            delete[] temporaryString;
+                            delete[] stringPtr;
                     } else
                         valuesRes[c] = func(valuesLhs[c], valuesRhs[c], ctx);
                 }
@@ -94,10 +94,10 @@ struct EwBinaryMat<DenseMatrix<VTres>, DenseMatrix<VTlhs>, DenseMatrix<VTrhs>> {
             for(size_t r = 0; r < numRowsLhs; r++) {
                 for(size_t c = 0; c < numColsLhs; c++){
                     if constexpr(std::is_same_v<VTres, StringScalarType>){
-                        auto temporaryString = func(valuesLhs[c], valuesRhs[c], ctx);
-                        res->set(r,c, temporaryString);
+                        auto stringPtr = func(valuesLhs[c], valuesRhs[c], ctx);
+                        res->set(r,c, stringPtr);
                         if(opCode == BinaryOpCode::CONCAT)
-                            delete[] temporaryString;
+                            delete[] stringPtr;
                     } else
                         valuesRes[c] = func(valuesLhs[c], valuesRhs[c], ctx);
                 }
@@ -110,10 +110,10 @@ struct EwBinaryMat<DenseMatrix<VTres>, DenseMatrix<VTlhs>, DenseMatrix<VTrhs>> {
             for(size_t r = 0; r < numRowsLhs; r++) {
                 for(size_t c = 0; c < numColsLhs; c++){
                     if constexpr(std::is_same_v<VTres, StringScalarType>){
-                        auto temporaryString = func(valuesLhs[c], valuesRhs[0], ctx);
-                        res->set(r,c, temporaryString);
+                        auto stringPtr = func(valuesLhs[c], valuesRhs[0], ctx);
+                        res->set(r,c, stringPtr);
                         if(opCode == BinaryOpCode::CONCAT)
-                            delete[] temporaryString;
+                            delete[] stringPtr;
                     } else
                         valuesRes[c] = func(valuesLhs[c], valuesRhs[0], ctx);
                 }

--- a/src/runtime/local/kernels/EwBinaryMat.h
+++ b/src/runtime/local/kernels/EwBinaryMat.h
@@ -74,8 +74,16 @@ struct EwBinaryMat<DenseMatrix<VTres>, DenseMatrix<VTlhs>, DenseMatrix<VTrhs>> {
         if(numRowsLhs == numRowsRhs && numColsLhs == numColsRhs) {
             // matrix op matrix (same size)
             for(size_t r = 0; r < numRowsLhs; r++) {
-                for(size_t c = 0; c < numColsLhs; c++)
-                    valuesRes[c] = func(valuesLhs[c], valuesRhs[c], ctx);
+                for(size_t c = 0; c < numColsLhs; c++){
+                    if constexpr(std::is_same_v<VTres, StringScalarType>){
+                        auto temporaryString = func(valuesLhs[c], valuesRhs[c], ctx);
+                        res->set(r,c, temporaryString);
+                        if(opCode == BinaryOpCode::CONCAT)
+                            delete[] temporaryString;
+                    } else
+                        valuesRes[c] = func(valuesLhs[c], valuesRhs[c], ctx);
+                }
+                    
                 valuesLhs += lhs->getRowSkip();
                 valuesRhs += rhs->getRowSkip();
                 valuesRes += res->getRowSkip();
@@ -84,8 +92,15 @@ struct EwBinaryMat<DenseMatrix<VTres>, DenseMatrix<VTlhs>, DenseMatrix<VTrhs>> {
         else if(numColsLhs == numColsRhs && (numRowsRhs == 1 || numRowsLhs == 1)) {
             // matrix op row-vector
             for(size_t r = 0; r < numRowsLhs; r++) {
-                for(size_t c = 0; c < numColsLhs; c++)
-                    valuesRes[c] = func(valuesLhs[c], valuesRhs[c], ctx);
+                for(size_t c = 0; c < numColsLhs; c++){
+                    if constexpr(std::is_same_v<VTres, StringScalarType>){
+                        auto temporaryString = func(valuesLhs[c], valuesRhs[c], ctx);
+                        res->set(r,c, temporaryString);
+                        if(opCode == BinaryOpCode::CONCAT)
+                            delete[] temporaryString;
+                    } else
+                        valuesRes[c] = func(valuesLhs[c], valuesRhs[c], ctx);
+                }
                 valuesLhs += lhs->getRowSkip();
                 valuesRes += res->getRowSkip();
             }
@@ -93,8 +108,15 @@ struct EwBinaryMat<DenseMatrix<VTres>, DenseMatrix<VTlhs>, DenseMatrix<VTrhs>> {
         else if(numRowsLhs == numRowsRhs && (numColsRhs == 1 || numColsLhs == 1)) {
             // matrix op col-vector
             for(size_t r = 0; r < numRowsLhs; r++) {
-                for(size_t c = 0; c < numColsLhs; c++)
-                    valuesRes[c] = func(valuesLhs[c], valuesRhs[0], ctx);
+                for(size_t c = 0; c < numColsLhs; c++){
+                    if constexpr(std::is_same_v<VTres, StringScalarType>){
+                        auto temporaryString = func(valuesLhs[c], valuesRhs[0], ctx);
+                        res->set(r,c, temporaryString);
+                        if(opCode == BinaryOpCode::CONCAT)
+                            delete[] temporaryString;
+                    } else
+                        valuesRes[c] = func(valuesLhs[c], valuesRhs[0], ctx);
+                }
                 valuesLhs += lhs->getRowSkip();
                 valuesRhs += rhs->getRowSkip();
                 valuesRes += res->getRowSkip();
@@ -340,14 +362,13 @@ struct EwBinaryMat<Matrix<VT>, Matrix<VT>, Matrix<VT>> {
         
         res->prepareAppend();
         for(size_t r = 0; r < numRows; r++)
-            for(size_t c = 0; c < numCols; c++)
-            {
-                if constexpr (std::is_same_v<VT, StringScalarType>)
-                {
+            for(size_t c = 0; c < numCols; c++){
+                if constexpr (std::is_same_v<VT, StringScalarType>){
                     auto temporaryString = func(lhs->get(r, c), rhs->get(r, c), ctx);
                     res->append(r, c, temporaryString);
-                    delete[] temporaryString;
-                }else
+                    if(opCode == BinaryOpCode::CONCAT)
+                        delete[] temporaryString;
+                } else
                     res->append(r, c) = func(lhs->get(r, c), rhs->get(r, c), ctx);
             }
         res->finishAppend();

--- a/src/runtime/local/kernels/EwBinaryMat.h
+++ b/src/runtime/local/kernels/EwBinaryMat.h
@@ -26,6 +26,7 @@
 
 #include <cassert>
 #include <cstddef>
+#include <type_traits>
 
 // ****************************************************************************
 // Struct for partial template specialization
@@ -340,7 +341,15 @@ struct EwBinaryMat<Matrix<VT>, Matrix<VT>, Matrix<VT>> {
         res->prepareAppend();
         for(size_t r = 0; r < numRows; r++)
             for(size_t c = 0; c < numCols; c++)
-                res->append(r, c) = func(lhs->get(r, c), rhs->get(r, c), ctx);
+            {
+                if constexpr (std::is_same_v<VT, StringScalarType>)
+                {
+                    auto temporaryString = func(lhs->get(r, c), rhs->get(r, c), ctx);
+                    res->append(r, c, temporaryString);
+                    delete[] temporaryString;
+                }else
+                    res->append(r, c) = func(lhs->get(r, c), rhs->get(r, c), ctx);
+            }
         res->finishAppend();
     }
 };

--- a/src/runtime/local/kernels/EwBinarySca.h
+++ b/src/runtime/local/kernels/EwBinarySca.h
@@ -191,8 +191,8 @@ MAKE_EW_BINARY_SCA(BinaryOpCode::LE , lhs <= rhs, strcmp(lhs, rhs) <= 0)
 MAKE_EW_BINARY_SCA(BinaryOpCode::GT , lhs >  rhs, strcmp(lhs, rhs) >  0)
 MAKE_EW_BINARY_SCA(BinaryOpCode::GE , lhs >= rhs, strcmp(lhs, rhs) >= 0) 
 // Min/max.
-MAKE_EW_BINARY_SCA(BinaryOpCode::MIN, std::min(lhs, rhs), std::min(static_cast<std::string_view>(lhs),static_cast<std::string_view>(rhs)).data())
-MAKE_EW_BINARY_SCA(BinaryOpCode::MAX, std::max(lhs, rhs), std::max(static_cast<std::string_view>(lhs),static_cast<std::string_view>(rhs)).data())
+MAKE_EW_BINARY_SCA(BinaryOpCode::MIN, std::min(lhs, rhs), strcmp(lhs, rhs) < 0 ? lhs : rhs)
+MAKE_EW_BINARY_SCA(BinaryOpCode::MAX, std::max(lhs, rhs), strcmp(lhs, rhs) > 0 ? lhs : rhs)
 // Logical.
 MAKE_EW_BINARY_SCA(BinaryOpCode::AND, lhs && rhs, NO_SUPPORT_FOR_STRING)
 MAKE_EW_BINARY_SCA(BinaryOpCode::OR , lhs || rhs, NO_SUPPORT_FOR_STRING)

--- a/src/runtime/local/kernels/EwBinarySca.h
+++ b/src/runtime/local/kernels/EwBinarySca.h
@@ -61,22 +61,39 @@ template<typename VTRes, typename VTLhs, typename VTRhs>
 EwBinaryScaFuncPtr<VTRes, VTLhs, VTRhs> getEwBinaryScaFuncPtr(BinaryOpCode opCode) {
     #define MAKE_CASE(opCode) case opCode: return &EwBinarySca<opCode, VTRes, VTLhs, VTRhs>::apply;
     if constexpr(std::is_same_v<VTRes, StringScalarType>){
-        // String-only ops.
+        // String-output ops instantiation.
         switch(opCode) {
             MAKE_CASE(BinaryOpCode::CONCAT)
+            MAKE_CASE(BinaryOpCode::MIN)
+            MAKE_CASE(BinaryOpCode::MAX)
             default:
-                throw std::runtime_error("unknown BinaryOpCode");
+                throw std::runtime_error("unknown BinaryOpCode to output string");
         }
     } else{
+        // Numeric-output ops
+        if constexpr(!std::is_same_v<VTLhs, StringScalarType>){
+            // Numeric-input ops instantiation
+            switch (opCode) {
+                // Arithmetic.
+                MAKE_CASE(BinaryOpCode::ADD)
+                MAKE_CASE(BinaryOpCode::SUB)
+                MAKE_CASE(BinaryOpCode::MUL)
+                MAKE_CASE(BinaryOpCode::DIV)
+                MAKE_CASE(BinaryOpCode::POW)
+                MAKE_CASE(BinaryOpCode::MOD)
+                MAKE_CASE(BinaryOpCode::LOG)
+                // Logical.
+                MAKE_CASE(BinaryOpCode::AND)
+                MAKE_CASE(BinaryOpCode::OR)
+                // Min/max.
+                MAKE_CASE(BinaryOpCode::MIN)
+                MAKE_CASE(BinaryOpCode::MAX)
+                default:
+                    break;
+            }
+        }
+        // Mixed types (in: string, out:int) instantiation
         switch (opCode) {
-            // Arithmetic.
-            MAKE_CASE(BinaryOpCode::ADD)
-            MAKE_CASE(BinaryOpCode::SUB)
-            MAKE_CASE(BinaryOpCode::MUL)
-            MAKE_CASE(BinaryOpCode::DIV)
-            MAKE_CASE(BinaryOpCode::POW)
-            MAKE_CASE(BinaryOpCode::MOD)
-            MAKE_CASE(BinaryOpCode::LOG)
             // Comparisons.
             MAKE_CASE(BinaryOpCode::EQ)
             MAKE_CASE(BinaryOpCode::NEQ)
@@ -84,12 +101,6 @@ EwBinaryScaFuncPtr<VTRes, VTLhs, VTRhs> getEwBinaryScaFuncPtr(BinaryOpCode opCod
             MAKE_CASE(BinaryOpCode::LE)
             MAKE_CASE(BinaryOpCode::GT)
             MAKE_CASE(BinaryOpCode::GE)
-            // Min/max.
-            MAKE_CASE(BinaryOpCode::MIN)
-            MAKE_CASE(BinaryOpCode::MAX)
-            // Logical.
-            MAKE_CASE(BinaryOpCode::AND)
-            MAKE_CASE(BinaryOpCode::OR)
 
             default:
                 throw std::runtime_error("unknown BinaryOpCode");
@@ -143,44 +154,48 @@ struct EwBinarySca<BinaryOpCode::CONCAT, StringScalarType, StringScalarType, Str
 template<>
 struct EwBinarySca<BinaryOpCode::LIKE, bool, StringScalarType, StringScalarType> {
     inline static bool apply(StringScalarType lhs, StringScalarType pattern, DCTX(ctx)) {
-        const uint64_t lhsLength = strlen(lhs)+1; 
-        const uint64_t patternLength = strlen(pattern)+1;
+        // const uint64_t lhsLength = strlen(lhs)+1; 
+        // const uint64_t patternLength = strlen(pattern)+1;
         bool found = false;
         // TODO: could take a while
         return found;
     }
 };
 
-#define MAKE_EW_BINARY_SCA(opCode, expr) \
+#define MAKE_EW_BINARY_SCA(opCode, numericExpr, stringExpr) \
     template<typename TRes, typename TLhs, typename TRhs> \
     struct EwBinarySca<opCode, TRes, TLhs, TRhs> { \
         inline static TRes apply(TLhs lhs, TRhs rhs, DCTX(ctx)) { \
-            return expr; \
+            if constexpr(std::is_same_v<TRhs, const char*>)\
+                return stringExpr; \
+            else \
+                return numericExpr; \
         } \
     };
 
+const int NO_SUPPORT_FOR_STRING = -1;
 // One such line for each binary function to support.
 // Arithmetic.
-MAKE_EW_BINARY_SCA(BinaryOpCode::ADD, lhs + rhs)
-MAKE_EW_BINARY_SCA(BinaryOpCode::SUB, lhs - rhs)
-MAKE_EW_BINARY_SCA(BinaryOpCode::MUL, lhs * rhs)
-MAKE_EW_BINARY_SCA(BinaryOpCode::DIV, lhs / rhs)
-MAKE_EW_BINARY_SCA(BinaryOpCode::POW, pow(lhs, rhs))
-MAKE_EW_BINARY_SCA(BinaryOpCode::MOD, std::fmod(lhs, rhs))
-MAKE_EW_BINARY_SCA(BinaryOpCode::LOG, std::log(lhs)/std::log(rhs))
+MAKE_EW_BINARY_SCA(BinaryOpCode::ADD, lhs + rhs, NO_SUPPORT_FOR_STRING)
+MAKE_EW_BINARY_SCA(BinaryOpCode::SUB, lhs - rhs, NO_SUPPORT_FOR_STRING)
+MAKE_EW_BINARY_SCA(BinaryOpCode::MUL, lhs * rhs, NO_SUPPORT_FOR_STRING)
+MAKE_EW_BINARY_SCA(BinaryOpCode::DIV, lhs / rhs, NO_SUPPORT_FOR_STRING)
+MAKE_EW_BINARY_SCA(BinaryOpCode::POW, pow(lhs, rhs), NO_SUPPORT_FOR_STRING)
+MAKE_EW_BINARY_SCA(BinaryOpCode::MOD, std::fmod(lhs, rhs), NO_SUPPORT_FOR_STRING)
+MAKE_EW_BINARY_SCA(BinaryOpCode::LOG, std::log(lhs)/std::log(rhs), NO_SUPPORT_FOR_STRING)
 // Comparisons.
-MAKE_EW_BINARY_SCA(BinaryOpCode::EQ , lhs == rhs)
-MAKE_EW_BINARY_SCA(BinaryOpCode::NEQ, lhs != rhs)
-MAKE_EW_BINARY_SCA(BinaryOpCode::LT , lhs <  rhs)
-MAKE_EW_BINARY_SCA(BinaryOpCode::LE , lhs <= rhs)
-MAKE_EW_BINARY_SCA(BinaryOpCode::GT , lhs >  rhs)
-MAKE_EW_BINARY_SCA(BinaryOpCode::GE , lhs >= rhs)
+MAKE_EW_BINARY_SCA(BinaryOpCode::EQ , lhs == rhs, strcmp(lhs, rhs) == 0)
+MAKE_EW_BINARY_SCA(BinaryOpCode::NEQ, lhs != rhs, strcmp(lhs, rhs) != 0)
+MAKE_EW_BINARY_SCA(BinaryOpCode::LT , lhs <  rhs, strcmp(lhs, rhs) <  0)
+MAKE_EW_BINARY_SCA(BinaryOpCode::LE , lhs <= rhs, strcmp(lhs, rhs) <= 0)
+MAKE_EW_BINARY_SCA(BinaryOpCode::GT , lhs >  rhs, strcmp(lhs, rhs) >  0)
+MAKE_EW_BINARY_SCA(BinaryOpCode::GE , lhs >= rhs, strcmp(lhs, rhs) >= 0) 
 // Min/max.
-MAKE_EW_BINARY_SCA(BinaryOpCode::MIN, std::min(lhs, rhs))
-MAKE_EW_BINARY_SCA(BinaryOpCode::MAX, std::max(lhs, rhs))
+MAKE_EW_BINARY_SCA(BinaryOpCode::MIN, std::min(lhs, rhs), std::min(static_cast<std::string_view>(lhs),static_cast<std::string_view>(rhs)).data())
+MAKE_EW_BINARY_SCA(BinaryOpCode::MAX, std::max(lhs, rhs), std::max(static_cast<std::string_view>(lhs),static_cast<std::string_view>(rhs)).data())
 // Logical.
-MAKE_EW_BINARY_SCA(BinaryOpCode::AND, lhs && rhs)
-MAKE_EW_BINARY_SCA(BinaryOpCode::OR , lhs || rhs)
+MAKE_EW_BINARY_SCA(BinaryOpCode::AND, lhs && rhs, NO_SUPPORT_FOR_STRING)
+MAKE_EW_BINARY_SCA(BinaryOpCode::OR , lhs || rhs, NO_SUPPORT_FOR_STRING)
 
 #undef MAKE_EW_BINARY_SCA
 

--- a/src/runtime/local/kernels/EwUnaryMat.h
+++ b/src/runtime/local/kernels/EwUnaryMat.h
@@ -25,6 +25,7 @@
 
 #include <cassert>
 #include <cstddef>
+#include <type_traits>
 
 // ****************************************************************************
 // Struct for partial template specialization
@@ -67,8 +68,15 @@ struct EwUnaryMat<DenseMatrix<VT>, DenseMatrix<VT>> {
         EwUnaryScaFuncPtr<VT, VT> func = getEwUnaryScaFuncPtr<VT, VT>(opCode);
         
         for(size_t r = 0; r < numRows; r++) {
-            for(size_t c = 0; c < numCols; c++)
-                valuesRes[c] = func(valuesArg[c], ctx);
+            for(size_t c = 0; c < numCols; c++){
+                if constexpr (std::is_same_v<VT, StringScalarType>)
+                {
+                    auto temporaryString = func(valuesArg[c], ctx);
+                    res->set(r,c, temporaryString);
+                    delete[] temporaryString;
+                }else
+                    valuesRes[c] = func(valuesArg[c], ctx);
+            }
             valuesArg += arg->getRowSkip();
             valuesRes += res->getRowSkip();
         }

--- a/src/runtime/local/kernels/Fill.h
+++ b/src/runtime/local/kernels/Fill.h
@@ -58,12 +58,22 @@ struct Fill<DenseMatrix<VT>, VT> {
         assert(numCols > 0 && "numCols must be > 0");
 
         if(res == nullptr)
-            res = DataObjectFactory::create<DenseMatrix<VT>>(numRows, numCols, false);
+        {
+            if constexpr (std::is_same_v<VT, const char*>)
+                res = DataObjectFactory::create<DenseMatrix<const char*>>(numRows, numCols, false, numCols*numRows*(strlen(arg)+1));
+            else
+                res = DataObjectFactory::create<DenseMatrix<VT>>(numRows, numCols, false);
+        }
 
         VT * valuesRes = res->getValues();
         for(size_t r = 0; r < numRows; r++) {
             for(size_t c = 0; c < numCols; c++)
-                valuesRes[c] = arg;
+            {
+                if constexpr (std::is_same_v<VT, const char*>)
+                    res->set(r,c, arg);
+                else
+                    valuesRes[c] = arg;
+            }
             valuesRes += res->getRowSkip();
         }
     }

--- a/src/runtime/local/kernels/Like.h
+++ b/src/runtime/local/kernels/Like.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2021 The DAPHNE Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <runtime/local/context/DaphneContext.h>
+#include <runtime/local/datastructures/DataObjectFactory.h>
+#include <runtime/local/datastructures/DenseMatrix.h>
+#include <string_view>
+#include <vector>
+#include <regex>
+
+using StringMatrix = DenseMatrix<const char*>;
+const char wildCardAnyNumberChars = '%';
+const char wildCardSingleChar = '_';
+const char matchWildCard[] = {wildCardAnyNumberChars, wildCardSingleChar, '\0'};
+
+struct Like {
+    static std::regex createRegex(std::string_view pattern){
+        std::string expression(pattern);
+        for(size_t charIdx = 0; charIdx < expression.size(); charIdx++){
+            if(expression[charIdx] == wildCardAnyNumberChars){
+                expression.replace(charIdx, 1, ".*", 2);
+                charIdx++;
+            }else if(expression[charIdx] == wildCardSingleChar)
+                expression[charIdx] = '.';
+        }
+        return std::regex(expression);
+    }
+
+    static void apply(StringMatrix *& res, const StringMatrix * arg, const size_t colIdx, std::string_view pattern, DCTX(ctx)) {
+        const size_t argRows = arg->getNumRows();
+        const size_t argCols = arg->getNumCols();
+        if(colIdx > argCols)
+            throw std::runtime_error("like: invalid column index");
+
+        auto valuesArg = arg->getValues();
+        std::vector<size_t> argRowMatchIdxs;
+        const std::regex exprToMatch = createRegex(pattern);
+
+        for(size_t r = 0; r < argRows; r++) {
+            if(std::regex_match(valuesArg[colIdx], exprToMatch))
+                argRowMatchIdxs.push_back(r);
+            valuesArg += arg->getRowSkip();
+        }
+        
+        if(res == nullptr)
+            res = DataObjectFactory::create<StringMatrix>(argRowMatchIdxs.size(), argCols, false);
+    
+        for(size_t resRowIdx = 0; resRowIdx < argRowMatchIdxs.size(); resRowIdx++)
+            for(size_t c = 0; c < argCols; c++)
+                res->set(resRowIdx, c, arg->get(argRowMatchIdxs[resRowIdx], c));
+    }
+};
+
+// ****************************************************************************
+// Convenience function
+// ****************************************************************************
+
+void like(StringMatrix *& res, const StringMatrix * arg, const size_t colIdx, std::string_view pattern, DCTX(ctx)) {
+    Like::apply(res, arg, colIdx, pattern, ctx);
+}

--- a/src/runtime/local/kernels/Transpose.h
+++ b/src/runtime/local/kernels/Transpose.h
@@ -61,8 +61,12 @@ struct Transpose<DenseMatrix<VT>, DenseMatrix<VT>> {
             res = arg->vectorTranspose();
         }
         else {
-            if (res == nullptr)
-                res = DataObjectFactory::create<DenseMatrix<VT>>(numCols, numRows, false);
+            if (res == nullptr){
+                if constexpr(std::is_same_v<VT, const char*>)
+                    res = DataObjectFactory::create<DenseMatrix<VT>>(numCols, numRows, false, arg->getStrBufSharedPtr()->getSize()); 
+                else
+                    res = DataObjectFactory::create<DenseMatrix<VT>>(numCols, numRows, false);
+            }
 
             const VT *valuesArg = arg->getValues();
             const size_t rowSkipArg = arg->getRowSkip();
@@ -70,7 +74,10 @@ struct Transpose<DenseMatrix<VT>, DenseMatrix<VT>> {
             for (size_t r = 0; r < numRows; r++) {
                 VT *valuesRes = res->getValues() + r;
                 for (size_t c = 0; c < numCols; c++) {
-                    *valuesRes = valuesArg[c];
+                    if constexpr(std::is_same_v<VT, const char*>)
+                        res->set(c, r, valuesArg[c]);
+                    else
+                        *valuesRes = valuesArg[c];
                     valuesRes += rowSkipRes;
                 }
                 valuesArg += rowSkipArg;

--- a/src/runtime/local/kernels/UnaryOpCode.h
+++ b/src/runtime/local/kernels/UnaryOpCode.h
@@ -29,6 +29,9 @@ enum class UnaryOpCode {
     FLOOR,
     CEIL,
     ROUND,
+    // String-only.
+    LOWERCASE,
+    UPPERCASE
 };
 
 #endif //SRC_RUNTIME_LOCAL_KERNELS_UNARYOPCODE_H

--- a/src/runtime/local/kernels/kernels.json
+++ b/src/runtime/local/kernels/kernels.json
@@ -851,7 +851,8 @@
             [["DenseMatrix", "int64_t"]],
             [["DenseMatrix", "uint64_t"]],
             [["DenseMatrix", "uint8_t"]],
-            [["DenseMatrix", "bool"]]
+            [["DenseMatrix", "bool"]],
+            [["DenseMatrix", "const char *"]]
         ]
     },
     {
@@ -1180,6 +1181,7 @@
             [["DenseMatrix", "int64_t"]],
             [["DenseMatrix", "uint8_t"]],
             [["DenseMatrix", "bool"]],
+            [["DenseMatrix", "const char *"]],
             [["CSRMatrix", "double"]],
             [["CSRMatrix", "float"]],
             [["CSRMatrix", "int64_t"]],
@@ -1456,7 +1458,8 @@
         "instantiations": [
             [["DenseMatrix", "double"], ["DenseMatrix", "double"]],
             [["DenseMatrix", "int64_t"], ["DenseMatrix", "int64_t"]],
-            [["DenseMatrix", "bool"], ["DenseMatrix", "bool"]]
+            [["DenseMatrix", "bool"], ["DenseMatrix", "bool"]],
+            [["DenseMatrix", "const char *"], ["DenseMatrix", "const char *"]]
         ]
     },
     {

--- a/src/runtime/local/kernels/kernels.json
+++ b/src/runtime/local/kernels/kernels.json
@@ -819,7 +819,8 @@
             [["DenseMatrix", "float"], "float"],
             [["DenseMatrix", "double"], "double"],
             [["DenseMatrix", "int64_t"], "int64_t"],
-            [["DenseMatrix", "uint8_t"], "uint8_t"]
+            [["DenseMatrix", "uint8_t"], "uint8_t"],
+            [["DenseMatrix", "const char *"], "const char *"]
         ]
     },
     {

--- a/src/runtime/local/kernels/kernels.json
+++ b/src/runtime/local/kernels/kernels.json
@@ -2873,5 +2873,34 @@
         "instantiations": [
             ["Frame"]
         ]
+    },
+    {
+        "kernelTemplate": {
+            "header": "Like.h",
+            "opName": "like",
+            "returnType": "void",
+            "templateParams": [
+            ],
+            "runtimeParams": [
+                {
+                    "type": "StringMatrix *&",
+                    "name": "res"
+                },
+                {
+                    "type": "const StringMatrix *",
+                    "name": "arg"
+                },
+                {
+                    "type": "const size_t",
+                    "name": "colIdx"
+                },
+                {
+                    "type": "std::string_view",
+                    "name": "pattern"
+                }
+            ]
+        },
+        "instantiations": [
+        ]
     }
 ]

--- a/src/runtime/local/kernels/kernels.json
+++ b/src/runtime/local/kernels/kernels.json
@@ -683,7 +683,7 @@
                     ["Frame", "Frame", "double"],
                     ["Frame", "Frame", "int64_t"]
                 ],
-                "opCodes": ["ADD", "SUB", "MUL", "DIV", "POW", "LOG", "EQ", "NEQ", "LT", "LE", "GT", "GE", "MIN", "MAX", "AND", "OR"]
+                "opCodes": ["ADD", "SUB", "MUL", "DIV", "POW", "LOG", "EQ", "NEQ", "LT", "LE", "GT", "GE", "MIN", "MAX", "AND", "OR", "CONCAT"]
             }
         ]
     },
@@ -1665,7 +1665,7 @@
             ["float", "float"],
             ["int64_t", "int64_t"]
         ],
-        "opCodes": ["SIGN", "SQRT", "EXP", "ABS", "FLOOR", "CEIL", "ROUND"]
+        "opCodes": ["SIGN", "SQRT", "EXP", "ABS", "FLOOR", "CEIL", "ROUND", "UPPERCASE", "LOWERCASE"]
     },
     {
         "kernelTemplate": {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -87,6 +87,7 @@ set(TEST_SOURCES
         runtime/local/kernels/HasSpecialValueTest.cpp
         runtime/local/kernels/InnerJoinTest.cpp
         runtime/local/kernels/IsSymmetricTest.cpp
+        runtime/local/kernels/LikeTest.cpp
         runtime/local/kernels/NumDistinctApproxTest.cpp
         runtime/local/kernels/MatMulTest.cpp
         runtime/local/kernels/OrderTest.cpp

--- a/test/api/cli/expressions/matrix_literal_success_1.daphne
+++ b/test/api/cli/expressions/matrix_literal_success_1.daphne
@@ -12,3 +12,8 @@ checkMatBool = [true,true,false,true];
 print(checkMatBool);
 checkMatBool = reshape(checkMatBool, 2, 2);
 print(checkMatBool);
+
+checkMatString= ["Hello", "", "The answer is", "42"];
+print(checkMatString);
+checkMatString = reshape(checkMatString, 2, 2);
+print(checkMatString);

--- a/test/api/cli/expressions/matrix_literal_success_1.txt
+++ b/test/api/cli/expressions/matrix_literal_success_1.txt
@@ -22,3 +22,11 @@ DenseMatrix(4x1, bool)
 DenseMatrix(2x2, bool)
 1 1
 0 1
+DenseMatrix(4x1, const char*)
+"Hello"
+""
+"The answer is"
+"42"
+DenseMatrix(2x2, const char*)
+"Hello" ""
+"The answer is" "42"

--- a/test/runtime/local/kernels/AggColTest.cpp
+++ b/test/runtime/local/kernels/AggColTest.cpp
@@ -35,7 +35,11 @@ template<class DTRes, class DTArg>
 void checkAggCol(AggOpCode opCode, const DTArg * arg, const DTRes * exp) {
     DTRes * res = nullptr;
     aggCol<DTRes, DTArg>(opCode, res, arg, nullptr);
-    CHECK(*res == *exp);
+    if constexpr(std::is_same_v<DTRes, DenseMatrix<StringScalarType>>)
+        for(size_t val = 0; val < exp->getNumItems(); val++)
+            CHECK(strcmp(res->getValues()[val], exp->getValues()[val]) == 0);
+    else
+        CHECK(*res == *exp);
 }
 
 TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("sum"), TAG_KERNELS, (DATA_TYPES), (VALUE_TYPES)) {
@@ -86,17 +90,19 @@ TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("min"), TAG_KERNELS, (DATA_TYPES), (VALUE_T
         0, 0, 5, 0,
     });
     auto m2exp = genGivenVals<DTRes>(1, {0, 0, 0, 0});
+    auto m3 = genGivenVals<DenseMatrix<const char*>>(3, {
+        "Zambia", "Australia", "UAE", "India",
+        "Portugal", "Germany", "Zimbabwe", "Vatican",
+        "Austria", "Finland", "Canada", "Iceland",
+    });
+    auto m3exp = genGivenVals<DenseMatrix<const char*>>(1, {"Austria", "Australia", "Canada", "Iceland"});
     
     checkAggCol(AggOpCode::MIN, m0, m0exp);
     checkAggCol(AggOpCode::MIN, m1, m1exp);
     checkAggCol(AggOpCode::MIN, m2, m2exp);
-    
-    DataObjectFactory::destroy(m0);
-    DataObjectFactory::destroy(m0exp);
-    DataObjectFactory::destroy(m1);
-    DataObjectFactory::destroy(m1exp);
-    DataObjectFactory::destroy(m2);
-    DataObjectFactory::destroy(m2exp);
+    checkAggCol(AggOpCode::MIN, m3, m3exp);
+
+    DataObjectFactory::destroy(m0, m0exp, m1, m1exp, m2, m2exp, m3, m3exp);
 }
 
 TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("max"), TAG_KERNELS, (DATA_TYPES), (VALUE_TYPES)) {
@@ -121,17 +127,20 @@ TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("max"), TAG_KERNELS, (DATA_TYPES), (VALUE_T
         0, 0, 5, 0,
     });
     auto m2exp = genGivenVals<DTRes>(1, {4, 2, 5, 9});
+
+    auto m3 = genGivenVals<DenseMatrix<const char*>>(3, {
+        "Zambia", "Australia", "UAE", "India",
+        "Portugal", "Germany", "Zimbabwe", "Vatican",
+        "Austria", "Finland", "Canada", "Iceland",
+    });
+    auto m3exp = genGivenVals<DenseMatrix<const char*>>(1, {"Zambia", "Germany", "Zimbabwe", "Vatican"});
     
     checkAggCol(AggOpCode::MAX, m0, m0exp);
     checkAggCol(AggOpCode::MAX, m1, m1exp);
     checkAggCol(AggOpCode::MAX, m2, m2exp);
+    checkAggCol(AggOpCode::MAX, m3, m3exp);
     
-    DataObjectFactory::destroy(m0);
-    DataObjectFactory::destroy(m0exp);
-    DataObjectFactory::destroy(m1);
-    DataObjectFactory::destroy(m1exp);
-    DataObjectFactory::destroy(m2);
-    DataObjectFactory::destroy(m2exp);
+DataObjectFactory::destroy(m0, m0exp, m1, m1exp, m2, m2exp, m3, m3exp);
 }
 
 TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("mean"), TAG_KERNELS, (DATA_TYPES), (int64_t, double)) {

--- a/test/runtime/local/kernels/AggRowTest.cpp
+++ b/test/runtime/local/kernels/AggRowTest.cpp
@@ -35,7 +35,11 @@ template<class DTRes, class DTArg>
 void checkAggRow(AggOpCode opCode, const DTArg * arg, const DTRes * exp) {
     DTRes * res = nullptr;
     aggRow<DTRes, DTArg>(opCode, res, arg, nullptr);
-    CHECK(*res == *exp);
+    if constexpr(std::is_same_v<DTRes, DenseMatrix<StringScalarType>>)
+        for(size_t val = 0; val < exp->getNumItems(); val++)
+            CHECK(strcmp(res->getValues()[val], exp->getValues()[val]) == 0);
+    else
+        CHECK(*res == *exp);
 }
 
 TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("sum"), TAG_KERNELS, (DATA_TYPES), (VALUE_TYPES)) {
@@ -86,17 +90,19 @@ TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("min"), TAG_KERNELS, (DATA_TYPES), (VALUE_T
         0, 0, 5, 0,
     });
     auto m2exp = genGivenVals<DTRes>(3, {0, 0, 0});
+    auto m3 = genGivenVals<DenseMatrix<const char*>>(3, {
+        "Zambia", "Australia", "UAE", "India",
+        "Portugal", "Germany", "Zimbabwe", "Vatican",
+        "Austria", "Finland", "Canada", "Iceland",
+    });
+    auto m3exp = genGivenVals<DenseMatrix<const char*>>(1, {"Australia", "Germany", "Austria"});
     
     checkAggRow(AggOpCode::MIN, m0, m0exp);
     checkAggRow(AggOpCode::MIN, m1, m1exp);
     checkAggRow(AggOpCode::MIN, m2, m2exp);
-    
-    DataObjectFactory::destroy(m0);
-    DataObjectFactory::destroy(m0exp);
-    DataObjectFactory::destroy(m1);
-    DataObjectFactory::destroy(m1exp);
-    DataObjectFactory::destroy(m2);
-    DataObjectFactory::destroy(m2exp);
+    checkAggRow(AggOpCode::MIN, m3, m3exp);
+
+    DataObjectFactory::destroy(m0, m0exp, m1, m1exp, m2, m2exp, m3, m3exp);
 }
 
 TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("max"), TAG_KERNELS, (DATA_TYPES), (VALUE_TYPES)) {
@@ -122,16 +128,20 @@ TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("max"), TAG_KERNELS, (DATA_TYPES), (VALUE_T
     });
     auto m2exp = genGivenVals<DTRes>(3, {9, 2, 5});
     
+    auto m3 = genGivenVals<DenseMatrix<const char*>>(3, {
+        "Zambia", "Australia", "UAE", "India",
+        "Portugal", "Germany", "Zimbabwe", "Vatican",
+        "Austria", "Finland", "Canada", "Iceland",
+    });
+    auto m3exp = genGivenVals<DenseMatrix<const char*>>(1, {"Zambia", "Zimbabwe", "Iceland"});
+    
+
     checkAggRow(AggOpCode::MAX, m0, m0exp);
     checkAggRow(AggOpCode::MAX, m1, m1exp);
     checkAggRow(AggOpCode::MAX, m2, m2exp);
+    checkAggRow(AggOpCode::MAX, m3, m3exp);
     
-    DataObjectFactory::destroy(m0);
-    DataObjectFactory::destroy(m0exp);
-    DataObjectFactory::destroy(m1);
-    DataObjectFactory::destroy(m1exp);
-    DataObjectFactory::destroy(m2);
-    DataObjectFactory::destroy(m2exp);
+    DataObjectFactory::destroy(m0, m0exp, m1, m1exp, m2, m2exp, m3, m3exp);
 }
 
 TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("idxmin"), TAG_KERNELS, (DenseMatrix), (VALUE_TYPES)) {
@@ -156,12 +166,19 @@ TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("idxmin"), TAG_KERNELS, (DenseMatrix), (VAL
         0, 0, 5, 0,
     });
     auto m2exp = genGivenVals<DTRes>(3, {1, 0, 0});
+    auto m3 = genGivenVals<DenseMatrix<const char*>>(3, {
+        "Zambia", "Australia", "UAE", "India",
+        "Portugal", "Germany", "Zimbabwe", "Vatican",
+        "Austria", "Finland", "Canada", "Iceland",
+    });
+    auto m3exp = genGivenVals<DenseMatrix<int>>(3, {1, 1, 0});
     
     checkAggRow(AggOpCode::IDXMIN, m0, m0exp);
     checkAggRow(AggOpCode::IDXMIN, m1, m1exp);
     checkAggRow(AggOpCode::IDXMIN, m2, m2exp);
-    
-    DataObjectFactory::destroy(m0, m0exp, m1, m1exp, m2, m2exp);
+    checkAggRow(AggOpCode::IDXMIN, m3, m3exp);
+
+    DataObjectFactory::destroy(m0, m0exp, m1, m1exp, m2, m2exp, m3, m3exp);
 }
 
 TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("idxmax"), TAG_KERNELS, (DenseMatrix), (VALUE_TYPES)) {

--- a/test/runtime/local/kernels/EwBinaryMatTest.cpp
+++ b/test/runtime/local/kernels/EwBinaryMatTest.cpp
@@ -27,7 +27,6 @@
 #include <vector>
 
 #include <cstdint>
-
 #define TEST_NAME(opName) "EwBinaryMat (" opName ")"
 #define DATA_TYPES DenseMatrix, CSRMatrix
 #define VALUE_TYPES double, uint32_t
@@ -37,6 +36,20 @@ void checkEwBinaryMat(BinaryOpCode opCode, const DT * lhs, const DT * rhs, const
     DT * res = nullptr;
     ewBinaryMat<DT, DT, DT>(opCode, res, lhs, rhs, nullptr);
     CHECK(*res == *exp);
+}
+
+template<typename VTRes>
+void checkEwBinaryStrMat(BinaryOpCode opCode, const DenseMatrix<StringScalarType> * lhs, 
+                        const DenseMatrix<StringScalarType> * rhs, const DenseMatrix<VTRes> * exp) {
+    DenseMatrix<VTRes> * res = nullptr;
+    ewBinaryMat<DenseMatrix<VTRes>, DenseMatrix<StringScalarType>, DenseMatrix<StringScalarType>>(opCode, res, lhs, rhs, nullptr);
+    if constexpr(std::is_same_v<VTRes, StringScalarType>){
+        for(size_t r = 0; r < exp->getNumRows(); r++)
+            for(size_t c = 0; c < exp->getNumCols(); c++)
+                CHECK(strcmp(res->get(r,c), exp->get(r,c)) == 0);
+    }
+    else
+        CHECK(*res == *exp);
 }
 
 template<class SparseDT, class DT>
@@ -221,12 +234,18 @@ TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("eq"), TAG_KERNELS, (DenseMatrix), (VALUE_T
     auto m1 = genGivenVals<DT>(2, {1, 2, 3,  4, 5, 6,});
     auto m2 = genGivenVals<DT>(2, {1, 0, 3,  4, 4, 9,});
     auto m3 = genGivenVals<DT>(2, {1, 0, 1,  1, 0, 0,});
-    
     checkEwBinaryMat(BinaryOpCode::EQ, m1, m2, m3);
-    
     DataObjectFactory::destroy(m1);
     DataObjectFactory::destroy(m2);
     DataObjectFactory::destroy(m3);
+
+    auto m4 = genGivenVals<DenseMatrix<const char*>>(2, {"12", "23", "34",  "90", "as", "triple",});
+    auto m5 = genGivenVals<DenseMatrix<const char*>>(2, {"121", "23", "4",  "90", "as", "double",});
+    auto m6 = genGivenVals<DenseMatrix<int>>(2, {0, 1, 0,  1, 1, 0,});
+    checkEwBinaryStrMat(BinaryOpCode::EQ, m4, m5, m6);
+    DataObjectFactory::destroy(m4);
+    DataObjectFactory::destroy(m5);
+    DataObjectFactory::destroy(m6);
 }
 
 TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("neq"), TAG_KERNELS, (DenseMatrix), (VALUE_TYPES)) {
@@ -241,6 +260,14 @@ TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("neq"), TAG_KERNELS, (DenseMatrix), (VALUE_
     DataObjectFactory::destroy(m1);
     DataObjectFactory::destroy(m2);
     DataObjectFactory::destroy(m3);
+
+    auto m4 = genGivenVals<DenseMatrix<const char*>>(2, {"12", "23", "34",  "90", "as", "triple",});
+    auto m5 = genGivenVals<DenseMatrix<const char*>>(2, {"121", "23", "4",  "90", "as", "double",});
+    auto m6 = genGivenVals<DenseMatrix<int>>(2, {1, 0, 1,  0, 0, 1,});
+    checkEwBinaryStrMat(BinaryOpCode::NEQ, m4, m5, m6);
+    DataObjectFactory::destroy(m4);
+    DataObjectFactory::destroy(m5);
+    DataObjectFactory::destroy(m6);
 }
 
 TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("lt"), TAG_KERNELS, (DenseMatrix), (VALUE_TYPES)) {
@@ -255,6 +282,14 @@ TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("lt"), TAG_KERNELS, (DenseMatrix), (VALUE_T
     DataObjectFactory::destroy(m1);
     DataObjectFactory::destroy(m2);
     DataObjectFactory::destroy(m3);
+
+    auto m4 = genGivenVals<DenseMatrix<const char*>>(2, {"12", "23", "34",  "90", "as", "triple",});
+    auto m5 = genGivenVals<DenseMatrix<const char*>>(2, {"121", "23", "4",  "90", "as", "double",});
+    auto m6 = genGivenVals<DenseMatrix<int>>(2, {1, 0, 1,  0, 0, 0,});
+    checkEwBinaryStrMat(BinaryOpCode::LT, m4, m5, m6);
+    DataObjectFactory::destroy(m4);
+    DataObjectFactory::destroy(m5);
+    DataObjectFactory::destroy(m6);
 }
 
 TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("le"), TAG_KERNELS, (DenseMatrix), (VALUE_TYPES)) {
@@ -269,6 +304,14 @@ TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("le"), TAG_KERNELS, (DenseMatrix), (VALUE_T
     DataObjectFactory::destroy(m1);
     DataObjectFactory::destroy(m2);
     DataObjectFactory::destroy(m3);
+
+    auto m4 = genGivenVals<DenseMatrix<const char*>>(2, {"12", "23", "34",  "90", "as", "triple",});
+    auto m5 = genGivenVals<DenseMatrix<const char*>>(2, {"121", "23", "4",  "90", "as", "double",});
+    auto m6 = genGivenVals<DenseMatrix<int>>(2, {1, 1, 1,  1, 1, 0,});
+    checkEwBinaryStrMat(BinaryOpCode::LE, m4, m5, m6);
+    DataObjectFactory::destroy(m4);
+    DataObjectFactory::destroy(m5);
+    DataObjectFactory::destroy(m6);
 }
 
 TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("gt"), TAG_KERNELS, (DenseMatrix), (VALUE_TYPES)) {
@@ -283,6 +326,14 @@ TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("gt"), TAG_KERNELS, (DenseMatrix), (VALUE_T
     DataObjectFactory::destroy(m1);
     DataObjectFactory::destroy(m2);
     DataObjectFactory::destroy(m3);
+
+    auto m4 = genGivenVals<DenseMatrix<const char*>>(2, {"12", "23", "34",  "90", "as", "triple",});
+    auto m5 = genGivenVals<DenseMatrix<const char*>>(2, {"121", "23", "4",  "90", "as", "double",});
+    auto m6 = genGivenVals<DenseMatrix<int>>(2, {0, 0, 0,  0, 0, 1,});
+    checkEwBinaryStrMat(BinaryOpCode::GT, m4, m5, m6);
+    DataObjectFactory::destroy(m4);
+    DataObjectFactory::destroy(m5);
+    DataObjectFactory::destroy(m6);
 }
 
 TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("ge"), TAG_KERNELS, (DenseMatrix), (VALUE_TYPES)) {
@@ -297,6 +348,14 @@ TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("ge"), TAG_KERNELS, (DenseMatrix), (VALUE_T
     DataObjectFactory::destroy(m1);
     DataObjectFactory::destroy(m2);
     DataObjectFactory::destroy(m3);
+
+    auto m4 = genGivenVals<DenseMatrix<const char*>>(2, {"12", "23", "34",  "90", "as", "triple",});
+    auto m5 = genGivenVals<DenseMatrix<const char*>>(2, {"121", "23", "4",  "90", "as", "double",});
+    auto m6 = genGivenVals<DenseMatrix<int>>(2, {0, 1, 0,  1, 1, 1,});
+    checkEwBinaryStrMat(BinaryOpCode::GE, m4, m5, m6);
+    DataObjectFactory::destroy(m4);
+    DataObjectFactory::destroy(m5);
+    DataObjectFactory::destroy(m6);
 }
 
 // ****************************************************************************
@@ -315,6 +374,14 @@ TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("min"), TAG_KERNELS, (DenseMatrix), (VALUE_
     DataObjectFactory::destroy(m1);
     DataObjectFactory::destroy(m2);
     DataObjectFactory::destroy(m3);
+
+    auto m4 = genGivenVals<DenseMatrix<const char*>>(2, {"12", "23", "34",  "90", "as", "triple",});
+    auto m5 = genGivenVals<DenseMatrix<const char*>>(2, {"121", "23", "4",  "90", "as", "double",});
+    auto m6 = genGivenVals<DenseMatrix<const char*>>(2, {"12", "23", "34",  "90", "as", "double",});
+    checkEwBinaryStrMat(BinaryOpCode::MIN, m4, m5, m6);
+    DataObjectFactory::destroy(m4);
+    DataObjectFactory::destroy(m5);
+    DataObjectFactory::destroy(m6);
 }
 
 TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("max"), TAG_KERNELS, (DenseMatrix), (VALUE_TYPES)) {
@@ -329,6 +396,14 @@ TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("max"), TAG_KERNELS, (DenseMatrix), (VALUE_
     DataObjectFactory::destroy(m1);
     DataObjectFactory::destroy(m2);
     DataObjectFactory::destroy(m3);
+
+    auto m4 = genGivenVals<DenseMatrix<const char*>>(2, {"12", "23", "34",  "90", "as", "triple",});
+    auto m5 = genGivenVals<DenseMatrix<const char*>>(2, {"121", "23", "4",  "90", "as", "double",});
+    auto m6 = genGivenVals<DenseMatrix<const char*>>(2, {"121", "23", "4",  "90", "as", "triple",});
+    checkEwBinaryStrMat(BinaryOpCode::MAX, m4, m5, m6);
+    DataObjectFactory::destroy(m4);
+    DataObjectFactory::destroy(m5);
+    DataObjectFactory::destroy(m6);
 }
 
 // ****************************************************************************
@@ -359,6 +434,21 @@ TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("or"), TAG_KERNELS, (DenseMatrix), (VALUE_T
     checkEwBinaryMat(BinaryOpCode::OR, m1, m2, m3);
     
     DataObjectFactory::destroy(m1, m2, m3);
+}
+
+
+// ****************************************************************************
+// String-only
+// ****************************************************************************
+
+TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("concat"), TAG_KERNELS, (DenseMatrix), (VALUE_TYPES)) {
+    auto m1 = genGivenVals<DenseMatrix<const char*>>(2, {"12", "23", "34",  "90", "as", "triple",});
+    auto m2 = genGivenVals<DenseMatrix<const char*>>(2, {"121", "23", "4",  "90", "as", "double",});
+    auto m3 = genGivenVals<DenseMatrix<const char*>>(2, {"12121", "2323", "344",  "9090", "asas", "tripledouble",});
+    checkEwBinaryStrMat(BinaryOpCode::CONCAT, m1, m2, m3);
+    DataObjectFactory::destroy(m1);
+    DataObjectFactory::destroy(m2);
+    DataObjectFactory::destroy(m3);
 }
 
 // ****************************************************************************

--- a/test/runtime/local/kernels/EwBinaryMatTest.cpp
+++ b/test/runtime/local/kernels/EwBinaryMatTest.cpp
@@ -31,23 +31,13 @@
 #define DATA_TYPES DenseMatrix, CSRMatrix
 #define VALUE_TYPES double, uint32_t
 
-template<class DT>
-void checkEwBinaryMat(BinaryOpCode opCode, const DT * lhs, const DT * rhs, const DT * exp) {
-    DT * res = nullptr;
-    ewBinaryMat<DT, DT, DT>(opCode, res, lhs, rhs, nullptr);
-    CHECK(*res == *exp);
-}
-
-template<typename VTRes>
-void checkEwBinaryStrMat(BinaryOpCode opCode, const DenseMatrix<StringScalarType> * lhs, 
-                        const DenseMatrix<StringScalarType> * rhs, const DenseMatrix<VTRes> * exp) {
-    DenseMatrix<VTRes> * res = nullptr;
-    ewBinaryMat<DenseMatrix<VTRes>, DenseMatrix<StringScalarType>, DenseMatrix<StringScalarType>>(opCode, res, lhs, rhs, nullptr);
-    if constexpr(std::is_same_v<VTRes, StringScalarType>){
-        for(size_t r = 0; r < exp->getNumRows(); r++)
-            for(size_t c = 0; c < exp->getNumCols(); c++)
-                CHECK(strcmp(res->get(r,c), exp->get(r,c)) == 0);
-    }
+template<class DTRes, class DTLhs, class DTRhs>
+void checkEwBinaryMat(BinaryOpCode opCode, const DTLhs * lhs, const DTRhs * rhs, const DTRes * exp) {
+    DTRes * res = nullptr;
+    ewBinaryMat<DTRes, DTLhs, DTRhs>(opCode, res, lhs, rhs, nullptr);
+    if constexpr(std::is_same_v<DTRes, DenseMatrix<StringScalarType>>)
+        for(size_t val = 0; val < exp->getNumItems(); val++)
+            CHECK(strcmp(res->getValues()[val], exp->getValues()[val]) == 0);
     else
         CHECK(*res == *exp);
 }
@@ -242,7 +232,7 @@ TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("eq"), TAG_KERNELS, (DenseMatrix), (VALUE_T
     auto m4 = genGivenVals<DenseMatrix<const char*>>(2, {"12", "23", "34",  "90", "as", "triple",});
     auto m5 = genGivenVals<DenseMatrix<const char*>>(2, {"121", "23", "4",  "90", "as", "double",});
     auto m6 = genGivenVals<DenseMatrix<int>>(2, {0, 1, 0,  1, 1, 0,});
-    checkEwBinaryStrMat(BinaryOpCode::EQ, m4, m5, m6);
+    checkEwBinaryMat(BinaryOpCode::EQ, m4, m5, m6);
     DataObjectFactory::destroy(m4);
     DataObjectFactory::destroy(m5);
     DataObjectFactory::destroy(m6);
@@ -264,7 +254,7 @@ TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("neq"), TAG_KERNELS, (DenseMatrix), (VALUE_
     auto m4 = genGivenVals<DenseMatrix<const char*>>(2, {"12", "23", "34",  "90", "as", "triple",});
     auto m5 = genGivenVals<DenseMatrix<const char*>>(2, {"121", "23", "4",  "90", "as", "double",});
     auto m6 = genGivenVals<DenseMatrix<int>>(2, {1, 0, 1,  0, 0, 1,});
-    checkEwBinaryStrMat(BinaryOpCode::NEQ, m4, m5, m6);
+    checkEwBinaryMat(BinaryOpCode::NEQ, m4, m5, m6);
     DataObjectFactory::destroy(m4);
     DataObjectFactory::destroy(m5);
     DataObjectFactory::destroy(m6);
@@ -286,7 +276,7 @@ TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("lt"), TAG_KERNELS, (DenseMatrix), (VALUE_T
     auto m4 = genGivenVals<DenseMatrix<const char*>>(2, {"12", "23", "34",  "90", "as", "triple",});
     auto m5 = genGivenVals<DenseMatrix<const char*>>(2, {"121", "23", "4",  "90", "as", "double",});
     auto m6 = genGivenVals<DenseMatrix<int>>(2, {1, 0, 1,  0, 0, 0,});
-    checkEwBinaryStrMat(BinaryOpCode::LT, m4, m5, m6);
+    checkEwBinaryMat(BinaryOpCode::LT, m4, m5, m6);
     DataObjectFactory::destroy(m4);
     DataObjectFactory::destroy(m5);
     DataObjectFactory::destroy(m6);
@@ -308,7 +298,7 @@ TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("le"), TAG_KERNELS, (DenseMatrix), (VALUE_T
     auto m4 = genGivenVals<DenseMatrix<const char*>>(2, {"12", "23", "34",  "90", "as", "triple",});
     auto m5 = genGivenVals<DenseMatrix<const char*>>(2, {"121", "23", "4",  "90", "as", "double",});
     auto m6 = genGivenVals<DenseMatrix<int>>(2, {1, 1, 1,  1, 1, 0,});
-    checkEwBinaryStrMat(BinaryOpCode::LE, m4, m5, m6);
+    checkEwBinaryMat(BinaryOpCode::LE, m4, m5, m6);
     DataObjectFactory::destroy(m4);
     DataObjectFactory::destroy(m5);
     DataObjectFactory::destroy(m6);
@@ -330,7 +320,7 @@ TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("gt"), TAG_KERNELS, (DenseMatrix), (VALUE_T
     auto m4 = genGivenVals<DenseMatrix<const char*>>(2, {"12", "23", "34",  "90", "as", "triple",});
     auto m5 = genGivenVals<DenseMatrix<const char*>>(2, {"121", "23", "4",  "90", "as", "double",});
     auto m6 = genGivenVals<DenseMatrix<int>>(2, {0, 0, 0,  0, 0, 1,});
-    checkEwBinaryStrMat(BinaryOpCode::GT, m4, m5, m6);
+    checkEwBinaryMat(BinaryOpCode::GT, m4, m5, m6);
     DataObjectFactory::destroy(m4);
     DataObjectFactory::destroy(m5);
     DataObjectFactory::destroy(m6);
@@ -352,7 +342,7 @@ TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("ge"), TAG_KERNELS, (DenseMatrix), (VALUE_T
     auto m4 = genGivenVals<DenseMatrix<const char*>>(2, {"12", "23", "34",  "90", "as", "triple",});
     auto m5 = genGivenVals<DenseMatrix<const char*>>(2, {"121", "23", "4",  "90", "as", "double",});
     auto m6 = genGivenVals<DenseMatrix<int>>(2, {0, 1, 0,  1, 1, 1,});
-    checkEwBinaryStrMat(BinaryOpCode::GE, m4, m5, m6);
+    checkEwBinaryMat(BinaryOpCode::GE, m4, m5, m6);
     DataObjectFactory::destroy(m4);
     DataObjectFactory::destroy(m5);
     DataObjectFactory::destroy(m6);
@@ -378,7 +368,7 @@ TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("min"), TAG_KERNELS, (DenseMatrix), (VALUE_
     auto m4 = genGivenVals<DenseMatrix<const char*>>(2, {"12", "23", "34",  "90", "as", "triple",});
     auto m5 = genGivenVals<DenseMatrix<const char*>>(2, {"121", "23", "4",  "90", "as", "double",});
     auto m6 = genGivenVals<DenseMatrix<const char*>>(2, {"12", "23", "34",  "90", "as", "double",});
-    checkEwBinaryStrMat(BinaryOpCode::MIN, m4, m5, m6);
+    checkEwBinaryMat(BinaryOpCode::MIN, m4, m5, m6);
     DataObjectFactory::destroy(m4);
     DataObjectFactory::destroy(m5);
     DataObjectFactory::destroy(m6);
@@ -400,7 +390,7 @@ TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("max"), TAG_KERNELS, (DenseMatrix), (VALUE_
     auto m4 = genGivenVals<DenseMatrix<const char*>>(2, {"12", "23", "34",  "90", "as", "triple",});
     auto m5 = genGivenVals<DenseMatrix<const char*>>(2, {"121", "23", "4",  "90", "as", "double",});
     auto m6 = genGivenVals<DenseMatrix<const char*>>(2, {"121", "23", "4",  "90", "as", "triple",});
-    checkEwBinaryStrMat(BinaryOpCode::MAX, m4, m5, m6);
+    checkEwBinaryMat(BinaryOpCode::MAX, m4, m5, m6);
     DataObjectFactory::destroy(m4);
     DataObjectFactory::destroy(m5);
     DataObjectFactory::destroy(m6);
@@ -445,7 +435,7 @@ TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("concat"), TAG_KERNELS, (DenseMatrix), (VAL
     auto m1 = genGivenVals<DenseMatrix<const char*>>(2, {"12", "23", "34",  "90", "as", "triple",});
     auto m2 = genGivenVals<DenseMatrix<const char*>>(2, {"121", "23", "4",  "90", "as", "double",});
     auto m3 = genGivenVals<DenseMatrix<const char*>>(2, {"12121", "2323", "344",  "9090", "asas", "tripledouble",});
-    checkEwBinaryStrMat(BinaryOpCode::CONCAT, m1, m2, m3);
+    checkEwBinaryMat(BinaryOpCode::CONCAT, m1, m2, m3);
     DataObjectFactory::destroy(m1);
     DataObjectFactory::destroy(m2);
     DataObjectFactory::destroy(m3);

--- a/test/runtime/local/kernels/EwBinaryScaTest.cpp
+++ b/test/runtime/local/kernels/EwBinaryScaTest.cpp
@@ -27,8 +27,13 @@
 
 template<BinaryOpCode opCode, typename VT>
 void checkEwBinarySca(VT lhs, VT rhs, VT exp) {
-    CHECK(EwBinarySca<opCode, VT, VT, VT>::apply(lhs, rhs, nullptr) == exp);
-    CHECK(ewBinarySca<VT, VT, VT>(opCode, lhs, rhs, nullptr) == exp);
+    if constexpr(std::is_same_v<VT, StringScalarType>){
+        CHECK(strcmp(EwBinarySca<opCode, VT, VT, VT>::apply(lhs, rhs, nullptr), exp) == 0);
+        CHECK(strcmp(ewBinarySca<VT, VT, VT>(opCode, lhs, rhs, nullptr), exp) == 0);
+    }else{
+        CHECK(EwBinarySca<opCode, VT, VT, VT>::apply(lhs, rhs, nullptr) == exp);
+        CHECK(ewBinarySca<VT, VT, VT>(opCode, lhs, rhs, nullptr) == exp);
+    }
 }
 
 // ****************************************************************************
@@ -149,6 +154,17 @@ TEMPLATE_TEST_CASE(TEST_NAME("or"), TAG_KERNELS, VALUE_TYPES) {
     checkEwBinarySca<BinaryOpCode::OR, VT>( 0, -2, 1);
     checkEwBinarySca<BinaryOpCode::OR, VT>(-2,  0, 1);
     checkEwBinarySca<BinaryOpCode::OR, VT>(-2, -2, 1);
+}
+
+// ****************************************************************************
+// String
+// ****************************************************************************
+TEMPLATE_TEST_CASE(TEST_NAME("CONCAT"), TAG_KERNELS, VALUE_TYPES) {
+    using VT = const char* ;
+    VT lhs = "Hello";
+    VT rhs = "World!";
+    VT exp = "HelloWorld!";
+    checkEwBinarySca<BinaryOpCode::CONCAT, VT>(lhs, rhs, exp);
 }
 
 // ****************************************************************************

--- a/test/runtime/local/kernels/EwBinaryScaTest.cpp
+++ b/test/runtime/local/kernels/EwBinaryScaTest.cpp
@@ -25,39 +25,38 @@
 #define TEST_NAME(opName) "EwBinarySca (" opName ")"
 #define VALUE_TYPES double, uint32_t
 
-template<BinaryOpCode opCode, typename VT>
-void checkEwBinarySca(VT lhs, VT rhs, VT exp) {
-    if constexpr(std::is_same_v<VT, StringScalarType>){
-        CHECK(strcmp(EwBinarySca<opCode, VT, VT, VT>::apply(lhs, rhs, nullptr), exp) == 0);
-        CHECK(strcmp(ewBinarySca<VT, VT, VT>(opCode, lhs, rhs, nullptr), exp) == 0);
+template<BinaryOpCode opCode, typename VTArg, typename VTRes>
+void checkEwBinarySca(VTArg lhs, VTArg rhs, VTRes exp) {
+    if constexpr(std::is_same_v<VTRes, StringScalarType>){
+        CHECK(strcmp(EwBinarySca<opCode, VTRes, VTArg, VTArg>::apply(lhs, rhs, nullptr), exp) == 0);
+        CHECK(strcmp(ewBinarySca<VTRes, VTArg, VTArg>(opCode, lhs, rhs, nullptr), exp) == 0);
     }else{
-        CHECK(EwBinarySca<opCode, VT, VT, VT>::apply(lhs, rhs, nullptr) == exp);
-        CHECK(ewBinarySca<VT, VT, VT>(opCode, lhs, rhs, nullptr) == exp);
+        CHECK(EwBinarySca<opCode, VTRes, VTArg, VTArg>::apply(lhs, rhs, nullptr) == exp);
+        CHECK(ewBinarySca<VTRes, VTArg, VTArg>(opCode, lhs, rhs, nullptr) == exp);
     }
 }
-
 // ****************************************************************************
 // Arithmetic
 // ****************************************************************************
 
 TEMPLATE_TEST_CASE(TEST_NAME("add"), TAG_KERNELS, VALUE_TYPES) {
     using VT = TestType;
-    checkEwBinarySca<BinaryOpCode::ADD, VT>(0, 0, 0);
-    checkEwBinarySca<BinaryOpCode::ADD, VT>(0, 1, 1);
-    checkEwBinarySca<BinaryOpCode::ADD, VT>(1, 2, 3);
+    checkEwBinarySca<BinaryOpCode::ADD, VT, VT>(0, 0, 0);
+    checkEwBinarySca<BinaryOpCode::ADD, VT, VT>(0, 1, 1);
+    checkEwBinarySca<BinaryOpCode::ADD, VT, VT>(1, 2, 3);
 }
 
 TEMPLATE_TEST_CASE(TEST_NAME("mul"), TAG_KERNELS, VALUE_TYPES) {
     using VT = TestType;
-    checkEwBinarySca<BinaryOpCode::MUL, VT>(0, 0, 0);
-    checkEwBinarySca<BinaryOpCode::MUL, VT>(0, 1, 0);
-    checkEwBinarySca<BinaryOpCode::MUL, VT>(2, 3, 6);
+    checkEwBinarySca<BinaryOpCode::MUL, VT, VT>(0, 0, 0);
+    checkEwBinarySca<BinaryOpCode::MUL, VT, VT>(0, 1, 0);
+    checkEwBinarySca<BinaryOpCode::MUL, VT, VT>(2, 3, 6);
 }
 
 TEMPLATE_TEST_CASE(TEST_NAME("div"), TAG_KERNELS, VALUE_TYPES) {
     using VT = TestType;
-    checkEwBinarySca<BinaryOpCode::DIV, VT>(0, 3, 0);
-    checkEwBinarySca<BinaryOpCode::DIV, VT>(6, 3, 2);
+    checkEwBinarySca<BinaryOpCode::DIV, VT, VT>(0, 3, 0);
+    checkEwBinarySca<BinaryOpCode::DIV, VT, VT>(6, 3, 2);
 }
 
 // ****************************************************************************
@@ -66,44 +65,56 @@ TEMPLATE_TEST_CASE(TEST_NAME("div"), TAG_KERNELS, VALUE_TYPES) {
 
 TEMPLATE_TEST_CASE(TEST_NAME("eq"), TAG_KERNELS, VALUE_TYPES) {
     using VT = TestType;
-    checkEwBinarySca<BinaryOpCode::EQ, VT>(0, 0, 1);
-    checkEwBinarySca<BinaryOpCode::EQ, VT>(3, 3, 1);
-    checkEwBinarySca<BinaryOpCode::EQ, VT>(3, 5, 0);
+    checkEwBinarySca<BinaryOpCode::EQ, VT, VT>(0, 0, 1);
+    checkEwBinarySca<BinaryOpCode::EQ, VT, VT>(3, 3, 1);
+    checkEwBinarySca<BinaryOpCode::EQ, VT, VT>(3, 5, 0);
+    checkEwBinarySca<BinaryOpCode::EQ, const char*, int>("hi", "hi", 1);
+    checkEwBinarySca<BinaryOpCode::EQ, const char*, int>("hi", "bye", 0);
 }
 
 TEMPLATE_TEST_CASE(TEST_NAME("neq"), TAG_KERNELS, VALUE_TYPES) {
     using VT = TestType;
-    checkEwBinarySca<BinaryOpCode::NEQ, VT>(0, 0, 0);
-    checkEwBinarySca<BinaryOpCode::NEQ, VT>(3, 3, 0);
-    checkEwBinarySca<BinaryOpCode::NEQ, VT>(3, 5, 1);
+    checkEwBinarySca<BinaryOpCode::NEQ, VT, VT>(0, 0, 0);
+    checkEwBinarySca<BinaryOpCode::NEQ, VT, VT>(3, 3, 0);
+    checkEwBinarySca<BinaryOpCode::NEQ, VT, VT>(3, 5, 1);
+    checkEwBinarySca<BinaryOpCode::NEQ, const char*, int>("hi", "hi", 0);
+    checkEwBinarySca<BinaryOpCode::NEQ, const char*, int>("hi", "bye", 1);
 }
 
 TEMPLATE_TEST_CASE(TEST_NAME("lt"), TAG_KERNELS, VALUE_TYPES) {
     using VT = TestType;
-    checkEwBinarySca<BinaryOpCode::LT, VT>(1, 1, 0);
-    checkEwBinarySca<BinaryOpCode::LT, VT>(1, 3, 1);
-    checkEwBinarySca<BinaryOpCode::LT, VT>(4, 2, 0);
+    checkEwBinarySca<BinaryOpCode::LT, VT, VT>(1, 1, 0);
+    checkEwBinarySca<BinaryOpCode::LT, VT, VT>(1, 3, 1);
+    checkEwBinarySca<BinaryOpCode::LT, VT, VT>(4, 2, 0);
+    checkEwBinarySca<BinaryOpCode::LT, const char*, int>("wow", "cool", 0);
+    checkEwBinarySca<BinaryOpCode::LT, const char*, int>("bye", "hi", 1);
 }
 
 TEMPLATE_TEST_CASE(TEST_NAME("le"), TAG_KERNELS, VALUE_TYPES) {
     using VT = TestType;
-    checkEwBinarySca<BinaryOpCode::LE, VT>(1, 1, 1);
-    checkEwBinarySca<BinaryOpCode::LE, VT>(1, 3, 1);
-    checkEwBinarySca<BinaryOpCode::LE, VT>(4, 2, 0);
+    checkEwBinarySca<BinaryOpCode::LE, VT, VT>(1, 1, 1);
+    checkEwBinarySca<BinaryOpCode::LE, VT, VT>(1, 3, 1);
+    checkEwBinarySca<BinaryOpCode::LE, VT, VT>(4, 2, 0);
+    checkEwBinarySca<BinaryOpCode::LE, const char*, int>("wow", "what", 0);
+    checkEwBinarySca<BinaryOpCode::LE, const char*, int>("bye", "hi", 1);
 }
 
 TEMPLATE_TEST_CASE(TEST_NAME("gt"), TAG_KERNELS, VALUE_TYPES) {
     using VT = TestType;
-    checkEwBinarySca<BinaryOpCode::GT, VT>(1, 1, 0);
-    checkEwBinarySca<BinaryOpCode::GT, VT>(1, 3, 0);
-    checkEwBinarySca<BinaryOpCode::GT, VT>(4, 2, 1);
+    checkEwBinarySca<BinaryOpCode::GT, VT, VT>(1, 1, 0);
+    checkEwBinarySca<BinaryOpCode::GT, VT, VT>(1, 3, 0);
+    checkEwBinarySca<BinaryOpCode::GT, VT, VT>(4, 2, 1);
+    checkEwBinarySca<BinaryOpCode::GT, const char*, int>("zebra", "what", 1);
+    checkEwBinarySca<BinaryOpCode::GT, const char*, int>("bye", "hi", 0);
 }
 
 TEMPLATE_TEST_CASE(TEST_NAME("ge"), TAG_KERNELS, VALUE_TYPES) {
     using VT = TestType;
-    checkEwBinarySca<BinaryOpCode::GE, VT>(1, 1, 1);
-    checkEwBinarySca<BinaryOpCode::GE, VT>(1, 3, 0);
-    checkEwBinarySca<BinaryOpCode::GE, VT>(4, 2, 1);
+    checkEwBinarySca<BinaryOpCode::GE, VT, VT>(1, 1, 1);
+    checkEwBinarySca<BinaryOpCode::GE, VT, VT>(1, 3, 0);
+    checkEwBinarySca<BinaryOpCode::GE, VT, VT>(4, 2, 1);
+    checkEwBinarySca<BinaryOpCode::GE, const char*, int>("zebra", "zebra", 1);
+    checkEwBinarySca<BinaryOpCode::GE, const char*, int>("bye", "hi", 0);
 }
 
 // ****************************************************************************
@@ -112,16 +123,18 @@ TEMPLATE_TEST_CASE(TEST_NAME("ge"), TAG_KERNELS, VALUE_TYPES) {
 
 TEMPLATE_TEST_CASE(TEST_NAME("min"), TAG_KERNELS, VALUE_TYPES) {
     using VT = TestType;
-    checkEwBinarySca<BinaryOpCode::MIN, VT>(2, 2, 2);
-    checkEwBinarySca<BinaryOpCode::MIN, VT>(2, 3, 2);
-    checkEwBinarySca<BinaryOpCode::MIN, VT>(3, 0, 0);
+    checkEwBinarySca<BinaryOpCode::MIN, VT, VT>(2, 2, 2);
+    checkEwBinarySca<BinaryOpCode::MIN, VT, VT>(2, 3, 2);
+    checkEwBinarySca<BinaryOpCode::MIN, VT, VT>(3, 0, 0);
+    checkEwBinarySca<BinaryOpCode::MIN, const char*, const char*>("Antony", "John", "Antony");
 }
 
 TEMPLATE_TEST_CASE(TEST_NAME("max"), TAG_KERNELS, VALUE_TYPES) {
     using VT = TestType;
-    checkEwBinarySca<BinaryOpCode::MAX, VT>(2, 2, 2);
-    checkEwBinarySca<BinaryOpCode::MAX, VT>(2, 3, 3);
-    checkEwBinarySca<BinaryOpCode::MAX, VT>(3, 0, 3);
+    checkEwBinarySca<BinaryOpCode::MAX, VT, VT>(2, 2, 2);
+    checkEwBinarySca<BinaryOpCode::MAX, VT, VT>(2, 3, 3);
+    checkEwBinarySca<BinaryOpCode::MAX, VT, VT>(3, 0, 3);
+    checkEwBinarySca<BinaryOpCode::MAX, const char*, const char*>("Antony", "John", "John");
 }
 
 // ****************************************************************************
@@ -130,30 +143,30 @@ TEMPLATE_TEST_CASE(TEST_NAME("max"), TAG_KERNELS, VALUE_TYPES) {
 
 TEMPLATE_TEST_CASE(TEST_NAME("and"), TAG_KERNELS, VALUE_TYPES) {
     using VT = TestType;
-    checkEwBinarySca<BinaryOpCode::AND, VT>( 0,  0, 0);
-    checkEwBinarySca<BinaryOpCode::AND, VT>( 0,  1, 0);
-    checkEwBinarySca<BinaryOpCode::AND, VT>( 1,  0, 0);
-    checkEwBinarySca<BinaryOpCode::AND, VT>( 1,  1, 1);
-    checkEwBinarySca<BinaryOpCode::AND, VT>( 0,  2, 0);
-    checkEwBinarySca<BinaryOpCode::AND, VT>( 2,  0, 0);
-    checkEwBinarySca<BinaryOpCode::AND, VT>( 2,  2, 1);
-    checkEwBinarySca<BinaryOpCode::AND, VT>( 0, -2, 0);
-    checkEwBinarySca<BinaryOpCode::AND, VT>(-2,  0, 0);
-    checkEwBinarySca<BinaryOpCode::AND, VT>(-2, -2, 1);
+    checkEwBinarySca<BinaryOpCode::AND, VT, VT>( 0,  0, 0);
+    checkEwBinarySca<BinaryOpCode::AND, VT, VT>( 0,  1, 0);
+    checkEwBinarySca<BinaryOpCode::AND, VT, VT>( 1,  0, 0);
+    checkEwBinarySca<BinaryOpCode::AND, VT, VT>( 1,  1, 1);
+    checkEwBinarySca<BinaryOpCode::AND, VT, VT>( 0,  2, 0);
+    checkEwBinarySca<BinaryOpCode::AND, VT, VT>( 2,  0, 0);
+    checkEwBinarySca<BinaryOpCode::AND, VT, VT>( 2,  2, 1);
+    checkEwBinarySca<BinaryOpCode::AND, VT, VT>( 0, -2, 0);
+    checkEwBinarySca<BinaryOpCode::AND, VT, VT>(-2,  0, 0);
+    checkEwBinarySca<BinaryOpCode::AND, VT, VT>(-2, -2, 1);
 }
 
 TEMPLATE_TEST_CASE(TEST_NAME("or"), TAG_KERNELS, VALUE_TYPES) {
     using VT = TestType;
-    checkEwBinarySca<BinaryOpCode::OR, VT>( 0,  0, 0);
-    checkEwBinarySca<BinaryOpCode::OR, VT>( 0,  1, 1);
-    checkEwBinarySca<BinaryOpCode::OR, VT>( 1,  0, 1);
-    checkEwBinarySca<BinaryOpCode::OR, VT>( 1,  1, 1);
-    checkEwBinarySca<BinaryOpCode::OR, VT>( 0,  2, 1);
-    checkEwBinarySca<BinaryOpCode::OR, VT>( 2,  0, 1);
-    checkEwBinarySca<BinaryOpCode::OR, VT>( 2,  2, 1);
-    checkEwBinarySca<BinaryOpCode::OR, VT>( 0, -2, 1);
-    checkEwBinarySca<BinaryOpCode::OR, VT>(-2,  0, 1);
-    checkEwBinarySca<BinaryOpCode::OR, VT>(-2, -2, 1);
+    checkEwBinarySca<BinaryOpCode::OR, VT, VT>( 0,  0, 0);
+    checkEwBinarySca<BinaryOpCode::OR, VT, VT>( 0,  1, 1);
+    checkEwBinarySca<BinaryOpCode::OR, VT, VT>( 1,  0, 1);
+    checkEwBinarySca<BinaryOpCode::OR, VT, VT>( 1,  1, 1);
+    checkEwBinarySca<BinaryOpCode::OR, VT, VT>( 0,  2, 1);
+    checkEwBinarySca<BinaryOpCode::OR, VT, VT>( 2,  0, 1);
+    checkEwBinarySca<BinaryOpCode::OR, VT, VT>( 2,  2, 1);
+    checkEwBinarySca<BinaryOpCode::OR, VT, VT>( 0, -2, 1);
+    checkEwBinarySca<BinaryOpCode::OR, VT, VT>(-2,  0, 1);
+    checkEwBinarySca<BinaryOpCode::OR, VT, VT>(-2, -2, 1);
 }
 
 // ****************************************************************************
@@ -164,7 +177,7 @@ TEMPLATE_TEST_CASE(TEST_NAME("CONCAT"), TAG_KERNELS, VALUE_TYPES) {
     VT lhs = "Hello";
     VT rhs = "World!";
     VT exp = "HelloWorld!";
-    checkEwBinarySca<BinaryOpCode::CONCAT, VT>(lhs, rhs, exp);
+    checkEwBinarySca<BinaryOpCode::CONCAT, VT, VT>(lhs, rhs, exp);
 }
 
 // ****************************************************************************

--- a/test/runtime/local/kernels/EwUnaryScaTest.cpp
+++ b/test/runtime/local/kernels/EwUnaryScaTest.cpp
@@ -31,8 +31,13 @@
 
 template<UnaryOpCode opCode, typename VT>
 void checkEwUnarySca(VT arg, VT exp) {
-    CHECK(EwUnarySca<opCode, VT, VT>::apply(arg, nullptr) == exp);
-    CHECK(ewUnarySca<VT, VT>(opCode, arg, nullptr) == exp);
+    if constexpr(std::is_same_v<VT, StringScalarType>){
+        CHECK(strcmp(EwUnarySca<opCode, VT, VT>::apply(arg, nullptr), exp) == 0);
+        CHECK(strcmp(ewUnarySca<VT, VT>(opCode, arg, nullptr), exp) == 0);
+    }else{
+        CHECK(EwUnarySca<opCode, VT, VT>::apply(arg, nullptr) == exp);
+        CHECK(ewUnarySca<VT, VT>(opCode, arg, nullptr) == exp);
+    }
 }
 
 template<UnaryOpCode opCode, typename VT>
@@ -68,6 +73,19 @@ TEMPLATE_TEST_CASE(TEST_NAME("sign, floating-point-specific"), TAG_KERNELS, FP_V
     checkEwUnarySca<UnaryOpCode::SIGN, VT>(-std::numeric_limits<VT>::infinity(), -1);
     checkEwUnaryScaNaN<UnaryOpCode::SIGN, VT>(std::numeric_limits<VT>::quiet_NaN());
 }
+
+// ****************************************************************************
+// String
+// ****************************************************************************
+TEMPLATE_TEST_CASE(TEST_NAME("Lower/UpperCase"), TAG_KERNELS, VALUE_TYPES) {
+    using VT = const char* ;
+    VT arg = "hElLo";
+    VT expUpper = "HELLO";
+    VT expLower = "hello";
+    checkEwUnarySca<UnaryOpCode::UPPERCASE, VT>(arg, expUpper);
+    checkEwUnarySca<UnaryOpCode::LOWERCASE, VT>(arg, expLower);
+}
+
 
 // ****************************************************************************
 // Invalid op-code

--- a/test/runtime/local/kernels/LikeTest.cpp
+++ b/test/runtime/local/kernels/LikeTest.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 The DAPHNE Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <runtime/local/datastructures/CSRMatrix.h>
+#include <runtime/local/datagen/GenGivenVals.h>
+#include <runtime/local/datastructures/DenseMatrix.h>
+#include <runtime/local/kernels/Like.h>
+#include <tags.h>
+
+#include <catch.hpp>
+
+#include <vector>
+
+void checkLikeMat(const DenseMatrix<const char*>* arg, const size_t colIdx, const char* pattern, const DenseMatrix<const char*>* exp) {
+    DenseMatrix<const char*> * res = nullptr;
+    like(res, arg, colIdx, pattern, nullptr);
+    for(size_t val = 0; val < exp->getNumItems(); val++)
+        CHECK(strcmp(res->getValues()[val], exp->getValues()[val]) == 0);
+}
+
+TEMPLATE_PRODUCT_TEST_CASE("like", TAG_KERNELS, (DenseMatrix), const char*) {
+    using DTArg = TestType;
+    auto m1 = genGivenVals<DTArg>(5, {"12", "Prasliker", "51",  
+                                    "54", "Trampoler", "77",
+                                    "22", "Maxasminlike", "43",  
+                                    "98", "Phonyname", "85",
+                                    "123", "Maraslimilikes","222"});
+    const char* pattern = "%as%like_";
+    auto exp = genGivenVals<DTArg>(2, {"12", "Prasliker", "51",   
+                                    "123", "Maraslimilikes","222", });
+    checkLikeMat(m1, 1, pattern, exp);
+    DataObjectFactory::destroy(m1, exp);
+}


### PR DESCRIPTION

Implements following operations for `DenseMatrix<const char*>`:
- Element-wise: min/max, uppercase/lowercase, comparisons, concatenation.
- DSL: supports matrix of strings literals; now you can also use `fill` to create a strings matrix.
- `AggRow` and `AggCol` can now be used with strings matrix.
- `Transpose` can be applied on strings matrix, the strings layout in memory is changed as well to keep strings continuous in memory.
- Primitive `Like` kernel.

Implements following operations for `DenseMatrix<const char*>`:
- Element-wise: min/max, uppercase/lowercase, comparisons, concatenation.
- DSL: supports matrix of strings literals; now you can also use `fill` to create a strings matrix.
- `AggRow` and `AggCol` can now be used with strings matrix.
- `Transpose` can be applied on strings matrix, the strings layout in memory is changed as well to keep strings continuous in memory.
- Primitive `Like` kernel (not ewBinary here, see #415 ).

Notes:
As can be seen, supporting strings relies on ` if constexpr(std::is_same_v<VT, const char*>)` kind of compilation branching, which is in many cases much better than duplicating lots of code in template specializations when the difference is one line, for example:
```c
// Fill.h
   ...
        for(size_t r = 0; r < numRows; r++) {
            for(size_t c = 0; c < numCols; c++){
                if constexpr (std::is_same_v<VT, const char*>)
                    res->set(r,c, arg);
                else
                    valuesRes[c] = arg;
            }
            valuesRes += res->getRowSkip();
        }
```
However, such branching can become more complex (see `EwBinarySca.h`). There, we have to repeat `MAKE_CASE` for the same `BinaryOpCode` (MIN/MAX), since we can now have different `VT` for `res` and `lhs/rhs`. 
For example, we want to do `MAKE_CASE(BinaryOpCode::EQ)` on `const char*` matrices and get `bool`/`int` matrix as a return, this is ok, but if we leave `MAKE_CASE(BinaryOpCode::MAX)` in the "general" switch statement, then the compiler will try to compile `MAX` op for `lhs/rhs` of type `const char*` and `res` of type `int`, which makes no sense or is, in other words, **ill-formed**. That's why we now have to condition on the types for proper instantiations. 
So in short, the extensibility in `EwBinarySca.h` on high level can be achieved as simple as conditionally add/constrain switch cases for template instantiations during compile time and have the division of the switch statement based on return/input types. 

Another example of complex branching is `AggRow.h`, where we have `IDXMIN` and `IDXMAX` opcodes implemented in-place before a general binary operations are used. Again, with the introduction of non-numeric `const char*` value type for `DenseMatrix`, we now have to take care and not instantiate templates that do not make sense. As in the example above, `IDXMIN` would expect string matrix and return numeric matrix. This is ok for `IDXMIN` and `IDXMAX` opcodes, but this combination of value types results in ill-formed code, so we branch.

In cases we don't want the code to compile past a certain point (e.g., we are done with calculations and know that the following code is irrelevant for our value type), we can simply do the following:
```c
//AggRow.h
            if constexpr(std::is_same_v<VTArg, const char*>)
                return;
            else{
                // The op-code is either MEAN or STDDEV
               ...
            }

```
__________________________
Suggestion for the following work: consider using `string_view` (non-owning read only access into a null-terminated area in memory) for accessing strings in `CharBuf`, this way we have quick info on string length (instead of current `strlen()` each time we need it), and probably more important, we get access to `std` libraries for our strings, without disrupting continuity of the memory (as it could be the case with `std::string`). 
Closes #415 .