### PR TITLE
Add profiling support

### DIFF
--- a/doc/GettingStarted.md
+++ b/doc/GettingStarted.md
@@ -48,6 +48,7 @@ launching DAPHNE via Docker (see below) should work the same way as in a native 
 | cmake                                | 3.17                      | On Ubuntu 20.04, install by `sudo snap install cmake --classic` to fulfill the version requirement; `apt` provides only version 3.16.3. |
 | git                                  | 2.25.1                    |                                                                                                                                         |
 | libssl-dev                           | 1.1.1                     | Dependency introduced while optimizing grpc build (which used to build ssl unnecessarily)                                               |
+| libpfm4-dev                          | 4.10                      | This dependency is needed for profiling support [DAPHNE-#479]                                                                           |
 | lld                                  | 10.0.0                    |                                                                                                                                         |
 | ninja                                | 1.10.0                    |                                                                                                                                         |
 | pkg-config                           | 0.29.1                    |                                                                                                                                         |

--- a/src/api/cli/DaphneUserConfig.h
+++ b/src/api/cli/DaphneUserConfig.h
@@ -46,6 +46,7 @@ struct DaphneUserConfig {
     bool hyperthreadingEnabled = false;
     bool debugMultiThreading = false;
     bool use_fpgaopencl = false;
+    bool enable_profiling = false;
 
     bool debug_llvm = false;
     bool explain_kernels = false;

--- a/src/api/internal/daphne_internal.cpp
+++ b/src/api/internal/daphne_internal.cpp
@@ -266,6 +266,11 @@ int startDAPHNE(int argc, const char** argv, DaphneLibResult* daphneLibRes, int 
         llvm::cl::init(configFileInitValue)
     );
 
+    static opt<bool> enableProfiling (
+            "enable-profiling", cat(daphneOptions),
+            desc("Enable profiling support")
+    );
+
     // Positional arguments ---------------------------------------------------
     
     static opt<string> inputFile(Positional, desc("script"), Required);
@@ -404,6 +409,9 @@ int startDAPHNE(int argc, const char** argv, DaphneLibResult* daphneLibRes, int 
         user_config.use_fpgaopencl = true;
     }
 
+    if(enableProfiling) {
+        user_config.enable_profiling = true;
+    }
 
     // add this after the cli args loop to work around args order
     if(!user_config.libdir.empty() && user_config.use_cuda)

--- a/src/compiler/execution/DaphneIrExecutor.cpp
+++ b/src/compiler/execution/DaphneIrExecutor.cpp
@@ -136,6 +136,9 @@ bool DaphneIrExecutor::runPasses(mlir::ModuleOp module)
         if (userConfig_.use_distributed)
             pm.addPass(mlir::daphne::createDistributePipelinesPass());
 
+        if (userConfig_.enable_profiling)
+            pm.addNestedPass<mlir::func::FuncOp>(mlir::daphne::createProfilingPass());
+
         pm.addNestedPass<mlir::func::FuncOp>(mlir::daphne::createInsertDaphneContextPass(userConfig_));
 
 #ifdef USE_CUDA

--- a/src/compiler/lowering/CMakeLists.txt
+++ b/src/compiler/lowering/CMakeLists.txt
@@ -19,6 +19,7 @@ add_mlir_dialect_library(MLIRDaphneTransforms
     MarkCUDAOpsPass.cpp
     MarkFPGAOPENCLOpsPass.cpp
     InsertDaphneContextPass.cpp
+    ProfilingPass.cpp
     ManageObjRefsPass.cpp
     LowerToLLVMPass.cpp
     RewriteToCallKernelOpPass.cpp

--- a/src/compiler/lowering/ProfilingPass.cpp
+++ b/src/compiler/lowering/ProfilingPass.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 The DAPHNE Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <ir/daphneir/Daphne.h>
+#include <ir/daphneir/Passes.h>
+
+#include <mlir/Pass/Pass.h>
+
+using namespace mlir;
+
+#include <iostream>
+
+/**
+ * @brief Inserts profiling tracepoints
+ */
+struct ProfilingPass: public PassWrapper<ProfilingPass, OperationPass<func::FuncOp>>
+{
+    explicit ProfilingPass() {}
+    void runOnOperation() final;
+};
+
+void ProfilingPass::runOnOperation()
+{
+    func::FuncOp f = getOperation();
+    Block & b = f.getBody().front();
+
+    OpBuilder builder(&b, b.begin());
+    Location loc = builder.getUnknownLoc();
+
+    builder.create<daphne::StartProfilingOp>(loc);
+    builder.setInsertionPoint(b.getTerminator());
+    builder.create<daphne::StopProfilingOp>(loc);
+}
+
+std::unique_ptr<Pass> daphne::createProfilingPass()
+{
+    return std::make_unique<ProfilingPass>();
+}

--- a/src/ir/daphneir/DaphneOps.td
+++ b/src/ir/daphneir/DaphneOps.td
@@ -1428,6 +1428,24 @@ def Daphne_DecRefOp : Daphne_Op<"decRef"> {
 }
 
 // ****************************************************************************
+// Profiling
+// ****************************************************************************
+
+def Daphne_StartProfilingOp : Daphne_Op<"startProfiling"> {
+    let summary = "Starts profiling";
+
+    let arguments = (ins); // no arguments
+    let results = (outs); // no results
+}
+
+def Daphne_StopProfilingOp : Daphne_Op<"stopProfiling"> {
+    let summary = "Stops profiling";
+
+    let arguments = (ins); //no arguments
+    let results = (outs); // no results
+}
+
+// ****************************************************************************
 // Old operations
 // ****************************************************************************
 // These are currently still need for the prototype to work. They will be

--- a/src/ir/daphneir/Passes.h
+++ b/src/ir/daphneir/Passes.h
@@ -45,6 +45,7 @@ namespace mlir::daphne {
     std::unique_ptr<Pass> createDistributePipelinesPass();
     std::unique_ptr<Pass> createInferencePass(InferenceConfig cfg = {false, true, true, true, true});
     std::unique_ptr<Pass> createInsertDaphneContextPass(const DaphneUserConfig& cfg);
+    std::unique_ptr<Pass> createProfilingPass();
     std::unique_ptr<Pass> createLowerToLLVMPass(const DaphneUserConfig& cfg);
     std::unique_ptr<Pass> createManageObjRefsPass();
     std::unique_ptr<Pass> createPrintIRPass(std::string message = "");

--- a/src/runtime/local/kernels/CMakeLists.txt
+++ b/src/runtime/local/kernels/CMakeLists.txt
@@ -100,6 +100,10 @@ else()
     list(APPEND LIBS LLVMSupport Util MLIRDaphneInference)
 endif()
 
-list(APPEND LIBS Eigen3::Eigen Arrow::arrow_shared Parquet::parquet_shared DaphneMetaDataParser MLIRDaphne MLIRDaphneTransforms)
 
-target_link_libraries(AllKernels PUBLIC ${LIBS} ${MPI_LIBRARIES})
+list(APPEND LIBS DaphneMetaDataParser MLIRDaphne MLIRDaphneTransforms)
+list(APPEND LIBS Eigen3::Eigen Arrow::arrow_shared Parquet::parquet_shared)
+
+find_library(PAPI_LIB NAMES libpapi.so HINTS ${PROJECT_BINARY_DIR}/installed/lib REQUIRED)
+
+target_link_libraries(AllKernels PUBLIC ${LIBS} ${MPI_LIBRARIES} ${PAPI_LIB})

--- a/src/runtime/local/kernels/StartProfiling.h
+++ b/src/runtime/local/kernels/StartProfiling.h
@@ -14,8 +14,16 @@
  * limitations under the License.
  */
 
-#include <api/internal/daphne_internal.h>
+#pragma once
 
-int main(int argc, const char** argv) {
-    return mainInternal(argc, argv, nullptr);
+#include <runtime/local/context/DaphneContext.h>
+
+#include <papi.h>
+
+// ****************************************************************************
+// Convenience function
+// ****************************************************************************
+
+void startProfiling(DCTX(ctx)) {
+    PAPI_hl_region_begin("fixme");
 }

--- a/src/runtime/local/kernels/StopProfiling.h
+++ b/src/runtime/local/kernels/StopProfiling.h
@@ -14,8 +14,16 @@
  * limitations under the License.
  */
 
-#include <api/internal/daphne_internal.h>
+#pragma once
 
-int main(int argc, const char** argv) {
-    return mainInternal(argc, argv, nullptr);
+#include <runtime/local/context/DaphneContext.h>
+
+#include <papi.h>
+
+// ****************************************************************************
+// Convenience function
+// ****************************************************************************
+
+void stopProfiling(DCTX(ctx)) {
+    PAPI_hl_region_end("fixme");
 }

--- a/src/runtime/local/kernels/kernels.json
+++ b/src/runtime/local/kernels/kernels.json
@@ -3552,5 +3552,29 @@
                 ]
             }
         ]
+    },
+    {
+        "kernelTemplate": {
+            "header": "StartProfiling.h",
+            "opName": "startProfiling",
+            "returnType": "void",
+            "templateParams": [],
+            "runtimeParams": []
+        },
+        "instantiations": [
+            []
+        ]
+    },
+    {
+        "kernelTemplate": {
+            "header": "StopProfiling.h",
+            "opName": "stopProfiling",
+            "returnType": "void",
+            "templateParams": [],
+            "runtimeParams": []
+        },
+        "instantiations": [
+            []
+        ]
     }
 ]


### PR DESCRIPTION
This is an initial attempt at adding profiling support to Daphne. As a first draft, I've added support for the [PAPI library](https://icl.utk.edu/papi/).

There's a profiling compiler pass that adds profiling 'tracepoints' at the beginning of each block, which call the Start/StopProfiling kernels.  This is more of a placeholder and we should decide exactly how / where this should be enabled. This can be exposed at the DSL / IR level via a pair of (start/stop) profiling operations.

The profiling kernels only support the HL (high-level) PAPI API at the moment, but we can switch to the low-level API if needed. PAPI also supports various plugins (e.g. for CUDA) which we can consider using / enabling.

Finally, we should also discuss whether PAPI is good enough or if we'd like to consider / evaluate other profiling tools / frameworks.

The documentation on how to use the new profiling infrastructure is also missing at the moment. You can try it by passing the   _--enable-profiling_ CLI option to Daphne and settings the relevant PAPI HL environmental variables, e.g.:
`PAPI_EVENTS="perf::CYCLES,perf::INSTRUCTIONS,perf::CACHE-REFERENCES,perf::CACHE MISSES,perf::BRANCHES,perf::BRANCH-MISSES" PAPI_REPORT=1 ./daphne --enable-profiling script.daph`

This PR partly addresses #423 
