### PR TITLE
[DAPHNE-#417] Incorrect GROUP BY result when all keys are the same

### DIFF
--- a/src/runtime/local/kernels/Order.h
+++ b/src/runtime/local/kernels/Order.h
@@ -154,9 +154,6 @@ struct OrderFrame {
             DeduceValueTypeAndExecute<ColumnIDSort>::apply(arg->getSchema()[colIdx], arg, idx, groups, ascending[numColIdxs-1], colIdx, ctx);
         } else {
             DeduceValueTypeAndExecute<MultiColumnIDSort>::apply(arg->getSchema()[colIdx], arg, idx, groups, ascending[numColIdxs-1], colIdx, ctx);
-            if (groups.front().first == 0 && groups.front().second == numRows) {
-                groups.clear();
-            }
             groupsRes->insert(groupsRes->end(), groups.begin(), groups.end());
         }
     }
@@ -228,9 +225,6 @@ struct Order<DenseMatrix<VTRes>, DenseMatrix<VTArg>> {
             columnIDSort(idx, arg, colIdxs[numColIdxs-1], groups, ascending[numColIdxs-1], ctx);
         } else {
             multiColumnIDSort(idx, arg, colIdxs[numColIdxs-1], groups, ascending[numColIdxs-1], ctx);
-            if (groups.front().first == 0 && groups.front().second == numRows) {
-                groups.clear();
-            }
             groupsRes->insert(groupsRes->end(), groups.begin(), groups.end());
         }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -38,6 +38,7 @@ set(TEST_SOURCES
         api/cli/scoping/ScopingTest.cpp
         api/cli/scriptargs/ScriptArgsTest.cpp
         api/cli/sql/SQLTest.cpp
+        api/cli/sql/SQLResultTest.cpp
         api/cli/syntax/SyntaxTest.cpp
         api/cli/vectorized/MultiThreadedOpsTest.cpp
         api/cli/vectorized/VectorizedPipelineTest.cpp

--- a/test/api/cli/sql/SQLResultTest.cpp
+++ b/test/api/cli/sql/SQLResultTest.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 The DAPHNE Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <api/cli/Utils.h>
+
+#include <tags.h>
+
+#include <catch.hpp>
+
+#include <sstream>
+#include <string>
+
+const std::string dirPath = "test/api/cli/sql/";
+
+#define MAKE_TEST_CASE(name, count) \
+    TEST_CASE(name, TAG_OPERATIONS) { \
+        for(unsigned i = 1; i <= count; i++) { \
+            DYNAMIC_SECTION(name "_" << i << ".daphne") { \
+                compareDaphneToRefSimple(dirPath, name, i); \
+            } \
+        } \
+    }
+
+MAKE_TEST_CASE("group", 1)

--- a/test/api/cli/sql/group_1.daphne
+++ b/test/api/cli/sql/group_1.daphne
@@ -1,0 +1,5 @@
+f = frame([1, 1, 1], [1, 2, 3], "a", "b");
+print(f);
+registerView("f", f);
+res = sql("SELECT f.a, sum(f.b) FROM f GROUP BY f.a;");
+print(res);

--- a/test/api/cli/sql/group_1.txt
+++ b/test/api/cli/sql/group_1.txt
@@ -1,0 +1,6 @@
+Frame(3x2, [a:int64_t, b:int64_t])
+1 1
+1 2
+1 3
+Frame(1x2, [f.a:int64_t, sum(f.b):int64_t])
+1 6

--- a/test/runtime/local/kernels/GroupTest.cpp
+++ b/test/runtime/local/kernels/GroupTest.cpp
@@ -56,11 +56,14 @@ TEMPLATE_TEST_CASE("Group", TAG_KERNELS, (Frame)) {
                                                         2, 1, 2, 1, 2, 1, 2, 1, 2, 1 });
     auto c9 = genGivenVals<DenseMatrix<VT1>>(numRows, { 1.6, 2.7, 3.2, 1.5, 2.7, 1.5, 2.7, 1.6, 2.8, 1.5,
                                                         2.7, 1.6, 2.7, 1.5, 2.8, 1.5, 2.7, 1.6, 2.8, 1.5 });
