### PR TITLE
Build script improvements

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
         path: ./thirdparty
         key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('build.sh') }}
         restore-keys: |
-          ${{ runner.os }}-${{ env.cache-name }}-
+          ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('build.sh') }}
 
     - if: ${{ steps.cache-deps.outputs.cache-hit == 'true' }}
       name: Print cache hit result

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,5 +177,6 @@ if(USE_FPGAOPENCL)
 endif() 
 add_subdirectory(src/util)
 
+add_dependencies(CompilerUtils MLIRDaphneTransformsIncGen)
 
 add_subdirectory(test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,20 +129,9 @@ if(USE_CUDA AND CMAKE_CUDA_COMPILER)
     endif()
 endif()
 
-option(USE_ARROW "Whether to activate compilation of Arrow/Parquet features" OFF)
-if(USE_ARROW)
-    find_package(Arrow CONFIG REQUIRED
-        PATHS thirdparty/installed/lib/cmake/arrow
-        NO_DEFAULT_PATH
-    )
-    find_package(Parquet CONFIG REQUIRED
-        PATHS thirdparty/installed/lib/cmake/arrow
-        NO_DEFAULT_PATH
-    )
-    link_libraries(arrow_shared parquet_shared)
-    add_definitions(-DUSE_ARROW)
-    message(STATUS "Arrow/Parquet enabled")
-endif()
+
+find_package(Arrow REQUIRED)
+find_package(Parquet REQUIRED)
 
 option(USE_FPGAOPENCL "Whether to activate compilation of FPGA OpenCL features" OFF)
 if(USE_FPGAOPENCL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,15 +74,15 @@ set(BLA_VENDOR OpenBLAS)
 set(BLA_STATIC ON)
 find_package(BLAS)
 
+SET(ANTLR_VERSION 4.9.2 CACHE STRING "The version of ANTLR (parsing library).")
+message(STATUS "ANTLR_VERSION: ${ANTLR_VERSION}")
+
 # specify multiple paths in CMAKE_PREFIX_PATH separated by semicolon to add multiple include dirs
 # to make compile/exec in container plus finding includes in local IDE work, specify both, local third party sources
 # prefix and /usr/local e.g.: -DCMAKE_PREFIX_PATH="/usr/local;${PROJECT_SOURCE_DIR}/thirdparty/installed"
-
-message(STATUS "ANTLR_VERSION: ${ANTLR_VERSION}")
 foreach(path ${CMAKE_PREFIX_PATH})
     message(STATUS "CMAKE_PREFIX_PATH:  ${path}")
     include_directories(${path}/include)
-    include_directories(${path}/include/openblas)
     file(GLOB ANTLR_JAR_FOUND ${path}/share/antlr4/antlr-${ANTLR_VERSION}-complete.jar)
     if(DEFINED ANTLR_JAR_FOUND)
         message(STATUS "ANTLR_JAR_FOUND: ${ANTLR_JAR_FOUND}")
@@ -93,7 +93,6 @@ endforeach(path)
 # fallback if not using CMAKE_PREFIX_PATH (e.g., system/container install)
 if(NOT DEFINED CMAKE_PREFIX_PATH)
     set(ANTLR4_JAR_LOCATION /usr/local/share/antlr4/antlr-${ANTLR_VERSION}-complete.jar CACHE STRING "default value for ANTLR jar file")
-    include_directories(/usr/local/include/openblas)
 endif()
 
 # check <package>_ROOT env var

--- a/build.sh
+++ b/build.sh
@@ -526,10 +526,23 @@ fi
 # Process dependencies if requested (--with-deps)
 if [ $WITH_DEPS -gt 0 ]; then
 
+    # Directory name of the LLVM dependency
+    llvmName="llvm-project"
+
     # Make sure that the submodule(s) have been updated since the last clone/pull.
     # But only if this is a git repo.
+    # Extra care needs to be taken if the submodule was loaded from gh action cache
     if [ -d .git ]; then
-        git submodule update --init --recursive
+        if [ -e "${thirdpartyPath}/${llvmName}/.git" ]; then # Note: .git in the submodule is not a directory.
+            submodule_path=$(cut -d ' ' -f 2 < .git)
+
+            # if the third party directory was loaded from gh action cache, this path will not exist
+            if [ -d "$submodule_path" ]; then
+                git submodule update --init --recursive
+            fi
+        else
+            git submodule update --init --recursive
+        fi
     fi
 
     #******************************************************************************
@@ -743,7 +756,6 @@ if [ $WITH_DEPS -gt 0 ]; then
     # file does not exist (first build of the prototype) or does not contain the
     # expected hash (upgrade of the LLVM sub-module).
 
-    llvmName="llvm-project"
     llvmCommit="llvmCommit-local-none"
     cd "${thirdpartyPath}/${llvmName}"
     if [ -e .git ]; then # Note: .git in the submodule is not a directory.

--- a/build.sh
+++ b/build.sh
@@ -734,12 +734,13 @@ if ! is_dependency_installed "llvm_v${llvmCommit}" || [ "$(cat "${llvmCommitFile
        -DLLVM_ENABLE_RTTI=ON \
        -DCMAKE_INSTALL_PREFIX="$installPrefix"
     cmake --build "$buildPrefix/$llvmName" --target check-mlir
-    echo "$llvmCommit" > "$llvmCommitFilePath"
-    cd - > /dev/null
-    dependency_install_success "llvm_v${llvmCommit}"
-else
-    daphne_msg "No need to build MLIR/LLVM again."
-fi
+    cmake --build "$buildPrefix/$llvmName" --target install
+      echo "$llvmCommit" > "$llvmCommitFilePath"
+      cd - > /dev/null
+      dependency_install_success "llvm_v${llvmCommit}"
+  else
+      daphne_msg "No need to build MLIR/LLVM again."
+  fi
 
 if [[ $BUILD_FPGAOPENCL = *"ON"* ]]; then
   FPGAOPENCL_BISTREAM_DIR="$projectRoot/src/runtime/local/kernels/FPGAOPENCL/bitstreams"
@@ -761,10 +762,9 @@ fi
 
 daphne_msg "Build Daphne"
 
-cmake -S "$projectRoot" -B "$daphneBuildDir" -G Ninja $BUILD_CUDA $BUILD_ARROW $BUILD_FPGAOPENCL $BUILD_DEBUG \
-  -DCMAKE_PREFIX_PATH="$installPrefix" -DANTLR_VERSION="$antlrVersion"  \
-  -DMLIR_DIR="$buildPrefix/$llvmName/lib/cmake/mlir/" \
-  -DLLVM_DIR="$buildPrefix/$llvmName/lib/cmake/llvm/"
+cmake -S "$projectRoot" -B "$daphneBuildDir" -G Ninja -DANTLR_VERSION="$antlrVersion" \
+  -DCMAKE_PREFIX_PATH="$installPrefix" \
+  $BUILD_CUDA $BUILD_ARROW $BUILD_FPGAOPENCL $BUILD_DEBUG
 
 cmake --build "$daphneBuildDir" --target "$target"
 

--- a/build.sh
+++ b/build.sh
@@ -27,7 +27,7 @@ function printHelp {
     printLogo
     echo "Build the DAPHNE prototype."
     echo ""
-    echo "Usage: $0 [-h|--help] [--target TARGET]"
+    echo "Usage: $0 [-h|--help] [--target <target>]"
     echo ""
     echo "This includes downloading and building all required third-party "
     echo "material, if necessary. Simply invoke this script without any "
@@ -38,7 +38,7 @@ function printHelp {
     echo "  -h, --help        Print this help message and exit."
     echo "  --installPrefix <path>"
     echo "                    Set the prefix for the install path of third party dependencies (default: <projectRoot>/thirdparty)"
-    echo "  --target TARGET   Build the cmake target TARGET (defaults to '$target')"
+    echo "  --target <target> Build the cmake target TARGET (defaults to '$target')"
     echo "  --clean           Remove DAPHNE build output (DAPHNE_ROOT/{bin,build,lib}"
     echo "  --cleanCache      Remove downloaded and extracted third party artifacts"
     echo "  --cleanDeps       Remove build output of third party dependencies (<thirdpartyPath>/{build,installed})"
@@ -325,7 +325,7 @@ function cleanCache {
 function cleanAll {
   cd "$projectRoot"
   message="This will delete the DAPHNE build output and everyting in $thirdpartyPath and reset this directory to its \
-    last state in git."
+last state in git."
   if [ "$fancy" -eq 0 ] || ! [ -t 1 ] ; then
       printf "WARNING! ${message}"
   else
@@ -345,8 +345,10 @@ function cleanAll {
   rm -rf "$thirdpartyPath"
   git checkout "$thirdpartyPath"
 
+  local par_acceptAll_old=par_acceptAll
   par_acceptAll="1"
   cleanBuildDirs
+  par_acceptAll=$par_accpetAll_old
   cd - > /dev/null
 }
 
@@ -376,7 +378,7 @@ function is_dependency_downloaded() {
 
 function clean_param_check() {
   if [ "$par_clean" -gt 0 ]; then
-    echo echo "Only *one* clean parameter (clean/cleanAll/cleanDeps/cleanCache) is allowed!"
+    echo "Only *one* clean parameter (clean/cleanAll/cleanDeps/cleanCache) is allowed!"
     exit 1
   fi
 }
@@ -833,3 +835,4 @@ build_ts_end=$(date +%s%N)
 daphne_msg "Successfully built Daphne://${target} (took $(printableTimestamp $((build_ts_end - build_ts_begin))))"
 
 set +e
+

--- a/build.sh
+++ b/build.sh
@@ -63,11 +63,14 @@ fancy="1"
 # Prints info message with style ... Daphne style 8-)
 function daphne_msg() {
     local message date dotSize dots textSize columnWidth
-    # get width of terminal
-    columnWidth="$(tput cols)"
+
     # check if output is directed to file, if true, set width to 120
     if ! [ -t 1 ]; then
         columnWidth=120
+        fancy="0"
+    else
+        # get width of terminal
+        columnWidth="$(tput cols)"
     fi
     prefix="[DAPHNE]"
     message="..${*}"

--- a/build.sh
+++ b/build.sh
@@ -36,6 +36,8 @@ function printHelp {
     echo ""
     echo "Optional arguments:"
     echo "  -h, --help        Print this help message and exit."
+    echo "  --installPrefix <path>"
+    echo "                    Set the prefix for the install path of third party dependencies (default: <projectRoot>/thirdparty)"
     echo "  --target TARGET   Build the cmake target TARGET (defaults to '$target')"
     echo "  --clean           Remove all temporary build directories for a fresh build"
     echo "  --cleanAll        Remove all thirdparty library directories for a build from scratch"
@@ -430,6 +432,10 @@ while [[ $# -gt 0 ]]; do
             echo building DEBUG version
             export BUILD_DEBUG="-DCMAKE_BUILD_TYPE=Debug"
             ;;
+        --installPrefix)
+            installPrefix=$1
+            shift
+            ;;
         *)
             unknown_options="${unknown_options} ${key}"
             ;;
@@ -499,7 +505,7 @@ fi
 if ! is_dependency_installed "antlr_v${antlrVersion}"; then
     mkdir -p "$installPrefix"/share/antlr4/
     cp "$cacheDir/$antlrJarName" "$installPrefix/share/antlr4/$antlrJarName"
-    
+
     daphne_msg "Applying 0000-antlr-silence-compiler-warnings.patch"
     # disable fail on error as first build might fail and patches might be rejected
     set +e

--- a/build.sh
+++ b/build.sh
@@ -44,6 +44,7 @@ function printHelp {
     echo "  --cleanDeps       Remove build output of third party dependencies (<thirdpartyPath>/{build,installed})"
     echo "  --cleanAll        Remove all build output and reset the directory of the third party dependencies"
     echo "  -nf, --no-fancy   Suppress all colored and animated output"
+    echo "  -nd, --no-deps    Avoid building third party dependencies at all"
     echo "  -y, --yes         Accept all prompts"
     echo "  --arrow           Compile with support for Arrow/Parquet files"
     echo "  --cuda            Compile with support for CUDA ops"
@@ -56,11 +57,11 @@ function printHelp {
 #******************************************************************************
 # Daphne Colors
 daphne_red_fg='\e[38;2;247;1;70m'
-daphne_red_bg='\e[48;2;247;1;70m'
+#daphne_red_bg='\e[48;2;247;1;70m'
 daphne_blue_fg='\e[38;2;120;137;251m'
-daphne_blue_bg='\e[48;2;36;42;76m'
-daphne_black_fg='\e[38;2;0;0;0m'
-daphne_black_bg='\e[48;2;0;0;0m'
+#daphne_blue_bg='\e[48;2;36;42;76m'
+#daphne_black_fg='\e[38;2;0;0;0m'
+#daphne_black_bg='\e[48;2;0;0;0m'
 reset='\e[00m'
 fancy="1"
 
@@ -79,18 +80,18 @@ function daphne_msg() {
     prefix="[DAPHNE]"
     message="..${*}"
     date="[$(date +"%d.%m.%y %H:%M:%S")]"
-    textSize=$(( ${columnWidth} - ${#date}-${#prefix} ))
-    dotSize=$(( ${textSize} - ${#message} ))
+    textSize=$((columnWidth - ${#date} - ${#prefix}))
+    dotSize=$((textSize - ${#message}))
 
     dots=""
-    for (( i = 0; i < dotSize; i++)); do
+    for ((i = 0; i < dotSize; i++)); do
         dots="${dots}."
     done
 
     message="${message}${dots}"
 
     # no fancy output (if disabled or not standard output, e.g. piped into file)
-    if [ "$fancy" -eq 0 ] || ! [ -t 1 ] ; then
+    if [ "$fancy" -eq 0 ] || ! [ -t 1 ]; then
         printf "%s%s%s\n" "${prefix}" "${message}" "${date}"
         return 0
     fi
@@ -100,7 +101,7 @@ function daphne_msg() {
     return 0
 }
 
-function printableTimestamp () {
+function printableTimestamp() {
     local t="0"
     local result=""
     local tmp
@@ -182,7 +183,7 @@ function printableTimestamp () {
     printf "%s\n" "${result}"
 }
 
-function printLogo(){
+function printLogo() {
     daphne_msg ""
     daphne_msg ".Welcome to"
     daphne_msg ""
@@ -210,9 +211,9 @@ function clean() {
     # Throw error, if clean is executed, but output is piped to a file. In this case the user has to accept the
     # cleaning via parameter --yes
     if ! [ -t 1 ] && ! [ "$par_acceptAll" -eq 1 ]; then
-        >&2 printf "${daphne_red_fg}"
+        printf >&2 "${daphne_red_fg}"
         printf "Error: To clean Daphne while piping the output into a file set the --yes option, to accept cleaning.\n" | tee /dev/stderr
-        >&2 printf "${reset}"
+        printf >&2 "${reset}"
         exit 1
     fi
 
@@ -233,7 +234,7 @@ function clean() {
         fi
         shift
     fi
-    if [ "$fancy" -eq 0 ] || ! [ -t 1 ] ; then
+    if [ "$fancy" -eq 0 ] || ! [ -t 1 ]; then
         printf "WARNING. This will delete the following..."
     else
         printf "${daphne_red_fg}WARNING.${reset} This will delete following..."
@@ -251,7 +252,7 @@ function clean() {
 
     # prompt confirmation, if not set by --yes
     if [ "$par_acceptAll" == "0" ]; then
-        read -p "Are you sure? (y/n) " answer
+        read -r -p "Are you sure? (y/n) " answer
 
         if [[ "$answer" != [yY] ]]; then
             echo "Abort."
@@ -292,16 +293,16 @@ function cleanDeps {
     echo "-- Cleanup of third party build directories in ${thirdpartyPath} ..."
 
     local dirs=("${buildPrefix}" "${installPrefix}")
-    local files=(\
-      "${thirdpartyPath}/absl_v"*".install.success" \
-      "${thirdpartyPath}/antlr_v"*".install.success" \
-      "${thirdpartyPath}/catch2_v"*".install.success" \
-      "${thirdpartyPath}/grpc_v"*".install.success" \
-      "${thirdpartyPath}/nlohmannjson_v"*".install.success" \
-      "${thirdpartyPath}/openBlas_v"*".install.success" \
-      "${thirdpartyPath}/llvm_v"*".install.success" \
-      "${thirdpartyPath}/arrow_v"*".install.success" \
-      "${llvmCommitFilePath}")
+    local files=(
+        "${thirdpartyPath}/absl_v"*".install.success"
+        "${thirdpartyPath}/antlr_v"*".install.success"
+        "${thirdpartyPath}/catch2_v"*".install.success"
+        "${thirdpartyPath}/grpc_v"*".install.success"
+        "${thirdpartyPath}/nlohmannjson_v"*".install.success"
+        "${thirdpartyPath}/openBlas_v"*".install.success"
+        "${thirdpartyPath}/llvm_v"*".install.success"
+        "${thirdpartyPath}/arrow_v"*".install.success"
+        "${llvmCommitFilePath}")
 
     clean dirs files
 }
@@ -311,45 +312,45 @@ function cleanCache {
 
     local dirs=("${sourcePrefix}" "${cacheDir}")
 
-    local files=(\
-      "${thirdpartyPath}/absl_v"*".download.success" \
-      "${thirdpartyPath}/antlr_v"*".download.success" \
-      "${thirdpartyPath}/grpc_v"*".download.success" \
-      "${thirdpartyPath}/openBlas_v"*".download.success" \
-      "${thirdpartyPath}/arrow_v"*".download.success" \
-      )
+    local files=(
+        "${thirdpartyPath}/absl_v"*".download.success"
+        "${thirdpartyPath}/antlr_v"*".download.success"
+        "${thirdpartyPath}/grpc_v"*".download.success"
+        "${thirdpartyPath}/openBlas_v"*".download.success"
+        "${thirdpartyPath}/arrow_v"*".download.success"
+    )
 
     clean dirs files
 }
 
 function cleanAll {
-  cd "$projectRoot"
-  message="This will delete the DAPHNE build output and everyting in $thirdpartyPath and reset this directory to its \
+    cd "$projectRoot"
+    message="This will delete the DAPHNE build output and everyting in $thirdpartyPath and reset this directory to its \
 last state in git."
-  if [ "$fancy" -eq 0 ] || ! [ -t 1 ] ; then
-      printf "WARNING! ${message}"
-  else
-      printf "${daphne_red_fg}WARNING!${reset} ${message}"
-  fi
+    if [ "$fancy" -eq 0 ] || ! [ -t 1 ]; then
+        printf "WARNING! ${message}"
+    else
+        printf "${daphne_red_fg}WARNING!${reset} ${message}"
+    fi
 
-  # prompt confirmation, if not set by --yes
-  if [ "$par_acceptAll" == "0" ]; then
-      read -p "Are you sure? (y/n) " answer
+    # prompt confirmation, if not set by --yes
+    if [ "$par_acceptAll" == "0" ]; then
+        read -r -p "Are you sure? (y/n) " answer
 
-      if [[ "$answer" != [yY] ]]; then
-          echo "Abort."
-          exit 0
-      fi
-  fi
+        if [[ "$answer" != [yY] ]]; then
+            echo "Abort."
+            exit 0
+        fi
+    fi
 
-  rm -rf "$thirdpartyPath"
-  git checkout "$thirdpartyPath"
+    rm -rf "$thirdpartyPath"
+    git checkout "$thirdpartyPath"
 
-  local par_acceptAll_old=par_acceptAll
-  par_acceptAll="1"
-  cleanBuildDirs
-  par_acceptAll=$par_accpetAll_old
-  cd - > /dev/null
+    local par_acceptAll_old=par_acceptAll
+    par_acceptAll="1"
+    cleanBuildDirs
+    par_acceptAll=$par_acceptAll_old
+    cd - >/dev/null
 }
 
 #******************************************************************************
@@ -377,10 +378,10 @@ function is_dependency_downloaded() {
 }
 
 function clean_param_check() {
-  if [ "$par_clean" -gt 0 ]; then
-    echo "Only *one* clean parameter (clean/cleanAll/cleanDeps/cleanCache) is allowed!"
-    exit 1
-  fi
+    if [ "$par_clean" -gt 0 ]; then
+        echo "Only *one* clean parameter (clean/cleanAll/cleanDeps/cleanCache) is allowed!"
+        exit 1
+    fi
 }
 
 #******************************************************************************
@@ -435,64 +436,63 @@ while [[ $# -gt 0 ]]; do
     key=$1
     shift
     case $key in
-        -h|--help)
-            par_printHelp="1"
-            ;;
-        --clean)
-            clean_param_check
-            par_clean="1"
-            ;;
-        --cleanAll)
-            clean_param_check
-            par_clean="2"
-            ;;
-        --cleanDeps)
-            clean_param_check
-            par_clean="3"
-            ;;
-        --cleanCache)
-            clean_param_check
-            par_clean="4"
-            ;;
-        --target)
-            target=$1
-            shift
-            ;;
-        -nf|--no-fancy)
-            fancy="0"
-            ;;
-        -y|--yes)
-            par_acceptAll="1"
-            ;;
-        --cuda)
-            echo using CUDA
-            export BUILD_CUDA="-DUSE_CUDA=ON"
-            ;;
-        --arrow)
-            echo using ARROW
-            BUILD_ARROW="-DUSE_ARROW=ON"
-            ;;
-        --fpgaopencl)
-            echo using FPGAOPENCL
-            export BUILD_FPGAOPENCL="-DUSE_FPGAOPENCL=ON"
-            ;;
-        --debug)
-            echo building DEBUG version
-            export BUILD_DEBUG="-DCMAKE_BUILD_TYPE=Debug"
-            ;;
-        --installPrefix)
-            installPrefix=$1
-            shift
-            ;;
-        --no-deps)
-            WITH_DEPS=0
-            ;;
-        *)
-            unknown_options="${unknown_options} ${key}"
-            ;;
+    -h | --help)
+        par_printHelp="1"
+        ;;
+    --clean)
+        clean_param_check
+        par_clean="1"
+        ;;
+    --cleanAll)
+        clean_param_check
+        par_clean="2"
+        ;;
+    --cleanDeps)
+        clean_param_check
+        par_clean="3"
+        ;;
+    --cleanCache)
+        clean_param_check
+        par_clean="4"
+        ;;
+    --target)
+        target=$1
+        shift
+        ;;
+    -nf | --no-fancy)
+        fancy="0"
+        ;;
+    -y | --yes)
+        par_acceptAll="1"
+        ;;
+    --cuda)
+        echo using CUDA
+        export BUILD_CUDA="-DUSE_CUDA=ON"
+        ;;
+    --arrow)
+        echo using ARROW
+        BUILD_ARROW="-DUSE_ARROW=ON"
+        ;;
+    --fpgaopencl)
+        echo using FPGAOPENCL
+        export BUILD_FPGAOPENCL="-DUSE_FPGAOPENCL=ON"
+        ;;
+    --debug)
+        echo building DEBUG version
+        export BUILD_DEBUG="-DCMAKE_BUILD_TYPE=Debug"
+        ;;
+    --installPrefix)
+        installPrefix=$1
+        shift
+        ;;
+    -nd | --no-deps)
+        WITH_DEPS=0
+        ;;
+    *)
+        unknown_options="${unknown_options} ${key}"
+        ;;
     esac
 done
-
 
 if [ -n "$unknown_options" ]; then
     printf "Unknown option(s): '%s'\n\n" "$unknown_options"
@@ -506,21 +506,21 @@ if [ "$par_printHelp" -eq 1 ]; then
 fi
 
 if [ "$par_clean" -gt 0 ]; then
-  case $par_clean in
+    case $par_clean in
     1)
-      cleanBuildDirs
-      ;;
+        cleanBuildDirs
+        ;;
     2)
-      cleanAll
-      ;;
+        cleanAll
+        ;;
     3)
-      cleanDeps
-      ;;
+        cleanDeps
+        ;;
     4)
-      cleanCache
-      ;;
-  esac
-  exit 0
+        cleanCache
+        ;;
+    esac
+    exit 0
 fi
 
 # Print Daphne-Logo when first time executing
@@ -532,291 +532,285 @@ fi
 # Process dependencies if requested (--with-deps)
 if [ $WITH_DEPS -gt 0 ]; then
 
-  # Make sure that the submodule(s) have been updated since the last clone/pull.
-  # But only if this is a git repo.
-  if [ -d .git ]; then
-      git submodule update --init --recursive
-  fi
+    # Make sure that the submodule(s) have been updated since the last clone/pull.
+    # But only if this is a git repo.
+    if [ -d .git ]; then
+        git submodule update --init --recursive
+    fi
 
-  #******************************************************************************
-  # Download and install third-party material if necessary
-  #******************************************************************************
+    #******************************************************************************
+    # Download and install third-party material if necessary
+    #******************************************************************************
 
-  #------------------------------------------------------------------------------
-  # Antlr4 (parser)
-  #------------------------------------------------------------------------------
-  antlrJarName="antlr-${antlrVersion}-complete.jar"
-  antlrCppRuntimeDirName="antlr4-cpp-runtime-${antlrVersion}-source"
-  antlrCppRuntimeZipName="${antlrCppRuntimeDirName}.zip"
+    #------------------------------------------------------------------------------
+    # Antlr4 (parser)
+    #------------------------------------------------------------------------------
+    antlrJarName="antlr-${antlrVersion}-complete.jar"
+    antlrCppRuntimeDirName="antlr4-cpp-runtime-${antlrVersion}-source"
+    antlrCppRuntimeZipName="${antlrCppRuntimeDirName}.zip"
 
-  # Download antlr4 C++ run-time if it does not exist yet.
-  if ! is_dependency_downloaded "antlr_v${antlrVersion}"; then
-      daphne_msg "Get Antlr version ${antlrVersion}"
-      # Download antlr4 jar if it does not exist yet.
-      daphne_msg "Download Antlr v${antlrVersion} java archive"
-      wget "https://www.antlr.org/download/${antlrJarName}" -qO "${cacheDir}/${antlrJarName}"
-      daphne_msg "Download Antlr v${antlrVersion} Runtime"
-      wget https://www.antlr.org/download/${antlrCppRuntimeZipName} -qO "${cacheDir}/${antlrCppRuntimeZipName}"
-      rm -rf "${sourcePrefix:?}/$antlrCppRuntimeDirName"
-      mkdir --parents "$sourcePrefix/$antlrCppRuntimeDirName"
-      unzip -q "$cacheDir/$antlrCppRuntimeZipName" -d "$sourcePrefix/$antlrCppRuntimeDirName"
-      dependency_download_success "antlr_v${antlrVersion}"
-  fi
-  # build antlr4 C++ run-time
-  if ! is_dependency_installed "antlr_v${antlrVersion}"; then
-      mkdir -p "$installPrefix"/share/antlr4/
-      cp "$cacheDir/$antlrJarName" "$installPrefix/share/antlr4/$antlrJarName"
+    # Download antlr4 C++ run-time if it does not exist yet.
+    if ! is_dependency_downloaded "antlr_v${antlrVersion}"; then
+        daphne_msg "Get Antlr version ${antlrVersion}"
+        # Download antlr4 jar if it does not exist yet.
+        daphne_msg "Download Antlr v${antlrVersion} java archive"
+        wget "https://www.antlr.org/download/${antlrJarName}" -qO "${cacheDir}/${antlrJarName}"
+        daphne_msg "Download Antlr v${antlrVersion} Runtime"
+        wget https://www.antlr.org/download/${antlrCppRuntimeZipName} -qO "${cacheDir}/${antlrCppRuntimeZipName}"
+        rm -rf "${sourcePrefix:?}/$antlrCppRuntimeDirName"
+        mkdir --parents "$sourcePrefix/$antlrCppRuntimeDirName"
+        unzip -q "$cacheDir/$antlrCppRuntimeZipName" -d "$sourcePrefix/$antlrCppRuntimeDirName"
+        dependency_download_success "antlr_v${antlrVersion}"
+    fi
+    # build antlr4 C++ run-time
+    if ! is_dependency_installed "antlr_v${antlrVersion}"; then
+        mkdir -p "$installPrefix"/share/antlr4/
+        cp "$cacheDir/$antlrJarName" "$installPrefix/share/antlr4/$antlrJarName"
 
-      daphne_msg "Applying 0000-antlr-silence-compiler-warnings.patch"
-      # disable fail on error as first build might fail and patches might be rejected
-      set +e
-      patch -Np0 -i "$patchDir/0000-antlr-silence-compiler-warnings.patch" \
-        -d "$sourcePrefix/$antlrCppRuntimeDirName"
-      # Github disabled the unauthenticated git:// protocol, patch antlr4 to use https://
-      # until we upgrade to antlr4-4.9.3+
-      sed -i 's#git://github.com#https://github.com#' "$sourcePrefix/$antlrCppRuntimeDirName/runtime/CMakeLists.txt"
+        daphne_msg "Applying 0000-antlr-silence-compiler-warnings.patch"
+        # disable fail on error as first build might fail and patches might be rejected
+        set +e
+        patch -Np0 -i "$patchDir/0000-antlr-silence-compiler-warnings.patch" \
+            -d "$sourcePrefix/$antlrCppRuntimeDirName"
+        # Github disabled the unauthenticated git:// protocol, patch antlr4 to use https://
+        # until we upgrade to antlr4-4.9.3+
+        sed -i 's#git://github.com#https://github.com#' "$sourcePrefix/$antlrCppRuntimeDirName/runtime/CMakeLists.txt"
 
-      daphne_msg "Build Antlr v${antlrVersion}"
-      cmake -S "$sourcePrefix/$antlrCppRuntimeDirName" -B "${buildPrefix}/${antlrCppRuntimeDirName}" \
-        -G Ninja -DANTLR4_INSTALL=ON -DCMAKE_INSTALL_PREFIX="$installPrefix" -DCMAKE_BUILD_TYPE=Release
-      cmake --build "${buildPrefix}/${antlrCppRuntimeDirName}"
-      daphne_msg "Applying 0001-antlr-gtest-silence-warnings.patch"
-      patch -Np1 -i "$patchDir/0001-antlr-gtest-silence-warnings.patch" \
-        -d "$buildPrefix/$antlrCppRuntimeDirName/runtime/thirdparty/utfcpp/extern/gtest/"
+        daphne_msg "Build Antlr v${antlrVersion}"
+        cmake -S "$sourcePrefix/$antlrCppRuntimeDirName" -B "${buildPrefix}/${antlrCppRuntimeDirName}" \
+            -G Ninja -DANTLR4_INSTALL=ON -DCMAKE_INSTALL_PREFIX="$installPrefix" -DCMAKE_BUILD_TYPE=Release
+        cmake --build "${buildPrefix}/${antlrCppRuntimeDirName}"
+        daphne_msg "Applying 0001-antlr-gtest-silence-warnings.patch"
+        patch -Np1 -i "$patchDir/0001-antlr-gtest-silence-warnings.patch" \
+            -d "$buildPrefix/$antlrCppRuntimeDirName/runtime/thirdparty/utfcpp/extern/gtest/"
 
-      # enable fail on error again
-      set -e
-      cmake --build "${buildPrefix}/${antlrCppRuntimeDirName}" --target install
+        # enable fail on error again
+        set -e
+        cmake --build "${buildPrefix}/${antlrCppRuntimeDirName}" --target install
 
-      dependency_install_success "antlr_v${antlrVersion}"
-  else
-      daphne_msg "No need to build Antlr4 again."
-  fi
-
-
-  #------------------------------------------------------------------------------
-  # catch2 (unit test framework)
-  #------------------------------------------------------------------------------
-  # Download catch2 release zip (if necessary), and unpack the single header file
-  # (if necessary).
-  catch2Name="catch2"
-  catch2ZipName="v$catch2Version.zip"
-  catch2SingleHeaderInstalledPath=$installPrefix/include/catch.hpp
-  if ! is_dependency_installed "catch2_v${catch2Version}"; then
-      daphne_msg "Get catch2 version ${catch2Version}"
-      mkdir --parents "${thirdpartyPath}/${catch2Name}"
-      cd "${thirdpartyPath}/${catch2Name}"
-      if [ ! -f "$catch2ZipName" ] || [ ! -f "$catch2SingleHeaderInstalledPath" ]
-      then
-          daphne_msg "Download catch2 version ${catch2Version}"
-          wget "https://github.com/catchorg/Catch2/archive/refs/tags/${catch2ZipName}" -qO "${cacheDir}/catch2-${catch2ZipName}"
-          unzip -q -p "$cacheDir/$catch2Name-$catch2ZipName" "Catch2-$catch2Version/single_include/catch2/catch.hpp" \
-              > "$catch2SingleHeaderInstalledPath"
-      fi
-      dependency_install_success "catch2_v${catch2Version}"
-  else
-      daphne_msg "No need to download Catch2 again."
-  fi
-
-
-  #------------------------------------------------------------------------------
-  # OpenBLAS (basic linear algebra subprograms)
-  #------------------------------------------------------------------------------
-  openBlasDirName="OpenBLAS-$openBlasVersion"
-  openBlasZipName="${openBlasDirName}.zip"
-  openBlasInstDirName=$installPrefix
-  if ! is_dependency_downloaded "openBlas_v${openBlasVersion}"; then
-      daphne_msg "Get OpenBlas version ${openBlasVersion}"
-      wget "https://github.com/xianyi/OpenBLAS/releases/download/v${openBlasVersion}/${openBlasZipName}" \
-          -qO "${cacheDir}/${openBlasZipName}"
-      unzip -q "$cacheDir/$openBlasZipName" -d "$sourcePrefix"
-      dependency_download_success "openBlas_v${openBlasVersion}"
-  fi
-  if ! is_dependency_installed "openBlas_v${openBlasVersion}"; then
-      cd "$sourcePrefix/$openBlasDirName"
-      make clean
-      # optimizes for multiple x86_64 architectures
-      make -j"$(nproc)" DYNAMIC_ARCH=1 TARGET=NEHALEM
-      make PREFIX="$openBlasInstDirName" install
-      cd - > /dev/null
-      dependency_install_success "openBlas_v${openBlasVersion}"
-  else
-      daphne_msg "No need to build OpenBlas again."
-  fi
-
-
-  #------------------------------------------------------------------------------
-  # nlohmann/json (library for JSON parsing)
-  #------------------------------------------------------------------------------
-  nlohmannjsonDirName=nlohmannjson
-  nlohmannjsonSingleHeaderName=json.hpp
-  if ! is_dependency_installed "nlohmannjson_v${nlohmannjsonVersion}"; then
-      daphne_msg "Get nlohmannjson version ${nlohmannjsonVersion}"
-      mkdir -p "${installPrefix}/include/${nlohmannjsonDirName}"
-      wget "https://github.com/nlohmann/json/releases/download/v$nlohmannjsonVersion/$nlohmannjsonSingleHeaderName" \
-        -qO "${installPrefix}/include/${nlohmannjsonDirName}/${nlohmannjsonSingleHeaderName}"
-      dependency_install_success "nlohmannjson_v${nlohmannjsonVersion}"
-  else
-      daphne_msg "No need to download nlohmannjson again."
-  fi
-
-  #------------------------------------------------------------------------------
-  # abseil (compiled separately to apply a patch)
-  #------------------------------------------------------------------------------
-  abslPath=$sourcePrefix/abseil-cpp
-  if ! is_dependency_downloaded "absl_v${abslVersion}"; then
-    daphne_msg "Get abseil version ${abslVersion}"
-    rm -rf "$abslPath"
-    git clone --depth 1 --branch "$abslVersion" https://github.com/abseil/abseil-cpp.git "$abslPath"
-    daphne_msg "Applying 0002-absl-stdmax-params.patch"
-    patch -Np1 -i "${patchDir}/0002-absl-stdmax-params.patch" -d "$abslPath"
-    dependency_download_success "absl_v${abslVersion}"
-  fi
-  if ! is_dependency_installed "absl_v${abslVersion}"; then
-      cmake -S "$abslPath" -B "$buildPrefix/absl" -G Ninja -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE \
-        -DCMAKE_INSTALL_PREFIX="$installPrefix" -DCMAKE_CXX_STANDARD=17 -DABSL_PROPAGATE_CXX_STD=ON
-      cmake --build "$buildPrefix/absl" --target install
-      dependency_install_success "absl_v${abslVersion}"
-  else
-      daphne_msg "No need to build Abseil again."
-  fi
-
-
-  #------------------------------------------------------------------------------
-  # gRPC
-  #------------------------------------------------------------------------------
-  grpcDirName="grpc"
-  grpcInstDir=$installPrefix
-  if ! is_dependency_downloaded "grpc_v${grpcVersion}"; then
-      daphne_msg "Get grpc version ${grpcVersion}"
-      # Download gRPC source code.
-      if [ -d "${sourcePrefix}/${grpcDirName}" ]; then
-        rm -rf "${sourcePrefix}/${grpcDirName:?}"
-      fi
-      git clone -b v$grpcVersion --depth 1 https://github.com/grpc/grpc "$sourcePrefix/$grpcDirName"
-      pushd "$sourcePrefix/$grpcDirName"
-      git submodule update --init --depth 1 third_party/boringssl-with-bazel
-      git submodule update --init --depth 1 third_party/cares/cares
-      git submodule update --init --depth 1 third_party/protobuf
-      git submodule update --init --depth 1 third_party/re2
-      daphne_msg "Applying 0003-protobuf-override.patch"
-      patch -Np1 -i "${patchDir}/0003-protobuf-override.patch" -d "$sourcePrefix/$grpcDirName/third_party/protobuf"
-      popd
-      dependency_download_success "grpc_v${grpcVersion}"
-  fi
-  if ! is_dependency_installed "grpc_v${grpcVersion}"; then
-      cmake -G Ninja -S "$sourcePrefix/$grpcDirName" -B "$buildPrefix/$grpcDirName" \
-        -DCMAKE_INSTALL_PREFIX="$grpcInstDir" \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DgRPC_INSTALL=ON \
-        -DgRPC_BUILD_TESTS=OFF \
-        -DCMAKE_CXX_STANDARD=17 \
-        -DCMAKE_INCLUDE_PATH="$installPrefix/include" \
-        -DgRPC_ABSL_PROVIDER=package \
-        -DgRPC_ZLIB_PROVIDER=package
-      cmake --build "$buildPrefix/$grpcDirName" --target install
-      dependency_install_success "grpc_v${grpcVersion}"
-  else
-      daphne_msg "No need to build GRPC again."
-  fi
-
-  #------------------------------------------------------------------------------
-  # Arrow / Parquet
-  #------------------------------------------------------------------------------
-  arrowDirName="arrow"
-  if [[ "$BUILD_ARROW" == "-DUSE_ARROW=ON" ]]; then
-      if ! is_dependency_downloaded "arrow_v${arrowVersion}"; then
-          rm -rf ${sourcePrefix}/${arrowDirName}
-          git clone -n https://github.com/apache/arrow.git ${sourcePrefix}/${arrowDirName}
-          cd ${sourcePrefix}/${arrowDirName}
-          git checkout $arrowVersion
-          dependency_download_success "arrow_v${arrowVersion}"
-      fi
-      if ! is_dependency_installed "arrow_v${arrowVersion}"; then
-          cmake -G Ninja -S "${sourcePrefix}/${arrowDirName}/cpp" -B "${buildPrefix}/${arrowDirName}" \
-              -DCMAKE_INSTALL_PREFIX=${installPrefix} \
-              -DARROW_CSV=ON -DARROW_FILESYSTEM=ON -DARROW_PARQUET=ON
-          cmake --build "${buildPrefix}/${arrowDirName}" --target install
-          dependency_install_success "arrow_v${arrowVersion}"
-      else
-          daphne_msg "No need to build Arrow again."
-      fi
-  fi
-
-  #------------------------------------------------------------------------------
-  # Build MLIR
-  #------------------------------------------------------------------------------
-  # We rarely need to build MLIR/LLVM, only during the first build of the
-  # prototype and after upgrades of the LLVM sub-module. To avoid unnecessary
-  # builds (which take several seconds even if there is nothing to do), we store
-  # the LLVM commit hash we built into a file, and only rebuild MLIR/LLVM if this
-  # file does not exist (first build of the prototype) or does not contain the
-  # expected hash (upgrade of the LLVM sub-module).
-
-  llvmName="llvm-project"
-  llvmCommit="llvmCommit-local-none"
-  cd "${thirdpartyPath}/${llvmName}"
-  if [ -e .git ] # Note: .git in the submodule is not a directory.
-  then
-    submodule_path=$(cat .git | cut -d ' ' -f 2)
-
-    # if the third party directory was loaded from gh action cache, this path will not exist
-    if [ -d $submodule_path ]; then
-      llvmCommit="$(git log -1 --format=%H)"
+        dependency_install_success "antlr_v${antlrVersion}"
     else
-      llvmCommit="20d454c79bbca7822eee88d188afb7a8747dac58"
+        daphne_msg "No need to build Antlr4 again."
     fi
-  else
-      # download and set up LLVM code if compilation is run without the local working copy being checked out from git
-      # e.g., compiling from released source artifact
-      llvmCommit="20d454c79bbca7822eee88d188afb7a8747dac58"
-      llvmSnapshotArtifact="llvm_${llvmCommit}.tar.gz"
-      llvmSnapshotPath="${cacheDir}/${llvmSnapshotArtifact}"
-      if ! is_dependency_downloaded "llvm_v${llvmCommit}"; then
+
+    #------------------------------------------------------------------------------
+    # catch2 (unit test framework)
+    #------------------------------------------------------------------------------
+    # Download catch2 release zip (if necessary), and unpack the single header file
+    # (if necessary).
+    catch2Name="catch2"
+    catch2ZipName="v$catch2Version.zip"
+    catch2SingleHeaderInstalledPath=$installPrefix/include/catch.hpp
+    if ! is_dependency_installed "catch2_v${catch2Version}"; then
+        daphne_msg "Get catch2 version ${catch2Version}"
+        mkdir --parents "${thirdpartyPath}/${catch2Name}"
+        cd "${thirdpartyPath}/${catch2Name}"
+        if [ ! -f "$catch2ZipName" ] || [ ! -f "$catch2SingleHeaderInstalledPath" ]; then
+            daphne_msg "Download catch2 version ${catch2Version}"
+            wget "https://github.com/catchorg/Catch2/archive/refs/tags/${catch2ZipName}" -qO "${cacheDir}/catch2-${catch2ZipName}"
+            unzip -q -p "$cacheDir/$catch2Name-$catch2ZipName" "Catch2-$catch2Version/single_include/catch2/catch.hpp" \
+                >"$catch2SingleHeaderInstalledPath"
+        fi
+        dependency_install_success "catch2_v${catch2Version}"
+    else
+        daphne_msg "No need to download Catch2 again."
+    fi
+
+    #------------------------------------------------------------------------------
+    # OpenBLAS (basic linear algebra subprograms)
+    #------------------------------------------------------------------------------
+    openBlasDirName="OpenBLAS-$openBlasVersion"
+    openBlasZipName="${openBlasDirName}.zip"
+    openBlasInstDirName=$installPrefix
+    if ! is_dependency_downloaded "openBlas_v${openBlasVersion}"; then
+        daphne_msg "Get OpenBlas version ${openBlasVersion}"
+        wget "https://github.com/xianyi/OpenBLAS/releases/download/v${openBlasVersion}/${openBlasZipName}" \
+            -qO "${cacheDir}/${openBlasZipName}"
+        unzip -q "$cacheDir/$openBlasZipName" -d "$sourcePrefix"
+        dependency_download_success "openBlas_v${openBlasVersion}"
+    fi
+    if ! is_dependency_installed "openBlas_v${openBlasVersion}"; then
+        cd "$sourcePrefix/$openBlasDirName"
+        make clean
+        # optimizes for multiple x86_64 architectures
+        make -j"$(nproc)" DYNAMIC_ARCH=1 TARGET=NEHALEM
+        make PREFIX="$openBlasInstDirName" install
+        cd - >/dev/null
+        dependency_install_success "openBlas_v${openBlasVersion}"
+    else
+        daphne_msg "No need to build OpenBlas again."
+    fi
+
+    #------------------------------------------------------------------------------
+    # nlohmann/json (library for JSON parsing)
+    #------------------------------------------------------------------------------
+    nlohmannjsonDirName=nlohmannjson
+    nlohmannjsonSingleHeaderName=json.hpp
+    if ! is_dependency_installed "nlohmannjson_v${nlohmannjsonVersion}"; then
+        daphne_msg "Get nlohmannjson version ${nlohmannjsonVersion}"
+        mkdir -p "${installPrefix}/include/${nlohmannjsonDirName}"
+        wget "https://github.com/nlohmann/json/releases/download/v$nlohmannjsonVersion/$nlohmannjsonSingleHeaderName" \
+            -qO "${installPrefix}/include/${nlohmannjsonDirName}/${nlohmannjsonSingleHeaderName}"
+        dependency_install_success "nlohmannjson_v${nlohmannjsonVersion}"
+    else
+        daphne_msg "No need to download nlohmannjson again."
+    fi
+
+    #------------------------------------------------------------------------------
+    # abseil (compiled separately to apply a patch)
+    #------------------------------------------------------------------------------
+    abslPath=$sourcePrefix/abseil-cpp
+    if ! is_dependency_downloaded "absl_v${abslVersion}"; then
+        daphne_msg "Get abseil version ${abslVersion}"
+        rm -rf "$abslPath"
+        git clone --depth 1 --branch "$abslVersion" https://github.com/abseil/abseil-cpp.git "$abslPath"
+        daphne_msg "Applying 0002-absl-stdmax-params.patch"
+        patch -Np1 -i "${patchDir}/0002-absl-stdmax-params.patch" -d "$abslPath"
+        dependency_download_success "absl_v${abslVersion}"
+    fi
+    if ! is_dependency_installed "absl_v${abslVersion}"; then
+        cmake -S "$abslPath" -B "$buildPrefix/absl" -G Ninja -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE \
+            -DCMAKE_INSTALL_PREFIX="$installPrefix" -DCMAKE_CXX_STANDARD=17 -DABSL_PROPAGATE_CXX_STD=ON
+        cmake --build "$buildPrefix/absl" --target install
+        dependency_install_success "absl_v${abslVersion}"
+    else
+        daphne_msg "No need to build Abseil again."
+    fi
+
+    #------------------------------------------------------------------------------
+    # gRPC
+    #------------------------------------------------------------------------------
+    grpcDirName="grpc"
+    grpcInstDir=$installPrefix
+    if ! is_dependency_downloaded "grpc_v${grpcVersion}"; then
+        daphne_msg "Get grpc version ${grpcVersion}"
+        # Download gRPC source code.
+        if [ -d "${sourcePrefix}/${grpcDirName}" ]; then
+            rm -rf "${sourcePrefix}/${grpcDirName:?}"
+        fi
+        git clone -b v$grpcVersion --depth 1 https://github.com/grpc/grpc "$sourcePrefix/$grpcDirName"
+        pushd "$sourcePrefix/$grpcDirName"
+        git submodule update --init --depth 1 third_party/boringssl-with-bazel
+        git submodule update --init --depth 1 third_party/cares/cares
+        git submodule update --init --depth 1 third_party/protobuf
+        git submodule update --init --depth 1 third_party/re2
+        daphne_msg "Applying 0003-protobuf-override.patch"
+        patch -Np1 -i "${patchDir}/0003-protobuf-override.patch" -d "$sourcePrefix/$grpcDirName/third_party/protobuf"
+        popd
+        dependency_download_success "grpc_v${grpcVersion}"
+    fi
+    if ! is_dependency_installed "grpc_v${grpcVersion}"; then
+        cmake -G Ninja -S "$sourcePrefix/$grpcDirName" -B "$buildPrefix/$grpcDirName" \
+            -DCMAKE_INSTALL_PREFIX="$grpcInstDir" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DgRPC_INSTALL=ON \
+            -DgRPC_BUILD_TESTS=OFF \
+            -DCMAKE_CXX_STANDARD=17 \
+            -DCMAKE_INCLUDE_PATH="$installPrefix/include" \
+            -DgRPC_ABSL_PROVIDER=package \
+            -DgRPC_ZLIB_PROVIDER=package
+        cmake --build "$buildPrefix/$grpcDirName" --target install
+        dependency_install_success "grpc_v${grpcVersion}"
+    else
+        daphne_msg "No need to build GRPC again."
+    fi
+
+    #------------------------------------------------------------------------------
+    # Arrow / Parquet
+    #------------------------------------------------------------------------------
+    arrowDirName="arrow"
+    if [[ "$BUILD_ARROW" == "-DUSE_ARROW=ON" ]]; then
+        if ! is_dependency_downloaded "arrow_v${arrowVersion}"; then
+            rm -rf "${sourcePrefix:?}/${arrowDirName}"
+            git clone -n https://github.com/apache/arrow.git "${sourcePrefix}/${arrowDirName}"
+            cd "${sourcePrefix}/${arrowDirName}"
+            git checkout $arrowVersion
+            dependency_download_success "arrow_v${arrowVersion}"
+        fi
+        if ! is_dependency_installed "arrow_v${arrowVersion}"; then
+            cmake -G Ninja -S "${sourcePrefix}/${arrowDirName}/cpp" -B "${buildPrefix}/${arrowDirName}" \
+                -DCMAKE_INSTALL_PREFIX="${installPrefix}" \
+                -DARROW_CSV=ON -DARROW_FILESYSTEM=ON -DARROW_PARQUET=ON
+            cmake --build "${buildPrefix}/${arrowDirName}" --target install
+            dependency_install_success "arrow_v${arrowVersion}"
+        else
+            daphne_msg "No need to build Arrow again."
+        fi
+    fi
+
+    #------------------------------------------------------------------------------
+    # Build MLIR
+    #------------------------------------------------------------------------------
+    # We rarely need to build MLIR/LLVM, only during the first build of the
+    # prototype and after upgrades of the LLVM sub-module. To avoid unnecessary
+    # builds (which take several seconds even if there is nothing to do), we store
+    # the LLVM commit hash we built into a file, and only rebuild MLIR/LLVM if this
+    # file does not exist (first build of the prototype) or does not contain the
+    # expected hash (upgrade of the LLVM sub-module).
+
+    llvmName="llvm-project"
+    llvmCommit="llvmCommit-local-none"
+    cd "${thirdpartyPath}/${llvmName}"
+    if [ -e .git ]; then # Note: .git in the submodule is not a directory.
+        submodule_path=$(cut -d ' ' -f 2 < .git)
+
+        # if the third party directory was loaded from gh action cache, this path will not exist
+        if [ -d "$submodule_path" ]; then
+            llvmCommit="$(git log -1 --format=%H)"
+        else
+            llvmCommit="20d454c79bbca7822eee88d188afb7a8747dac58"
+        fi
+    else
+        # download and set up LLVM code if compilation is run without the local working copy being checked out from git
+        # e.g., compiling from released source artifact
+        llvmCommit="20d454c79bbca7822eee88d188afb7a8747dac58"
+        llvmSnapshotArtifact="llvm_${llvmCommit}.tar.gz"
+        llvmSnapshotPath="${cacheDir}/${llvmSnapshotArtifact}"
+        if ! is_dependency_downloaded "llvm_v${llvmCommit}"; then
             daphne_msg "Geting LLVM/MLIR snapshot ${llvmCommit}"
-          wget https://github.com/llvm/llvm-project/archive/${llvmCommit}.tar.gz -qO "${llvmSnapshotPath}"
-          tar xzf "${llvmSnapshotPath}" --strip-components=1
-          dependency_download_success "llvm_v${llvmCommit}"
-      fi
-  fi
-
-  cd - > /dev/null # return back from llvm 3rd party subdir
-
-  if ! is_dependency_installed "llvm_v${llvmCommit}" || [ "$(cat "${llvmCommitFilePath}")" != "$llvmCommit" ]; then
-      daphne_msg "Building LLVM/MLIR from ${llvmCommit}"
-      cd "${thirdpartyPath}/${llvmName}"
-      echo "Need to build MLIR/LLVM."
-      cmake -G Ninja -S llvm -B "$buildPrefix/$llvmName" \
-         -DLLVM_ENABLE_PROJECTS=mlir \
-         -DLLVM_BUILD_EXAMPLES=OFF \
-         -DLLVM_TARGETS_TO_BUILD="X86" \
-         -DCMAKE_BUILD_TYPE=Release \
-         -DLLVM_ENABLE_ASSERTIONS=ON \
-         -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DLLVM_ENABLE_LLD=ON \
-         -DLLVM_ENABLE_RTTI=ON \
-         -DCMAKE_INSTALL_PREFIX="$installPrefix"
-      cmake --build "$buildPrefix/$llvmName" --target check-mlir
-      cmake --build "$buildPrefix/$llvmName" --target install
-      echo "$llvmCommit" > "$llvmCommitFilePath"
-      cd - > /dev/null
-      dependency_install_success "llvm_v${llvmCommit}"
-  else
-      daphne_msg "No need to build MLIR/LLVM again."
-  fi
-
-  if [[ $BUILD_FPGAOPENCL = *"ON"* ]]; then
-    FPGAOPENCL_BISTREAM_DIR="$projectRoot/src/runtime/local/kernels/FPGAOPENCL/bitstreams"
-    FPGAOPENCL_BISTREAM_URL="https://github.com/daphne-eu/supplemental-binaries/raw/main/fpga_bitstreams/"
-    if [ ! -d $FPGAOPENCL_BISTREAM_DIR ]; then
-      echo fetching FPGA bitstreams
-      mkdir -p $FPGAOPENCL_BISTREAM_DIR
-      cd $FPGAOPENCL_BISTREAM_DIR
-      wget $FPGAOPENCL_BISTREAM_URL/sgemm.aocx
-      wget $FPGAOPENCL_BISTREAM_URL/sgemv.aocx
-      wget $FPGAOPENCL_BISTREAM_URL/ssyrk.aocx
-      cd - > /dev/null
+            wget https://github.com/llvm/llvm-project/archive/${llvmCommit}.tar.gz -qO "${llvmSnapshotPath}"
+            tar xzf "${llvmSnapshotPath}" --strip-components=1
+            dependency_download_success "llvm_v${llvmCommit}"
+        fi
     fi
-  fi
+
+    cd - >/dev/null # return back from llvm 3rd party subdir
+
+    if ! is_dependency_installed "llvm_v${llvmCommit}" || [ "$(cat "${llvmCommitFilePath}")" != "$llvmCommit" ]; then
+        daphne_msg "Building LLVM/MLIR from ${llvmCommit}"
+        cd "${thirdpartyPath}/${llvmName}"
+        echo "Need to build MLIR/LLVM."
+        cmake -G Ninja -S llvm -B "$buildPrefix/$llvmName" \
+            -DLLVM_ENABLE_PROJECTS=mlir \
+            -DLLVM_BUILD_EXAMPLES=OFF \
+            -DLLVM_TARGETS_TO_BUILD="X86" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DLLVM_ENABLE_ASSERTIONS=ON \
+            -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DLLVM_ENABLE_LLD=ON \
+            -DLLVM_ENABLE_RTTI=ON \
+            -DCMAKE_INSTALL_PREFIX="$installPrefix"
+        cmake --build "$buildPrefix/$llvmName" --target check-mlir
+        cmake --build "$buildPrefix/$llvmName" --target install
+        echo "$llvmCommit" >"$llvmCommitFilePath"
+        cd - >/dev/null
+        dependency_install_success "llvm_v${llvmCommit}"
+    else
+        daphne_msg "No need to build MLIR/LLVM again."
+    fi
+
+    if [[ $BUILD_FPGAOPENCL = *"ON"* ]]; then
+        FPGAOPENCL_BISTREAM_DIR="$projectRoot/src/runtime/local/kernels/FPGAOPENCL/bitstreams"
+        FPGAOPENCL_BISTREAM_URL="https://github.com/daphne-eu/supplemental-binaries/raw/main/fpga_bitstreams/"
+        if [ ! -d "$FPGAOPENCL_BISTREAM_DIR" ]; then
+            echo fetching FPGA bitstreams
+            mkdir -p "$FPGAOPENCL_BISTREAM_DIR"
+            cd "$FPGAOPENCL_BISTREAM_DIR"
+            wget $FPGAOPENCL_BISTREAM_URL/sgemm.aocx
+            wget $FPGAOPENCL_BISTREAM_URL/sgemv.aocx
+            wget $FPGAOPENCL_BISTREAM_URL/ssyrk.aocx
+            cd - >/dev/null
+        fi
+    fi
 fi
 
 # *****************************************************************************
@@ -826,8 +820,8 @@ fi
 daphne_msg "Build Daphne"
 
 cmake -S "$projectRoot" -B "$daphneBuildDir" -G Ninja -DANTLR_VERSION="$antlrVersion" \
-  -DCMAKE_PREFIX_PATH="$installPrefix" \
-  $BUILD_CUDA $BUILD_ARROW $BUILD_FPGAOPENCL $BUILD_DEBUG
+    -DCMAKE_PREFIX_PATH="$installPrefix" \
+    $BUILD_CUDA $BUILD_ARROW $BUILD_FPGAOPENCL $BUILD_DEBUG
 
 cmake --build "$daphneBuildDir" --target "$target"
 

--- a/doc/DaphneDSLBuiltins.md
+++ b/doc/DaphneDSLBuiltins.md
@@ -392,7 +392,7 @@ The format is determined by the specified file name extension.
 Currently, the following formats are supported:
 - ".csv": comma-separated values
 - ".mtx": matrix market
-- ".parquet": Parquet (requires DAPHNE to be built with `--arrow`)
+- ".parquet": Apache Parquet format
 - ".dbdf": [DAPHNE's binary data format](/doc/BinaryFormat.md)
 
 For both reading and writing, file names can be specified as absolute or relative paths.

--- a/doc/GettingStarted.md
+++ b/doc/GettingStarted.md
@@ -51,7 +51,6 @@ Newer versions should work as well, older versions might work as well.
 | java (e.g. openjdk)                  | 11 (1.7 should be fine)   |                                                                                                                                         |
 | gfortran                             | 9.3.0                     |                                                                                                                                         |
 | uuid-dev                             |                           |                                                                                                                                         |
-| libboost-dev                         | 1.71.0.0                  | Only required when building with support for Arrow (`--arrow`)                                                                          |
 | wget                                 |                           | Used to fetch additional dependencies and other artefacts                                                                               |
 | ***                                  | ***                       | ***                                                                                                                                     |
 | CUDA SDK                             | 11.7.1                    | Optional for CUDA ops                                                                                                                   |

--- a/doc/GettingStarted.md
+++ b/doc/GettingStarted.md
@@ -28,32 +28,34 @@ Newer versions should work as well, older versions might work as well.
 
 ##### Operating system
 
-| OS        | distribution/version known to work (*)      | Comment                           |
-|-----------|---------------------------------------------|-----------------------------------|
-| GNU/Linux | Ubuntu 20.04.1 with kernel 5.8.0-43-generic ||
-| GNU/Linux | Ubuntu 18.04  | If used with Intel PAC D5005 FPGA |
+| OS        | distribution/version known to work (*) | Comment                                                                 |
+|-----------|----------------------------------------|-------------------------------------------------------------------------|
+| GNU/Linux | Manjaro                                | Last checked in January 2023                                            ||
+| GNU/Linux | Ubuntu 20.04 - 22.10                   | All versions in that range work. 20.04 needs CMake installed from Snap. |
+| GNU/Linux | Ubuntu 18.04                           | Used with Intel PAC D5005 FPGA, custom toolchain needed                 |
 
 ##### Software
 
-| tool/lib                           | version known to work (*) | comment                                                                                                                                 |
-|------------------------------------|---------------------------|-----------------------------------------------------------------------------------------------------------------------------------------|
-| clang                              | 10.0.0                    |                                                                                                                                         |
-| cmake                              | 3.17                      | On Ubuntu 20.04, install by `sudo snap install cmake --classic` to fulfill the version requirement; `apt` provides only version 3.16.3. |
-| git                                | 2.25.1                    |                                                                                                                                         |
-| libssl-dev                         | 1.1.1                     | Dependency introduced while optimizing grpc build (which used to build ssl unnecessarily)                                               |
-| lld                                | 10.0.0                    |                                                                                                                                         |
-| ninja                              | 1.10.0                    |                                                                                                                                         |
-| pkg-config                         | 0.29.1                    |                                                                                                                                         |
-| python3                            | 3.8.5                     |                                                                                                                                         |
-| numpy                              | 1.19.5                    |                                                                                                                                         |
-| java (e.g. openjdk)                | 11 (1.7 should be fine)   |                                                                                                                                         |
-| gfortran                           | 9.3.0                     |                                                                                                                                         |
-| uuid-dev                           |                           |                                                                                                                                         |
-| libboost-dev                       | 1.71.0.0                  | Only required when building with support for Arrow (`--arrow`)                                                                          |
-| wget                               |                           | Used to fetch additional dependencies and other artefacts                                                                               |
-| ***                                | ***                       | ***                                                                                                                                     |
-| CUDA SDK                           | 11.7.1                    | Optional for CUDA ops                                                                                                                   |
-| OneAPI SDK                         | 2022.x                    | Optional for OneAPI ops                                                                                                                 |
+| tool/lib                             | version known to work (*) | comment                                                                                                                                 |
+|--------------------------------------|---------------------------|-----------------------------------------------------------------------------------------------------------------------------------------|
+| GCC/G++                              | 9.3.0                     | Last checked version: 12.2                                                                                                              |
+| clang                                | 10.0.0                    |                                                                                                                                         |
+| cmake                                | 3.17                      | On Ubuntu 20.04, install by `sudo snap install cmake --classic` to fulfill the version requirement; `apt` provides only version 3.16.3. |
+| git                                  | 2.25.1                    |                                                                                                                                         |
+| libssl-dev                           | 1.1.1                     | Dependency introduced while optimizing grpc build (which used to build ssl unnecessarily)                                               |
+| lld                                  | 10.0.0                    |                                                                                                                                         |
+| ninja                                | 1.10.0                    |                                                                                                                                         |
+| pkg-config                           | 0.29.1                    |                                                                                                                                         |
+| python3                              | 3.8.5                     |                                                                                                                                         |
+| numpy                                | 1.19.5                    |                                                                                                                                         |
+| java (e.g. openjdk)                  | 11 (1.7 should be fine)   |                                                                                                                                         |
+| gfortran                             | 9.3.0                     |                                                                                                                                         |
+| uuid-dev                             |                           |                                                                                                                                         |
+| libboost-dev                         | 1.71.0.0                  | Only required when building with support for Arrow (`--arrow`)                                                                          |
+| wget                                 |                           | Used to fetch additional dependencies and other artefacts                                                                               |
+| ***                                  | ***                       | ***                                                                                                                                     |
+| CUDA SDK                             | 11.7.1                    | Optional for CUDA ops                                                                                                                   |
+| OneAPI SDK                           | 2022.x                    | Optional for OneAPI ops                                                                                                                 |
 | Intel FPGA SDK or OneAPI FPGA Add-On | 2022.x                    | Optional for FPGAOPENCL ops                                                                                                             |
 
 ##### Hardware
@@ -99,10 +101,19 @@ Simply build the system using the build-script without any arguments:
 When you do this the first time, or when there were updates to the LLVM submodule, this will also download and build the third-party material, which might increase the build time significantly.
 Subsequent builds, e.g., when you changed something in this repository, will be much faster.
 
-If the build fails in between (e.g., due to missing packages), multiple build directories (e.g., daphne, antlr, llvm) require cleanup. For convenience, you can call the following to remove them all.
-
+If the build fails in between (e.g., due to missing packages), multiple build directories (e.g., daphne, antlr, llvm) 
+require cleanup. To only remove build output use the following two commands:
 ```bash
 ./build.sh --clean
+./build.sh --cleanDeps
+```
+If you want to remove downloaded and extracted artifacts, use this:
+```bash
+./build.sh --cleanCache
+```
+For convenience, you can call the following to remove them all.
+```bash
+./build.sh --cleanAll
 ```
 
 See [this page](/doc/development/BuildingDaphne.md) for more information.

--- a/doc/README.md
+++ b/doc/README.md
@@ -40,7 +40,7 @@ limitations under the License.
 - [DAPHNE Configuration: Getting Information from the User](/doc/Config.md)
 - [Extending DAPHNE with more scheduling knobs](/doc/development/ExtendingSchedulingKnobs.md)
 - [Extending the DAPHNE Distributed Runtime](/doc/development/ExtendingDistributedRuntime.md)
-- [Building DAPHNE with the infamous build.sh script](/doc/development/BuildingDaphne.md)
+- [Building DAPHNE with the build.sh script](/doc/development/BuildingDaphne.md)
 
 ### Source Code Documentation
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -40,6 +40,7 @@ limitations under the License.
 - [DAPHNE Configuration: Getting Information from the User](/doc/Config.md)
 - [Extending DAPHNE with more scheduling knobs](/doc/development/ExtendingSchedulingKnobs.md)
 - [Extending the DAPHNE Distributed Runtime](/doc/development/ExtendingDistributedRuntime.md)
+- [Building DAPHNE with the infamous build.sh script](/doc/development/BuildingDaphne.md)
 
 ### Source Code Documentation
 

--- a/doc/development/BuildingDaphne.md
+++ b/doc/development/BuildingDaphne.md
@@ -107,7 +107,6 @@ All possible options for the build script:
 | --debug                 | Compile the daphne binary with debug symbols                                               |
 | --oneapi                | Compile with support for accelerated operations using the OneAPI SDK                       |
 | --fpgaopencl            | Compile with support for FPGA operations using the Intel FPGA SDK or OneAPI+FPGA Add-On    |
-| --arrow                 | Compile with support for Apache Arrow                                                      |
 
 ## 2. Extension
 ### Overview over the build script

--- a/doc/development/BuildingDaphne.md
+++ b/doc/development/BuildingDaphne.md
@@ -66,19 +66,20 @@ Clean all download and build directories, i.e., `<project_root>/build`, `<projec
 ### Options
 All possible options for the build script:
 
-| Option             | Effect                                                                                  |
-|--------------------|-----------------------------------------------------------------------------------------|
-| -h, --help         | Print the help page                                                                     |
-| --clean            | Clean build directories                                                                 |
-| --cleanAll         | Clean build directories and download directories                                        |
-| --target \<target> | Build specific target                                                                   |
-| -nf, --no-fancy    | Disable colorized output                                                                |
-| -y, --yes          | Accept prompt (e.g., when executing the clean command)                                  |
-| --cuda             | Compile with support for GPU operations using the CUDA SDK                              |
-| --debug            | Compile the daphne binary with debug symbols                                            |
-| --oneapi           | Compile with support for accelerated operations using the OneAPI SDK                    |
-| --fpgaopencl       | Compile with support for FPGA operations using the Intel FPGA SDK or OneAPI+FPGA Add-On |
-| --arrow            | Compile with support for Apache Arrow                                                   |
+| Option                 | Effect                                                                                     |
+|------------------------|-----------------------------------------------------------------------------------------|
+| -h, --help             | Print the help page                                                                        |
+| --installPrefix <path> | Install third party dependencies in <path> (default: <project_root>/thirdparty)            | 
+| --clean                | Clean build directories                              |
+| --cleanAll             | Clean build directories and download directories |
+| --target \<target>     | Build specific target                                                                      |
+| -nf, --no-fancy        | Disable colorized output                                                                   |
+| -y, --yes              | Accept prompt (e.g., when executing the clean command)                                     |
+| --cuda                 | Compile with support for GPU operations using the CUDA SDK                                 |
+| --debug                | Compile the daphne binary with debug symbols                                               |
+| --oneapi               | Compile with support for accelerated operations using the OneAPI SDK                       |
+| --fpgaopencl           | Compile with support for FPGA operations using the Intel FPGA SDK or OneAPI+FPGA Add-On    |
+| --arrow                | Compile with support for Apache Arrow                                                      |
 
 
 ## 2. Extension

--- a/doc/development/BuildingDaphne.md
+++ b/doc/development/BuildingDaphne.md
@@ -51,36 +51,63 @@ For example the following builds the main test target.
 
 ### Clean
 
-Clean all build directories, i.e., the daphne build dir `<project_root>/build` and the build directory of the dependencies 
-`<project_root>/thirdparty/build`:
+Clean all build directories, i.e., the daphne build dir `<project_root>/build` and the build output in 
+`<project_root>/bin` and  `<project_root>/lib`
 
 ```bash
 ./build.sh --clean
 ```
 
-Clean all download and build directories, i.e., `<project_root>/build`, `<project_root>/thirdparty/installed`, `<project_root>/thirdparty/build`, `<project_root>/thirdparty/sources`, and `<project_root>/thirdparty/download-cache`:
+Clean all downloads and extracted archive directories, i.e., `<thirdparty_dir`/download-cache, `<thirdparty_dir`/sources
+and `<thirdparty_dir`/*.download.success files: 
+
+```bash
+./build.sh --cleanCache
+```
+
+Clean third party build output, i.e., `<thirdparty_dir>/installed`, `<thirdparty_dir>/build` and 
+`<thirdparty_dir`/*.install.success files:
+
+```bash
+./build.sh --cleanDeps
+```
+
+Clean everything (DAPHNE build output and third party directory)
 
 ```bash
 ./build.sh --cleanAll
 ```
+
+### Minimize long compile times of dependencies
+The most time consuming part of getting DAPHNE compiled is building the third party dependencies.
+To avoid this, one can either use a prebuilt container image (in combination with some parameters to the build script 
+see below)) or at least build the dependencies once and subsequently point to the directory where the third party
+dependencies get installed. The bulid script must be invoked with the following two parameters to achieve this:
+``` ./build.sh --no-deps --installPrefix <path/to/installed/deps  ```. 
+
+If you have built DAPHNE and **change the installPrefix directory**, it is required to clean up and build again:
+``` ./build.sh --clean ```
+
 ### Options
 All possible options for the build script:
 
 | Option                 | Effect                                                                                     |
-|------------------------|-----------------------------------------------------------------------------------------|
+|------------------------|--------------------------------------------------------------------------------------------|
 | -h, --help             | Print the help page                                                                        |
 | --installPrefix <path> | Install third party dependencies in <path> (default: <project_root>/thirdparty)            | 
-| --clean                | Clean build directories                              |
-| --cleanAll             | Clean build directories and download directories |
+| --clean                | Clean DAPHNE build output (<project_root>/{bin,build,lib})                                 |
+| --cleanCache           | Clean downloaded and extracted third party artifacts                                       |
+| --cleanDeps            | Clean third party dependency build output and installed files                              |
+| --cleanAll             | Clean DAPHNE build output and reset the third party directory to the state in the git repo |
 | --target \<target>     | Build specific target                                                                      |
 | -nf, --no-fancy        | Disable colorized output                                                                   |
+| --no-deps              | Avoid building third party dependencies                                                    |
 | -y, --yes              | Accept prompt (e.g., when executing the clean command)                                     |
 | --cuda                 | Compile with support for GPU operations using the CUDA SDK                                 |
 | --debug                | Compile the daphne binary with debug symbols                                               |
 | --oneapi               | Compile with support for accelerated operations using the OneAPI SDK                       |
 | --fpgaopencl           | Compile with support for FPGA operations using the Intel FPGA SDK or OneAPI+FPGA Add-On    |
 | --arrow                | Compile with support for Apache Arrow                                                      |
-
 
 ## 2. Extension
 ### Overview over the build script
@@ -102,7 +129,9 @@ The following list contains a rough overview over the segments and the concrete 
 3. Clean build directories
    1. **clean(** \<array ref dirs> \<array ref files> **)** // removes all given directories (1. parameter) and all given files (2. parameter) from disk
    2. **cleanBuildDirs()** // cleans build dirs (daphne and dependency build dirs)
-   3. **cleanAll()** // cleans daphne build dir and wipes all dependencies from disk 
+   3. **cleanAll()** // cleans daphne build dir and wipes all dependencies from disk (resetting the third party directory) 
+   4. **cleanDeps()** // removes third party build output
+   5. **cleanCache()** // removes downloaded third party artifacts (but leaving git submodules (only LLVM/MLIR at the time of writing)
 4. Create / Check Indicator-files
    1. **dependency_install_success(** \<dep> **)** // used after successful build of a dependency; creates related indicator file 
    2. **dependency_download_success(** \<dep> **)** // used after successful download of a dependency; creates related indicator file

--- a/doc/development/BuildingDaphne.md
+++ b/doc/development/BuildingDaphne.md
@@ -52,21 +52,21 @@ For example the following builds the main test target.
 ### Clean
 
 Clean all build directories, i.e., the daphne build dir `<project_root>/build` and the build output in 
-`<project_root>/bin` and  `<project_root>/lib`
+`<project_root>/bin` and `<project_root>/lib`
 
 ```bash
 ./build.sh --clean
 ```
 
-Clean all downloads and extracted archive directories, i.e., `<thirdparty_dir`/download-cache, `<thirdparty_dir`/sources
-and `<thirdparty_dir`/*.download.success files: 
+Clean all downloads and extracted archive directories, i.e., `<thirdparty_dir>`/download-cache, `<thirdparty_dir>`/sources
+and `<thirdparty_dir>`/*.download.success files: 
 
 ```bash
 ./build.sh --cleanCache
 ```
 
 Clean third party build output, i.e., `<thirdparty_dir>/installed`, `<thirdparty_dir>/build` and 
-`<thirdparty_dir`/*.install.success files:
+`<thirdparty_dir>`/*.install.success files:
 
 ```bash
 ./build.sh --cleanDeps
@@ -91,23 +91,23 @@ If you have built DAPHNE and **change the installPrefix directory**, it is requi
 ### Options
 All possible options for the build script:
 
-| Option                 | Effect                                                                                     |
-|------------------------|--------------------------------------------------------------------------------------------|
-| -h, --help             | Print the help page                                                                        |
-| --installPrefix <path> | Install third party dependencies in <path> (default: <project_root>/thirdparty)            | 
-| --clean                | Clean DAPHNE build output (<project_root>/{bin,build,lib})                                 |
-| --cleanCache           | Clean downloaded and extracted third party artifacts                                       |
-| --cleanDeps            | Clean third party dependency build output and installed files                              |
-| --cleanAll             | Clean DAPHNE build output and reset the third party directory to the state in the git repo |
-| --target \<target>     | Build specific target                                                                      |
-| -nf, --no-fancy        | Disable colorized output                                                                   |
-| --no-deps              | Avoid building third party dependencies                                                    |
-| -y, --yes              | Accept prompt (e.g., when executing the clean command)                                     |
-| --cuda                 | Compile with support for GPU operations using the CUDA SDK                                 |
-| --debug                | Compile the daphne binary with debug symbols                                               |
-| --oneapi               | Compile with support for accelerated operations using the OneAPI SDK                       |
-| --fpgaopencl           | Compile with support for FPGA operations using the Intel FPGA SDK or OneAPI+FPGA Add-On    |
-| --arrow                | Compile with support for Apache Arrow                                                      |
+| Option                  | Effect                                                                                     |
+|-------------------------|--------------------------------------------------------------------------------------------|
+| -h, --help              | Print the help page                                                                        |
+| --installPrefix \<path> | Install third party dependencies in \<path> (default: <project_root>/thirdparty/installed) | 
+| --clean                 | Clean DAPHNE build output (<project_root>/{bin,build,lib})                                 |
+| --cleanCache            | Clean downloaded and extracted third party artifacts                                       |
+| --cleanDeps             | Clean third party dependency build output and installed files                              |
+| --cleanAll              | Clean DAPHNE build output and reset the third party directory to the state in the git repo |
+| --target \<target>      | Build specific target                                                                      |
+| -nf, --no-fancy         | Disable colorized output                                                                   |
+| --no-deps               | Avoid building third party dependencies                                                    |
+| -y, --yes               | Accept prompt (e.g., when executing the clean command)                                     |
+| --cuda                  | Compile with support for GPU operations using the CUDA SDK                                 |
+| --debug                 | Compile the daphne binary with debug symbols                                               |
+| --oneapi                | Compile with support for accelerated operations using the OneAPI SDK                       |
+| --fpgaopencl            | Compile with support for FPGA operations using the Intel FPGA SDK or OneAPI+FPGA Add-On    |
+| --arrow                 | Compile with support for Apache Arrow                                                      |
 
 ## 2. Extension
 ### Overview over the build script

--- a/pack.sh
+++ b/pack.sh
@@ -20,7 +20,7 @@ set -e
 function exit_with_usage {
   cat << EOF
 usage: pack.sh --version VERSION --feature FEATURE
---feature FEATURE......a feature flag like --cuda, --arrow, etc (omit or "none" for plain Daphne)
+--feature FEATURE......a feature flag like --cuda, etc (omit or "none" for plain Daphne)
 EOF
   exit 1
 }
@@ -66,7 +66,6 @@ fi
 
 # shellcheck disable=SC2254
 case "$FEATURE" in
-  arrow) ;&
   cuda)  ;&
   debug) ;&
   fpgaopencl)

