### PR TITLE
[BUGFIX] Use the static versions of Arrow and Parquet libs

### DIFF
--- a/src/runtime/distributed/worker/CMakeLists.txt
+++ b/src/runtime/distributed/worker/CMakeLists.txt
@@ -40,8 +40,8 @@ set(LIBS
         CallData
         Proto
         DaphneMetaDataParser
-        Arrow::arrow_shared
-        Parquet::parquet_shared
+        Arrow::arrow_static
+        Parquet::parquet_static
         )
 
 add_library(WorkerImpl ${SOURCES})

--- a/src/runtime/local/kernels/CMakeLists.txt
+++ b/src/runtime/local/kernels/CMakeLists.txt
@@ -94,6 +94,6 @@ else()
     list(APPEND LIBS LLVMSupport)
 endif()
 
-list(APPEND LIBS Arrow::arrow_shared Parquet::parquet_shared DaphneMetaDataParser MLIRDaphne MLIRDaphneTransforms)
+list(APPEND LIBS Arrow::arrow_static Parquet::parquet_static DaphneMetaDataParser MLIRDaphne MLIRDaphneTransforms)
 
 target_link_libraries(AllKernels PUBLIC ${LIBS})


### PR DESCRIPTION
With our current build system, if we use a shared thirdparty library, the resulting binary (executable or shared library) depends on the absolute path of the shared library. This means that it might not be possible to run Daphne on a host other than the one we built it on.