### PR TITLE
Duplicate inputs in pipeline input array.

### DIFF
--- a/test/api/cli/distributed/distributed_1.daphne
+++ b/test/api/cli/distributed/distributed_1.daphne
@@ -1,5 +1,2 @@
-// TODO: For now distributed runtime support only unique inputs, for a pipeline.
-// Therefore we create two different matrices instead of one & using it twice for the binary op.
-m1 = rand(10, 10, 0.0, 20.0, 1.0, 0);
-m2 = rand(10, 10, 0.0, 20.0, 1.0, 0);
-print(m1 + m2);
+m = rand(10, 10, 0.0, 20.0, 1.0, 0);
+print(m + m);

--- a/test/api/cli/distributed/distributed_2.daphne
+++ b/test/api/cli/distributed/distributed_2.daphne
@@ -1,5 +1,2 @@
-// TODO: For now distributed runtime support only unique inputs, for a pipeline.
-// Therefore we create two different matrices instead of one & using it twice for the binary op.
-m1 = rand(1500, 1200, 10.0, 20.0, 1.0, 0);
-m2 = rand(1500, 1200, 10.0, 20.0, 1.0, 0);
-print(m1 + m2);
+m = rand(1500, 1200, 10.0, 20.0, 1.0, 0);
+print(m + m);


### PR DESCRIPTION
Both vectorized and distributed pipelines could include an input multiple times in the pipeline input array.

Updated canonicalization pass for VectorizedPipelineOp in order to scan for duplicate inputs and in case both inputs have the same `VectorSplits` entry, one of them is removed.

Closes #461.