--- a/release.sh
+++ b/release.sh
@@ -26,7 +26,7 @@ usage: $0 --version VERSION --githash GIT_HASH [ --gpgkey GPG_KEY ] [ --artifact
 
 --artifact: If supplied, building the release artifact will be skipped and the script will only perform
             checksumming and optional signing.
---feature FEATURE......a feature flag like --cuda, --arrow, etc (omit or "none" for plain Daphne)
+--feature FEATURE......a feature flag like --cuda, etc (omit or "none" for plain Daphne)
 EOF
   exit 1
 }

--- a/src/parser/config/ConfigParser.cpp
+++ b/src/parser/config/ConfigParser.cpp
@@ -30,7 +30,7 @@ bool ConfigParser::fileExists(const std::string& filename) {
 
 void ConfigParser::readUserConfig(const std::string& filename, DaphneUserConfig& config) {
     std::ifstream ifs(filename);
-    nlohmann::basic_json jf = nlohmann::json::parse(ifs);
+    auto jf = nlohmann::json::parse(ifs);
 
 //try {
     checkAnyUnexpectedKeys(jf, filename);   // raise an error if the config JSON file contains any unexpected keys

--- a/src/runtime/distributed/worker/CMakeLists.txt
+++ b/src/runtime/distributed/worker/CMakeLists.txt
@@ -40,6 +40,8 @@ set(LIBS
         CallData
         Proto
         DaphneMetaDataParser
+        Arrow::arrow_shared
+        Parquet::parquet_shared
         )
 
 add_library(WorkerImpl ${SOURCES})

--- a/src/runtime/local/kernels/CMakeLists.txt
+++ b/src/runtime/local/kernels/CMakeLists.txt
@@ -94,5 +94,6 @@ else()
     list(APPEND LIBS LLVMSupport)
 endif()
 
-list(APPEND LIBS DaphneMetaDataParser MLIRDaphne MLIRDaphneTransforms)
+list(APPEND LIBS Arrow::arrow_shared Parquet::parquet_shared DaphneMetaDataParser MLIRDaphne MLIRDaphneTransforms)
+
 target_link_libraries(AllKernels PUBLIC ${LIBS})

--- a/src/runtime/local/kernels/Read.h
+++ b/src/runtime/local/kernels/Read.h
@@ -91,15 +91,11 @@ struct Read<DenseMatrix<VT>> {
 	case 1:
 		readMM(res, filename);
 		break;
-#ifdef USE_ARROW
 	case 2:
 		if(res == nullptr)
-			res = DataObjectFactory::create<DenseMatrix<VT>>(
-				fmd.numRows, fmd.numCols, false
-			);
+			res = DataObjectFactory::create<DenseMatrix<VT>>(fmd.numRows, fmd.numCols, false);
 		readParquet(res, filename, fmd.numRows, fmd.numCols);
 		break;
-#endif
 	case 3:
 		readDaphne(res, filename);
                 break;
@@ -135,15 +131,11 @@ struct Read<CSRMatrix<VT>> {
 	case 1:
 		readMM(res, filename);
 		break;
-#ifdef USE_ARROW
 	case 2:
 		if(res == nullptr)
-			res = DataObjectFactory::create<CSRMatrix<VT>>(
-				fmd.numRows, fmd.numCols, fmd.numNonZeros, false
-			);
+			res = DataObjectFactory::create<CSRMatrix<VT>>(fmd.numRows, fmd.numCols, fmd.numNonZeros, false);
 		readParquet(res, filename,fmd.numRows, fmd.numCols,fmd.numNonZeros, false);
 		break;
-#endif
 	case 3:
 		readDaphne(res, filename);
                 break;

--- a/test.sh
+++ b/test.sh
@@ -28,7 +28,6 @@ set -e
 
 catch2_options=""
 BUILD_CUDA=""
-BUILD_ARROW=""
 BUILD_FPGAOPENCL=""
 BUILD_DEBUG=""
 
@@ -39,10 +38,6 @@ while [[ $# -gt 0 ]]; do
         --cuda)
             echo using CUDA
             export BUILD_CUDA="--cuda"
-            ;;
-        --arrow)
-            echo using ARROW
-            BUILD_ARROW="--arrow"
             ;;
         --fpgaopencl)
             echo using FPGAOPENCL
@@ -59,7 +54,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 # Build tests.
-./build.sh $BUILD_CUDA $BUILD_ARROW $BUILD_FPGAOPENCL $BUILD_DEBUG --target run_tests
+./build.sh $BUILD_CUDA $BUILD_FPGAOPENCL $BUILD_DEBUG --target run_tests
 
 # Preparations for running DaphneLib (Python API) tests.
 export PYTHONPATH="$PYTHONPATH:$PWD/src/"

--- a/test/runtime/local/io/ReadParquetTest.cpp
+++ b/test/runtime/local/io/ReadParquetTest.cpp
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#ifdef USE_ARROW
-
 #include <runtime/local/datastructures/Frame.h>
 #include <runtime/local/datastructures/DenseMatrix.h>
 #include <runtime/local/datastructures/CSRMatrix.h>
@@ -85,5 +83,3 @@ TEMPLATE_PRODUCT_TEST_CASE("ReadParquet, DenseMatrix", TAG_IO, (DenseMatrix), (d
 
   DataObjectFactory::destroy(m);
 }
-
-#endif

--- a/thirdparty/patches/0004-arrow-git-log.patch
+++ b/thirdparty/patches/0004-arrow-git-log.patch
@@ -1,0 +1,24 @@
+--- cpp/cmake_modules/DefineOptions.cmake	2023-01-18 14:08:12.000000000 +0100
++++ cpp/cmake_modules/DefineOptions.cmake       2023-02-08 23:45:20.907959122 +0100
+
+@@ -729,7 +729,7 @@
+ # Compute default values for omitted variables
+ 
+ if(NOT ARROW_GIT_ID)
++  execute_process(COMMAND "git" " -c log.showSignature=false" "log" "-n1" "--format=%H"
+-  execute_process(COMMAND "git" "log" "-n1" "--format=%H"
+                   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+                   OUTPUT_VARIABLE ARROW_GIT_ID
+                   OUTPUT_STRIP_TRAILING_WHITESPACE)
+--- python/cmake_modules/DefineOptions.cmake    2023-01-18 14:08:12.000000000 +0100
++++ python/cmake_modules/DefineOptions.cmake    2023-02-08 23:45:20.907959122 +0100
+@@ -729,7 +729,7 @@
+ # Compute default values for omitted variables
+
+ if(NOT ARROW_GIT_ID)
++  execute_process(COMMAND "git" " -c log.showSignature=false" "log" "-n1" "--format=%H"
+-  execute_process(COMMAND "git" "log" "-n1" "--format=%H"
+                   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+                   OUTPUT_VARIABLE ARROW_GIT_ID
+                   OUTPUT_STRIP_TRAILING_WHITESPACE)
+


### PR DESCRIPTION
This PR contains several minor and major improvements to our infamous build script. Some of it is prep work for building daphne containers.

Commit messages speak for themselves but here's a quick summary:

* The clean parameters are changed according to #466 
* The prefix where third party dependencies are installed can be set with --installPrefix <path>
* The LLVM/MLIR dependency is now installed into installPrefix and the use of buildPrefix removed from the main cmake config invocation (at the bottom of build.sh)
* Third party dependency compilation can be omitted via --no-deps flag 