+    auto c10 = genGivenVals<DenseMatrix<VT0>>(numRows, { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1});
+    auto c11 = genGivenVals<DenseMatrix<VT0>>(numRows, { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+            11, 12, 13, 14, 15, 16, 17, 18, 19});
     
-    std::vector<Structure *> colsArg {c0, c1, c2, c3, c4, c5, c6, c7, c8, c9};
-    std::string labels[] = {"aaa", "bbb", "ccc", "ddd", "eee", "fff", "ggg", "hhh", "iii", "jjj"};
+    std::vector<Structure *> colsArg {c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11};
+    std::string labels[] = {"aaa", "bbb", "ccc", "ddd", "eee", "fff", "ggg", "hhh", "iii", "jjj", "kkk", "lll"};
     auto arg = DataObjectFactory::create<Frame>(colsArg, labels);
-    DataObjectFactory::destroy(c0, c1, c2, c3, c4, c5, c6, c7, c8, c9);
+    DataObjectFactory::destroy(c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11);
 
     Frame* exp{};
     Frame* res{};
@@ -87,6 +90,39 @@ TEMPLATE_TEST_CASE("Group", TAG_KERNELS, (Frame)) {
         DenseMatrix<uint64_t> * c1Exp = genGivenVals<DenseMatrix<uint64_t>>(numRows, { 10, 9, 1});
         std::vector<Structure *> colsExp {c0Exp, c1Exp};
         std::string labelsExp[] = {"aaa", "COUNT(ccc)"};
+        exp = DataObjectFactory::create<Frame>(colsExp, labelsExp);
+        DataObjectFactory::destroy(c0Exp, c1Exp);
+    }
+    SECTION("1 grouping column with one distinct value, 1 aggregation columns") {
+        numKeyCols = 1;
+        numAggCols = 1;
+        keyCols = new const char*[10]{labels[10].c_str()};
+        aggCols = new const char*[10]{labels[0].c_str()};
+        aggFuncs = new mlir::daphne::GroupEnum[numAggCols];
+        aggFuncs[0] = mlir::daphne::GroupEnum::COUNT;
+
+        numRows = 1;
+        DenseMatrix<VT0> * c0Exp = genGivenVals<DenseMatrix<VT0>>(numRows, { 1 });
+        DenseMatrix<uint64_t> * c1Exp = genGivenVals<DenseMatrix<uint64_t>>(numRows, { 20 });
+        std::vector<Structure *> colsExp {c0Exp, c1Exp};
+        std::string labelsExp[] = {"kkk", "COUNT(aaa)"};
+        exp = DataObjectFactory::create<Frame>(colsExp, labelsExp);
+        DataObjectFactory::destroy(c0Exp, c1Exp);
+    }
+    SECTION("1 grouping column with all distinct values, 1 aggregation columns") {
+        numKeyCols = 1;
+        numAggCols = 1;
+        keyCols = new const char*[10]{labels[11].c_str()};
+        aggCols = new const char*[10]{labels[0].c_str()};
+        aggFuncs = new mlir::daphne::GroupEnum[numAggCols];
+        aggFuncs[0] = mlir::daphne::GroupEnum::COUNT;
+
+        numRows = 20;
+        DenseMatrix<VT0> * c0Exp = genGivenVals<DenseMatrix<VT0>>(numRows, { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+            11, 12, 13, 14, 15, 16, 17, 18, 19});
+        DenseMatrix<uint64_t> * c1Exp = genGivenVals<DenseMatrix<uint64_t>>(numRows, { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1});
+        std::vector<Structure *> colsExp {c0Exp, c1Exp};
+        std::string labelsExp[] = {"lll", "COUNT(aaa)"};
         exp = DataObjectFactory::create<Frame>(colsExp, labelsExp);
         DataObjectFactory::destroy(c0Exp, c1Exp);
     }


### PR DESCRIPTION
* fixed a bug in the order kernels group export
* added group by tests specifically for key columns with no and all distinct values
* closes #417