### PR TITLE
Distributed runtime documentation.

### DIFF
--- a/doc/DistributedRuntime.md
+++ b/doc/DistributedRuntime.md
@@ -1,0 +1,79 @@
+<!--
+Copyright 2021 The DAPHNE Consortium
+
+Licensed under the Apache License, Version 2.0 (the "License");>
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Running DAPHNE on the distributed runtime
+
+## Background
+
+Daphne supports execution in a distributed fashion. Similar to the local vectorized engine, the distributed runtime
+uses multiple distributed nodes (workers) that work on their local data, while a main node, the coordinator, is responsible
+for transferring the data and code to be executed. The user is required to start the workers, either manually or using an 
+HPC tool as SLURM (scripts that start the workers locally or remotely, natively or not, can be found [here](https://github.com/daphne-eu/daphne/tree/main/deploy)). 
+<!-- TODO: add link to documentation. -->
+
+##  Scope
+
+This document focuses on:
+- how to start distributed workers
+- executing Daphne scripts on the distributed runtime
+
+
+## Build the daphne prototype
+
+First you need to build the Daphne prototype. This doc assumes that you already built Daphne and can run it locally. If 
+you need help building or running Daphne see [here](https://github.com/daphne-eu/daphne/blob/main/doc/GettingStarted.md).
+
+## Start distributed workers
+
+Before executing Daphne on the distributed runtime, worker nodes must first be up and running. You can start a distributed worker within the Daphne prototype directory as follows:
+
+```bash
+# IP:PORT is the IP and PORT the worker server will be listening too
+./build/src/runtime/distributed/worker/DistributedWorker IP:PORT 
+```
+
+There are [scripts](https://github.com/daphne-eu/daphne/tree/main/deploy) that automate this task and can help running multiple workers at once 
+locally or even utilizing tools (like SLURM) in HPC environments.
+
+## Set up environmental variables
+
+After setting up the workers, before we run Daphne we need to specify which IPs 
+and ports the workers are listening too. For now we use an environmental variable called 
+`DISTRIBUTED_WORKERS` where we list IPs and ports of the workers separated by a comma.
+
+```bash
+# Example for 2 workers.
+# Worker1 listens to localhost:5000
+# Worker2 listens to localhost:5001
+export DISTRIBUTED_WORKERS=localhost:5000,localhost:5001
+```
+
+## Run DAPHNE using the distributed runtime
+
+Now that we have all workers up and running and the environmental variable is set we can run Daphne. We enable the distributed runtime by specifying the flag argument `--distributed`.
+
+**(*)** Note that we execute Daphne from the same bash shell we've set up the environmental variable  `DISTRIBUTED_WORKERS`.
+
+```bash
+./build/bin/daphne --distributed ./example.script
+```
+
+### What Next?
+
+You might want to have a look at
+- the [distributed runtime development guideline](/doc/development/ExtendingDistributedRuntime.md)
+- the [contribution guidelines](/CONTRIBUTING.md)
+- the [open distributed related issues](https://github.com/daphne-eu/daphne/issues?q=is%3Aopen+is%3Aissue+label%3ADistributed)

--- a/doc/DistributedRuntime.md
+++ b/doc/DistributedRuntime.md
@@ -14,14 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-# Running DAPHNE on the distributed runtime
+# Running DAPHNE on the Distributed Runtime
 
 ## Background
 
 Daphne supports execution in a distributed fashion. Similar to the local vectorized engine, the distributed runtime
 uses multiple distributed nodes (workers) that work on their local data, while a main node, the coordinator, is responsible
 for transferring the data and code to be executed. The user is required to start the workers, either manually or using an 
-HPC tool as SLURM (scripts that start the workers locally or remotely, natively or not, can be found [here](https://github.com/daphne-eu/daphne/tree/main/deploy)). 
+HPC tool as SLURM (scripts that start the workers locally or remotely, natively or not, can be found [here](/deploy)). 
 <!-- TODO: add link to documentation. -->
 
 ##  Scope
@@ -34,7 +34,7 @@ This document focuses on:
 ## Build the daphne prototype
 
 First you need to build the Daphne prototype. This doc assumes that you already built Daphne and can run it locally. If 
-you need help building or running Daphne see [here](https://github.com/daphne-eu/daphne/blob/main/doc/GettingStarted.md).
+you need help building or running Daphne see [here](/doc/GettingStarted.md).
 
 ## Start distributed workers
 
@@ -45,7 +45,7 @@ Before executing Daphne on the distributed runtime, worker nodes must first be u
 ./build/src/runtime/distributed/worker/DistributedWorker IP:PORT 
 ```
 
-There are [scripts](https://github.com/daphne-eu/daphne/tree/main/deploy) that automate this task and can help running multiple workers at once 
+There are [scripts](/deploy) that automate this task and can help running multiple workers at once 
 locally or even utilizing tools (like SLURM) in HPC environments.
 
 ## Set up environmental variables

--- a/doc/DistributedRuntime.md
+++ b/doc/DistributedRuntime.md
@@ -106,7 +106,9 @@ $ export DISTRIBUTED_WORKERS=localhost:5000
 $ ./build/bin/daphne --distributed ./scripts/example/distributed.daph
 ```
 
-## Limitations
+## Current limitations
+
+Distributed Runtime is still under development and currently there are various limitations. Most of these limitations will be fixed in the future.
 
 - Distributed runtime for now heavily depends on the vectorized engine of Daphne and how pipelines are
 created and multiple operations are fused together (more [here - section 4](https://daphne-eu.eu/wp-content/uploads/2022/08/D2.2-Refined-System-Architecture.pdf)). This causes some limitations related to pipeline creation (e.g. [not supporting pipelines with different result outputs](/issues/397) or pipelines with no outputs).

--- a/doc/README.md
+++ b/doc/README.md
@@ -24,6 +24,7 @@ limitations under the License.
 - [FileMetaData Format (reading and writing data)](/doc/FileMetaDataFormat.md)
 - [DaphneDSL Language Reference](/doc/DaphneDSLLanguageRef.md)
 - [DaphneDSL Built-in Functions](/doc/DaphneDSLBuiltins.md)
+- [Running DAPHNE on the Distributed Runtime](/doc/DistributedRuntime.md)
 
 ## Developer Documentation
 
@@ -34,6 +35,7 @@ limitations under the License.
 - [Binary Data Format](/doc/BinaryFormat.md)
 - [DAPHNE Configuration: Getting Information from the User](/doc/Config.md)
 - [Extending DAPHNE with more scheduling knobs](/doc/development/ExtendingSchedulingKnobs.md)
+- [Extending the DAPHNE Distributed Runtime](/doc/development/ExtendingDistributedRuntime.md)
 
 ### Source Code Documentation
 

--- a/doc/development/ExtendingDistributedRuntime.md
+++ b/doc/development/ExtendingDistributedRuntime.md
@@ -1,0 +1,232 @@
+<!--
+Copyright 2021 The DAPHNE Consortium
+
+Licensed under the Apache License, Version 2.0 (the "License");>
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Extending DAPHNE distributed runtime
+
+This doc is about implementing and extending the distributed runtime. This focuses on 
+helping the Daphne developer understand the building blocks of the distributed runtime, 
+both of the Daphne coordinator as well as the Daphne distributed worker. If you want to 
+learn how to execute Daphne scripts on the distributed runtime, please see [here](/doc/DistributedRuntime.md).
+
+## Background
+
+Distributed runtime works similar to the vectorized engine. Compiler passes create 
+_pipelines_ by merging multiple operations. This allows Daphne to split data across multiple
+workers (nodes) and let them execute a pipeline in parallel. Daphne distributed runtime code 
+can be found at [`src/runtime/distributed`](https://github.com/daphne-eu/daphne/tree/distributed-documentation/src/runtime/distributed) where its split into two main parts. The 
+**coordinator** and the **worker**.
+
+Daphne distributed runtime works on an hierarchical approach.
+
+1. Workers are **not** aware of the total execution. They handle a single task-pipeline and return outputs,
+one pipeline at a time.
+2. Workers are **only** aware of their chunk of data. 
+
+
+# Coordinator
+
+The coordinator is responsible for distributing data and broadcasting the IR code fragment, 
+that is the task-pipeline. Each worker receives and compiles the IR optimizing it for it's
+local hardware. Coordinator code can be found at:
+```
+src/runtime/distributed/coordinator/kernels
+```
+
+## Distributed Wrapper
+
+**`DistributedWrapper.h`** kernel contains the Distributed wrapper class which is the main entry point 
+for a distributed pipeline on the coordinator:
+
+```c++
+void DistributedWrapper::execute(
+                const char *mlirCode,       // The IR code fragment
+                DT ***res,                  // An array of pipeline outputs
+                const Structure **inputs,   // Array of pipeline inputs
+                size_t numInputs,           // number of inputs
+                size_t numOutputs,          // number of outputs
+                int64_t *outRows,           // number of Rows for each pipeline output
+                int64_t *outCols,           // number of Columns for each pipeline output
+                VectorSplit *splits,        // Compiler hints on how each input should be split
+                VectorCombine *combines)    // Compiler hints on how each input should be combined
+```
+
+Using the hints `splits` provided by the compiler we determine whether an input should be 
+**Distributed/Scattered** (by rows or columns) or **Broadcasted**. Depending on which we call 
+the corresponding kernel (`Distribute.h` or `Broadcast.h` more below) which is then 
+responsible for transferring data to the workers. `DistributedCompute.h` kernel is then called
+in order to broadcast the IR code fragment and start the actually computation.
+Finally `DistributedCollect.h` kernel collects the final results (pipeline outputs).
+
+
+**`Distribute.h`**, **`Broadcast.h`**, **`DistributedCompute.h`** and **`DistributedCollect.h`** 
+similar to local runtime kernels
+use C++ template meta programming (more on how we utilize C++ templates on the local runtime [here](https://github.com/daphne-eu/daphne/blob/main/doc/ImplementBuiltinKernel.md)). Since Daphne supports many different distributed 
+backends (e.g. gRPC, MPI, etc.) we can not provide a fully generic code that would work for
+all implementations. Thus we specialize each template for each distributed backend we want to 
+support. 
+
+The Daphne developer can work on a new distributed backend by simply providing a new template 
+specialization of these 4 kernels with a different distributed backend.
+
+## Distributed backends
+
+Daphne supports multiple different devices (GPUs, distributed nodes, FPGAs etc.). Because of that
+all Daphne objects (e.g. Matrices) require to track where their data is stored. That is why each
+Daphne object contains meta data providing that information. Below you can see a list of all the different
+devices a Daphne object can be allocated to.
+
+```C++
+enum class ALLOCATION_TYPE {
+    DIST_GRPC,
+    DIST_OPENMPI,
+    DIST_SPARK,
+    GPU_CUDA,
+    GPU_HIP,
+    HOST,
+    HOST_PINNED_CUDA,
+    FPGA_INT, // Intel
+    FPGA_XLX, // Xilinx
+    ONEAPI, // probably need separate ones for CPU/GPU/FPGA
+    NUM_ALLOC_TYPES
+};
+```
+
+As we described above, each kernel is partially specialized for each distributed backend. We specialize
+the templated distributed kernels for each distributed allocation type in the `enum class` shown above 
+(e.g. `DIST_GRPC`).
+
+## Templated distributed kernels
+
+Each kernel is responsible for two things.
+
+1. Handling the communication part. That is sending data to the workers.
+2. Updating the meta data. That is populating the meta data of an object which can then lead
+to reduced communication (if an object is already placed on nodes, we don't need to re-send it).
+
+<!-- TODO: Add link to documentation of meta data. -->
+You can find more on meta data implementation [here](https://github.com/daphne-eu/daphne/blob/main/src/runtime/local/datastructures).
+
+Below we see **`Broadcast.h`** templated kernel, along with it's gRPC specialization.
+`DT` is the type of the object being broadcasted. 
+```C++
+
+// ****************************************************************************
+// Struct for partial template specialization
+// ****************************************************************************
+
+// DT is object type
+// AT is allocation type (distributed backend)
+template<ALLOCATION_TYPE AT, class DT>
+struct Broadcast {
+    static void apply(DT *mat, bool isScalar, DCTX(dctx)) = delete;
+};
+
+// ****************************************************************************
+// Convenience function
+// ****************************************************************************
+
+template<ALLOCATION_TYPE AT, class DT>
+void broadcast(DT *&mat, bool isScalar, DCTX(dctx))
+{
+    Broadcast<AT, DT>::apply(mat, isScalar, dctx);
+}
+
+// ****************************************************************************
+// (Partial) template specializations for different distributed backends
+// ****************************************************************************
+
+// ----------------------------------------------------------------------------
+// GRPC
+// ----------------------------------------------------------------------------
+
+template<class DT>
+struct Broadcast<ALLOCATION_TYPE::DIST_GRPC, DT>
+{
+    // Specific gRPC implementation...
+    ...
+```
+
+So for example if we wanted to add broadcast support for MPI all we need to do is provide the partial 
+template specialization of Broadcast kernel for MPI. 
+
+```C++
+// ----------------------------------------------------------------------------
+// MPI
+// ----------------------------------------------------------------------------
+
+template<class DT>
+struct Broadcast<ALLOCATION_TYPE::DIST_MPI, DT> 
+{
+    // Specific MPI implementation...
+    ...
+```
+
+# Distributed Worker
+
+Worker code can be found here:
+```bash
+src/runtime/distributed/worker
+```
+
+**`WorkerImpl.h`** contains the `WorkerImpl` class which provides all the logic for the distributed worker.
+There are 3 important methods in this class:
+
+- The **Store** method, which stores an object in memory and returns an identifier.
+- The **Compute** method, which receives the IR code fragment along with identifier of inputs, computes the pipeline and returns identifiers of pipeline outputs.
+- And the **Transfer** method, which is used to return an object using an identifier.
+```c++
+/**
+ * @brief Stores a matrix at worker's memory
+ * 
+ * @param mat Structure * obj to store
+ * @return StoredInfo Information regarding stored object (identifier, numRows, numCols)
+ */
+StoredInfo Store(DT *mat) ;
+
+/**
+ * @brief Computes a pipeline
+ * 
+ * @param outputs vector to populate with results of the pipeline (identifier, numRows/cols, etc.)
+ * @param inputs vector with inputs of pipeline (identifiers to use, etc.)
+ * @param mlirCode mlir code fragment
+ * @return WorkerImpl::Status tells us if everything went fine, with an optional error message
+ */
+Status Compute(vector<StoredInfo> *outputs, vector<StoredInfo> inputs, string mlirCode) ;
+
+/**
+ * @brief Returns a matrix stored in worker's memory
+ * 
+ * @param storedInfo Information regarding stored object (identifier, numRows, numCols)
+ * @return Structure* Returns object
+ */
+Structure * Transfer(StoredInfo storedInfo);
+```
+
+The developer can provide an implementation for a distributed worker by deriving `WorkerImpl` class.
+The derived class handles all the communication using the preferred distributed backend and invokes the parent methods for the logic.
+You can find the gRPC implementation of the distributed worker here:
+```bash
+src/runtime/distributed/worker/WorkerImplGrpc.h/.cpp
+```
+
+`main.cpp` is the entry point of the distributed worker. A distributed implementation is created using a pointer to the parent class
+`WorkerImpl`. The distributed node then blocks and waits for the coordinator to send a request by invoking the virtual method:
+
+```C++
+virtual void Wait() { };
+```
+
+Each distributed worker implementation needs to override this method and implement it in order to wait for requests.

--- a/doc/development/ExtendingDistributedRuntime.md
+++ b/doc/development/ExtendingDistributedRuntime.md
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-# Extending DAPHNE distributed runtime
+# Extending the DAPHNE Distributed Runtime
 
 This doc is about implementing and extending the distributed runtime. This focuses on 
 helping the Daphne developer understand the building blocks of the distributed runtime, 
@@ -26,7 +26,7 @@ learn how to execute Daphne scripts on the distributed runtime, please see [here
 Distributed runtime works similar to the vectorized engine. Compiler passes create 
 _pipelines_ by merging multiple operations. This allows Daphne to split data across multiple
 workers (nodes) and let them execute a pipeline in parallel. Daphne distributed runtime code 
-can be found at [`src/runtime/distributed`](https://github.com/daphne-eu/daphne/tree/distributed-documentation/src/runtime/distributed) where its split into two main parts. The 
+can be found at [`src/runtime/distributed`](/src/runtime/distributed) where it is split into two main parts. The 
 **coordinator** and the **worker**.
 
 Daphne distributed runtime works on an hierarchical approach.
@@ -60,20 +60,20 @@ void DistributedWrapper::execute(
                 int64_t *outRows,           // number of Rows for each pipeline output
                 int64_t *outCols,           // number of Columns for each pipeline output
                 VectorSplit *splits,        // Compiler hints on how each input should be split
-                VectorCombine *combines)    // Compiler hints on how each input should be combined
+                VectorCombine *combines)    // Compiler hints on how each output should be combined
 ```
 
 Using the hints `splits` provided by the compiler we determine whether an input should be 
 **Distributed/Scattered** (by rows or columns) or **Broadcasted**. Depending on which we call 
-the corresponding kernel (`Distribute.h` or `Broadcast.h` more below) which is then 
+the corresponding kernel (`Distribute.h` or `Broadcast.h`, more below) which is then 
 responsible for transferring data to the workers. `DistributedCompute.h` kernel is then called
-in order to broadcast the IR code fragment and start the actually computation.
-Finally `DistributedCollect.h` kernel collects the final results (pipeline outputs).
+in order to broadcast the IR code fragment and start the actual computation.
+Finally, `DistributedCollect.h` kernel collects the final results (pipeline outputs).
 
 
 **`Distribute.h`**, **`Broadcast.h`**, **`DistributedCompute.h`** and **`DistributedCollect.h`** 
 similar to local runtime kernels
-use C++ template meta programming (more on how we utilize C++ templates on the local runtime [here](https://github.com/daphne-eu/daphne/blob/main/doc/ImplementBuiltinKernel.md)). Since Daphne supports many different distributed 
+use C++ template meta programming (more on how we utilize C++ templates on the local runtime [here](/doc/ImplementBuiltinKernel.md)). Since Daphne supports many different distributed 
 backends (e.g. gRPC, MPI, etc.) we can not provide a fully generic code that would work for
 all implementations. Thus we specialize each template for each distributed backend we want to 
 support. 
@@ -84,7 +84,7 @@ specialization of these 4 kernels with a different distributed backend.
 ## Distributed backends
 
 Daphne supports multiple different devices (GPUs, distributed nodes, FPGAs etc.). Because of that
-all Daphne objects (e.g. Matrices) require to track where their data is stored. That is why each
+all Daphne objects (e.g. matrices) require tracking where their data is stored. That is why each
 Daphne object contains meta data providing that information. Below you can see a list of all the different
 devices a Daphne object can be allocated to.
 
@@ -117,7 +117,7 @@ Each kernel is responsible for two things.
 to reduced communication (if an object is already placed on nodes, we don't need to re-send it).
 
 <!-- TODO: Add link to documentation of meta data. -->
-You can find more on meta data implementation [here](https://github.com/daphne-eu/daphne/blob/main/src/runtime/local/datastructures).
+You can find more on meta data implementation [here](/src/runtime/local/datastructures).
 
 Below we see **`Broadcast.h`** templated kernel, along with it's gRPC specialization.
 `DT` is the type of the object being broadcasted. 

--- a/doc/development/ExtendingDistributedRuntime.md
+++ b/doc/development/ExtendingDistributedRuntime.md
@@ -88,6 +88,8 @@ all Daphne objects (e.g. matrices) require tracking where their data is stored. 
 Daphne object contains meta data providing that information. Below you can see a list of all the different
 devices a Daphne object can be allocated to.
 
+Please note that not all of them are supported yet and we might add more in the future.
+
 ```C++
 enum class ALLOCATION_TYPE {
     DIST_GRPC,
@@ -174,6 +176,10 @@ struct Broadcast<ALLOCATION_TYPE::DIST_MPI, DT>
     ...
 ```
 
+For now selection of a distributed backend is hardcoded [here](/src/runtime/distributed/coordinator/kernels/DistributedWrapper.h#L73). 
+<!-- 
+TODO: PR #436 provides support for MPI and implements a cli argument for selecting a distributed backend. This section will be updated once #436 is merged.
+ -->
 # Distributed Worker
 
 Worker code can be found here:

--- a/scripts/examples/distributed.daph
+++ b/scripts/examples/distributed.daph
@@ -1,0 +1,10 @@
+# Creating two random 2x3 matrix
+m1 = rand(6, 3, 1.0, 10.0, 1.0, 1);
+m2 = rand(6, 3, 1.0, 10.0, 1.0, 1);
+m3 = m1  + m2;
+print(m1);
+print(m2);
+print(m3);
+print("Hello world!");
+print("Bye!"); 
+


### PR DESCRIPTION
Added two .md files, both related to the use and development of the distributed runtime.
- One documentation file for the Daphne user, how to deploy distributed nodes (workers) and execute a script on the distributed runtime.
- One documentation file for the Daphne developer, explaining the basics on how to extend the existing infrastructure of the distributed runtime. 