### PR TITLE
[DAPHNE-#530] Docker Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,14 +16,19 @@ thirdparty/*
 
 # Python
 __pycache__/
-/venv
+/venv*
 
 # Jetbrains IDE
 .idea/
-cmake-*/
 
 tmpdaphne.daphne
 
 # release scripts output
 /artifacts
 
+bin/
+logs/
+profiler/
+precompiled-dependencies/
+/cmake*/
+/data

--- a/containers/Readme.md
+++ b/containers/Readme.md
@@ -14,39 +14,106 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-## DAPHNE container images
+# Getting Started with DAPHNE in a Docker Container
 
-This directory contains scripts and config files to build and run containers 
-that can be used to build and run DAPHNE. At the moment we support Docker and Singularity.
+Setting up a development environment for DAPHNE can be non-trivial, especially if different platforms 
+(operating systems and version etc.) are considered.
+Thus, we offer pre-built environments as docker container images that can be used on Linux and Windows/WSL hosts.
 
-The two containers we provide at the moment are 
-* **daphne-dev**: Use this to provide a container environment to the build script:<br/>
-``container/run-daphne-dev.sh ./build.sh`` <br/>
-This container is also used by our GitHub Action to test-build contributions to the main branch (and pull requests to main). 
-* **daphne-dev-interactive**: This container contains some additional convenience packages that are intended to
-make live easier in an interactive session. Additionally, it contains an entrypoint script that sets up 
-a user inside the container to circumvent permission issues.
+This documentation will explain:
+* building containers and running containers
+* docker container repositories
+  * for users: daphneeu/daphne
+  * for developers: daphneeu/daphne-dev
+* container types (docker and singularity)
+* accelerator support
 
-### Shell scripts for containers
-A quick intro how the shell scripts in this directory can aid in handling the DAPHNE containers is already given
-in [GettingStarted.md](../doc/GettingStarted.md)
+### Basic usage:
+   ```
+   # 1. Pull the DAPHNE source code.
+   git clone https://github.com/daphne-eu/daphne.git
+   cd daphne
+   
+   # 2. Pull the pre-built container image from DockerHub.   
+   docker pull daphneeu/daphne
+
+   # 3. Launch DAPHNE to run some DaphneDSL script
+   containers/quickstart.sh script/examples/hello-world.daph 
+   ```
+
+## Docker images
+The images we provide at the moment are 
+* **daphneeu/daphne**: This image provides a pre-compiled DAPHNE executable and is geared towards small image size
+  (containing only a minimal set of libraries required to run).
+* **daphneeu/daphne-dev**: This image provides an environment to build DAPHNE from source. Furthermore, it contains some 
+additional packages that are intended to make live easier in an interactive session and an 
+entrypoint script that sets up a user inside the container to circumvent permission issues and an ssh daemon to
+connect to a running container (useful for working remotely via VSCode for example).
+* **daphneeu/github-action**: this is used for continuous compilation via GitHub Actions
+* **daphneeu/daphne-deps**: this (unprovided) image is basically a checkpoint after the thirdparty dependencies have
+been built during image creation 
+
+## Container tags
+The images mentioned above come with different tags optionally support accelerator APIs:
+* **latest_BASE**: The image with this tag is the latest built for "standard" CPU operations.
+* **latest_CUDA**: This image incorporates the CUDA SDK (adding ~3.5GB of required disk space)
+* **< date >_< flavour >_< optional-version-string >_< OS-Version >**: This is the format of tags that indicate a daily/nightly
+build. E.g., <br /> ```2023-05-12_CUDA_12.1.1-cudnn8-runtime-ubuntu20.04``` identifies a **CUDA** image of CUDA version
+12.1.1 with *CUDNN 8** support that is based on Ubuntu 20.04 and was generated on the 12th of May 2023. 
+* For the currently imminent release 0.2 we will have a v0.2 tag. 
+* All images we provide at the moment are Ubuntu 20.04 based and run on the amd64 platform only. Developers frequently
+build for other OS and platform versions themselves. Contributions on the GitHub issue tracker are welcome.
+
+## Shell scripts for containers
+
+[//]: # (A quick intro how the shell scripts in this directory can aid in handling the DAPHNE containers is already given)
+[//]: # (in [GettingStarted.md]&#40;../doc/GettingStarted.md&#41;)
 
 The content of the scripts is quite self-explanatory but here's a shortlisting of what can be done:
-* **build-containers.sh**: Use this script to build your local Docker images. Alternatively, they can also be pulled 
-from Docker Hub: ``docker pull daphneeu/daphne-dev-interactive``
+* **build-containers.sh**: Use this script to build your local Docker images. The current setup in this script is 
+geared towards the DAPHNE image maintainers. So you might want to comment/remove what is not needed.
 * **run-docker-example.sh**: Use this as the starting point to customize scripts to launch the DAPHNE docker images from 
 your command line.
+* **quickstart.sh**: A quick start script to mount the current directory and run precompiled daphne. 
+* Tip: You can run any of the images with customizations disabled by providing an empty entrypoint parameter
+  (e.g., ``-entrypoint=``) to the ``docker run`` command.
 
-### Building a container
-To build the DAPHNE containers, use the provided ``build-containers.sh`` script contained in this directory.
+
+## Building a Docker container
+To build the DAPHNE containers, use the provided [``containers/build-containers.sh``](containers/build-containers.sh) 
+script contained in this directory.
 Edit the script to customize the repository and branch where DAPHNE is fetched from or to comment out one build command
 (e.g., if you don't want/need the interactive container).
 
-### Compiling DAPHNE 
-The provided containers contain a prebuilt version of the required third party dependencies. To use them 
-with build.sh (which by defaults tries to build the dependencies in the ``thirdparty`` subdirectory) the following parameters are required:
-``./build.sh --no-deps --installPrefix /usr/local``
+## Building a Singularity container
+To build a Singularity container instead of Docker use the following conversion technique:
+  ```bash
+    #one can also use [Singularity python](https://singularityhub.github.io/singularity-cli/)
+    #to convert the provided Dockerfile into Singularity recipe 
+    singularity build <ImageName.sif> docker://daphneeu/daphne-dev
+    
+    # This command will place you in a shell in the container, your home directory and /tmp mounted. 
+    singularity shell <ImageName.sif>
+    Singularity> cd <your/daphne/directory>
+    Singularity> ./build.sh --no-deps --installPrefix /usr/local
+```
+- Because the container instance works on the same folder, if one already built the system outside the container, it is 
+recommended to clean all build files to avoid conflicts (`./build.sh --clean -y`)
+- One may also do the commits from within the containers as normal (this holds for Singularity. With Docker images, your
+home directory and therefore your .gitconfig is usually not available (but this can be mitigated with additional work 
+by the user)).
+- The ssh remote access is not available right away. Manual work is required at the moment (and perhaps root privileges)
+to make this work. What'd be required are an sshd_config, generated host keys, manual sshd invocation and a custom port. 
+- For further options refer to the Singularity documentation (e.g., --nv for CUDA devices, etc).
+- These instructions should (in theory) be compatible to Apptainer but this is untested.
 
-### TODO
-* Rebuilding the containers automatically for latest changes
-* Images of released versions of DAPHNE 
+## Compiling DAPHNE 
+The provided dev containers contain a prebuilt version of the required third party dependencies. To use them (after
+creating a suitable script from the ``containers/run-docker-example.sh`` blueprints to launch the container) 
+with build.sh (which by defaults tries to build the dependencies in the ``thirdparty`` subdirectory) the following 
+parameters are required: ``./build.sh --no-deps --installPrefix /usr/local``
+
+
+[//]: # (### TODO)
+[//]: # (* Rebuilding the containers automatically for latest changes)
+[//]: # (* Images of released versions of DAPHNE )

--- a/containers/daphne-deps.Dockerfile
+++ b/containers/daphne-deps.Dockerfile
@@ -1,0 +1,89 @@
+# syntax=docker/dockerfile:1
+
+# Copyright 2023 The DAPHNE Consortium
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# This Dockerfile provides a basic DAPHNE compilation environment with all
+# third party dependencies precompiled (use ''./build.sh --no-deps --installPrefix /usr/local'' to compile DAPHNE)
+
+
+# defaults:
+ARG BASE_IMAGE=ubuntu:20.04
+ARG CMAKE_VERSION=3.26.3
+ARG DEBIAN_FRONTEND="noninteractive"
+ARG DEBCONF_NOWARNINGS="yes"
+ARG DAPHNE_DIR=/daphne
+ARG DAPHNE_REPO=https://github.com/daphne-eu/daphne.git
+ARG DAPHNE_BRANCH=main
+ARG TIMESTAMP=0
+ARG CREATION_DATE=0
+ARG GIT_HASH=0
+
+FROM ${BASE_IMAGE} as base
+ARG DEBIAN_FRONTEND
+ARG DEBCONF_NOWARNINGS
+RUN apt-get -qq -y update && apt-get -y upgrade \
+    && apt-get -y --no-install-recommends install  \
+    ca-certificates file git openssh-client unzip wget tar \
+    libomp-dev  libpfm4-dev libssl-dev libxml2-dev uuid-dev zlib1g-dev \
+    build-essential clang gfortran lld llvm ninja-build openjdk-11-jdk-headless pkg-config python3 \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+FROM base as build-cmake
+ARG NUM_CORES=4
+ARG CMAKE_VERSION
+ARG BUILD_DIR=/build-cmake
+WORKDIR $BUILD_DIR
+RUN wget -qO- https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION.tar.gz | tar xzf \
+    - --strip-components=1
+RUN ./bootstrap --parallel=$NUM_CORES --generator=Ninja --no-qt-gui --prefix=/usr/local
+RUN ninja
+RUN strip --strip-unneeded bin/*
+RUN ninja install
+WORKDIR /
+RUN rm -rf ${BUILD_DIR}
+
+FROM build-cmake as build
+ARG DAPHNE_DIR=/daphne
+ARG DAPHNE_REPO=https://github.com/daphne-eu/daphne.git
+ARG DAPHNE_BRANCH=main
+RUN git clone --depth=1 --single-branch --branch=$DAPHNE_BRANCH $DAPHNE_REPO $DAPHNE_DIR
+WORKDIR $DAPHNE_DIR
+RUN ./build.sh --no-fancy --no-submodule-update --installPrefix /usr/local
+RUN find /usr/local -exec file {} \; | grep -e "not stripped" | cut -d ":" -f 1 | xargs strip --strip-unneeded
+RUN rm -rf $DAPHNE_DIR
+RUN ldconfig
+WORKDIR /
+
+FROM base as daphne-deps
+ARG DAPHNE_REPO
+ARG DAPHNE_BRANCH
+ARG TIMESTAMP
+ARG CREATION_DATE
+ARG GIT_HASH
+LABEL "org.opencontainers.image.source"="${DAPHNE_REPO}"
+LABEL "org.opencontainers.image.base.name"="${BASE_IMAGE}"
+LABEL "org.opencontainers.image.version"="branch_${DAPHNE_BRANCH}_from_${TIMESTAMP}"
+LABEL "org.opencontainers.image.created"="${CREATION_DATE}"
+LABEL "org.opencontainers.image.revision"="${GIT_HASH}"
+COPY --from=build /usr/local/bin/ /usr/local/bin/
+COPY --from=build /usr/local/include/ /usr/local/include/
+COPY --from=build /usr/local/lib/ /usr/local/lib/
+COPY --from=build /usr/local/share/ /usr/local/share/
+RUN ldconfig
+
+FROM daphneeu/daphne-deps as github-action
+RUN apt-get -qq -y update && apt-get -y upgrade && apt-get -y --no-install-recommends install  \
+    moreutils python3-numpy python3-pandas && apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/containers/daphne-dev.Dockerfile
+++ b/containers/daphne-dev.Dockerfile
@@ -19,75 +19,121 @@
 # third party dependencies precompiled (use ''./build.sh --no-deps --installPrefix /usr/local'' to compile DAPHNE)
 
 ARG BASE_IMAGE=ubuntu:20.04
-ARG FINAL_BASE_IMAGE=ubuntu:20.04
-ARG CMAKE_VERSION=3.26.2
+#ARG FINAL_BASE_IMAGE=ubuntu:20.04
+ARG CMAKE_VERSION=3.26.3
 ARG TIMESTAMP=0
 
-FROM ${BASE_IMAGE} as base
-ARG DEBIAN_FRONTEND="noninteractive"
-ARG DEBCONF_NOWARNINGS="yes"
-RUN apt-get -qq -y update && apt-get -y upgrade \
-    && apt-get -y --no-install-recommends install  \
-    ca-certificates file git unzip wget tar \
-    libomp-dev libssl-dev libxml2-dev uuid-dev zlib1g-dev \
-    build-essential clang gfortran lld lldb llvm ninja-build openjdk-11-jdk-headless pkg-config \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
+#FROM ${BASE_IMAGE} as base
+#ARG DEBIAN_FRONTEND="noninteractive"
+#ARG DEBCONF_NOWARNINGS="yes"
+#RUN apt-get -qq -y update && apt-get -y upgrade \
+#    && apt-get -y --no-install-recommends install  \
+#    ca-certificates file git unzip wget tar \
+#    libomp-dev libssl-dev libxml2-dev uuid-dev zlib1g-dev \
+#    build-essential clang gfortran lld llvm ninja-build openjdk-11-jdk-headless pkg-config \
+#    && apt-get clean && rm -rf /var/lib/apt/lists/*
+#
+#FROM base as with-cmake
+#ARG NUM_CORES=4
+#ARG CMAKE_VERSION
+#ARG BUILD_DIR=/build-cmake
+#WORKDIR $BUILD_DIR
+#RUN wget -qO- https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION.tar.gz | tar xzf \
+#    - --strip-components=1
+#RUN ./bootstrap --parallel=$NUM_CORES --generator=Ninja --no-qt-gui --prefix=/usr/local
+#RUN ninja
+#RUN strip --strip-unneeded bin/*
+#RUN ninja install
+#WORKDIR /
+#RUN rm -rf ${BUILD_DIR}
+#
+#FROM with-cmake as daphne-deps-compile
+#ARG DAPHNE_DIR=/daphne
+#ARG DAPHNE_REPO=https://github.com/daphne-eu/daphne.git
+#ARG DAPHNE_BRANCH=main
+#ARG TIMESTAMP
+#ARG CREATION_DATE=0
+#ARG GIT_HASH=0
+#LABEL "org.opencontainers.image.source"="${DAPHNE_REPO}"
+#LABEL "org.opencontainers.image.base.name"="${BASE_IMAGE}"
+#LABEL "org.opencontainers.image.version"="$TIMESTAMP"
+#LABEL "org.opencontainers.image.created"="${CREATION_DATE}"
+#LABEL "org.opencontainers.image.revision"="${GIT_HASH}"
+#RUN git clone --depth=1 --single-branch --branch=$DAPHNE_BRANCH $DAPHNE_REPO $DAPHNE_DIR
+#WORKDIR $DAPHNE_DIR
+#RUN ./build.sh --no-fancy --no-submodule-update --installPrefix /usr/local
+#RUN find /usr/local -exec file {} \; | grep -e "not stripped" | cut -d ":" -f 1 | xargs strip --strip-unneeded
+#RUN rm -rf $DAPHNE_DIR
+#RUN ldconfig
+#WORKDIR /
 
-FROM base as with-cmake
-ARG NUM_CORES=4
-ARG CMAKE_VERSION
-ARG BUILD_DIR=/build-cmake
-WORKDIR $BUILD_DIR
-RUN wget -qO- https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION.tar.gz | tar xzf \
-    - --strip-components=1
-RUN ./bootstrap --parallel=$NUM_CORES --generator=Ninja --no-qt-gui --prefix=/usr/local
-RUN ninja
-RUN strip --strip-unneeded bin/*
-RUN ninja install
-WORKDIR /
-RUN rm -rf ${BUILD_DIR}
-
-FROM with-cmake as daphne-deps-compile
-ARG DAPHNE_DIR=/daphne
-ARG DAPHNE_REPO=https://github.com/daphne-eu/daphne.git
-ARG DAPHNE_BRANCH=main
-ARG TIMESTAMP
-ARG CREATION_DATE=0
-ARG GIT_HASH=0
-LABEL "org.opencontainers.image.source"="${DAPHNE_REPO}"
-LABEL "org.opencontainers.image.base.name"="${BASE_IMAGE}"
-LABEL "org.opencontainers.image.version"="$TIMESTAMP"
-LABEL "org.opencontainers.image.created"="${CREATION_DATE}"
-LABEL "org.opencontainers.image.revision"="${GIT_HASH}"
-RUN git clone --depth=1 --single-branch --branch=$DAPHNE_BRANCH $DAPHNE_REPO $DAPHNE_DIR
-WORKDIR $DAPHNE_DIR
-RUN ./build.sh --no-fancy --no-submodule-update --installPrefix /usr/local
-RUN find /usr/local -exec file {} \; | grep -e "not stripped" | cut -d ":" -f 1 | xargs strip --strip-unneeded
-RUN rm -rf $DAPHNE_DIR
-RUN ldconfig
-WORKDIR /
-
-FROM ${FINAL_BASE_IMAGE} as daphne-dev
-ARG DEBIAN_FRONTEND="noninteractive"
-RUN apt-get -qq -y update && apt-get -y upgrade && apt-get -y --no-install-recommends install  \
-    libssl1.1 libxml2-dev zlib1g-dev libtinfo-dev uuid-dev python3-numpy python3-pandas \
-    build-essential ninja-build openjdk-11-jdk-headless pkg-config \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
-COPY --from=daphne-deps-compile /usr/local/bin/ /usr/local/bin/
-COPY --from=daphne-deps-compile /usr/local/include/ /usr/local/include/
-COPY --from=daphne-deps-compile /usr/local/lib/ /usr/local/lib/
-COPY --from=daphne-deps-compile /usr/local/share/ /usr/local/share/
-RUN ldconfig
-
-FROM daphne-dev as daphne-dev-interactive
+FROM ${BASE_IMAGE} as daphne-dev
 ARG DEBIAN_FRONTEND="noninteractive"
 RUN apt-get -qq -y update && apt-get -y upgrade && apt-get -y --no-install-recommends install  \
-    vim nano rsync sudo iputils-ping virtualenv \
+    ca-certificates file git openssh-client unzip wget tar \
+    libomp-dev  libpfm4-dev libssl-dev libxml2-dev uuid-dev zlib1g-dev \
+    build-essential clang gfortran lld llvm ninja-build openjdk-11-jdk-headless pkg-config python3-numpy python3-pandas \
+    vim nano rsync sudo iputils-ping virtualenv openssh-server iproute2 git htop gdb lldb lld gpg-agent net-tools \
+    software-properties-common ca-certificates file unzip wget tar zstd \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
+COPY --from=daphneeu/daphne-deps /usr/local/bin/ /usr/local/bin/
+COPY --from=daphneeu/daphne-deps /usr/local/include/ /usr/local/include/
+COPY --from=daphneeu/daphne-deps /usr/local/lib/ /usr/local/lib/
+COPY --from=daphneeu/daphne-deps /usr/local/share/ /usr/local/share/
+RUN ldconfig
+#RUN useradd -rm -d /home/daphnedev -s /bin/bash -g users -G sudo -u 2000 daphnedev
+#RUN mkdir -p /home/daphnedev/.ssh
+#RUN chmod 700 /home/daphnedev/.ssh
 COPY entrypoint-interactive.sh /
+RUN mkdir -p /var/run/sshd
+EXPOSE 22
 ENTRYPOINT [ "/entrypoint-interactive.sh"]
 
-FROM daphne-dev as github-action
-ARG DEBIAN_FRONTEND="noninteractive"
-RUN apt-get -qq -y update && apt-get -y upgrade && apt-get -y --no-install-recommends install  \
-    moreutils && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+## Include OneAPI:
+#COPY --from=intel/oneapi-basekit:2023.1.0-devel-ubuntu20.04 /opt/intel /opt/
+## Directives from https://github.com/intel/oneapi-containers/blob/master/images/docker/basekit/Dockerfile.ubuntu-20.04
+#ENV LANG=C.UTF-8
+#ENV ACL_BOARD_VENDOR_PATH='/opt/Intel/OpenCLFPGA/oneAPI/Boards'
+#ENV ADVISOR_2023_DIR='/opt/intel/oneapi/advisor/2023.1.0'
+#ENV APM='/opt/intel/oneapi/advisor/2023.1.0/perfmodels'
+#ENV CCL_CONFIGURATION='cpu_gpu_dpcpp'
+#ENV CCL_ROOT='/opt/intel/oneapi/ccl/2021.9.0'
+#ENV CLASSPATH='/opt/intel/oneapi/mpi/2021.9.0//lib/mpi.jar:/opt/intel/oneapi/dal/2023.1.0/lib/onedal.jar'
+#ENV CMAKE_PREFIX_PATH='/opt/intel/oneapi/tbb/2021.9.0/env/..:/opt/intel/oneapi/dnnl/2023.1.0/cpu_dpcpp_gpu_dpcpp/../lib/cmake:/opt/intel/oneapi/dal/2023.1.0:/opt/intel/oneapi/compiler/2023.1.0/linux/IntelDPCPP:/opt/intel/oneapi/ccl/2021.9.0/lib/cmake/oneCCL'
+#ENV CMPLR_ROOT='/opt/intel/oneapi/compiler/2023.1.0'
+#ENV CPATH='/opt/intel/oneapi/tbb/2021.9.0/env/../include:/opt/intel/oneapi/mpi/2021.9.0//include:/opt/intel/oneapi/mkl/2023.1.0/include:/opt/intel/oneapi/ippcp/2021.7.0/include:/opt/intel/oneapi/ipp/2021.8.0/include:/opt/intel/oneapi/dpl/2022.1.0/linux/include:/opt/intel/oneapi/dnnl/2023.1.0/cpu_dpcpp_gpu_dpcpp/include:/opt/intel/oneapi/dev-utilities/2021.9.0/include:/opt/intel/oneapi/dal/2023.1.0/include:/opt/intel/oneapi/ccl/2021.9.0/include/cpu_gpu_dpcpp'
+#ENV DAALROOT='/opt/intel/oneapi/dal/2023.1.0'
+#ENV DALROOT='/opt/intel/oneapi/dal/2023.1.0'
+#ENV DAL_MAJOR_BINARY='1'
+#ENV DAL_MINOR_BINARY='1'
+#ENV DIAGUTIL_PATH='/opt/intel/oneapi/vtune/2023.1.0/sys_check/vtune_sys_check.py:/opt/intel/oneapi/debugger/2023.1.0/sys_check/debugger_sys_check.py:/opt/intel/oneapi/compiler/2023.1.0/sys_check/sys_check.sh:/opt/intel/oneapi/advisor/2023.1.0/sys_check/advisor_sys_check.py:'
+#ENV DNNLROOT='/opt/intel/oneapi/dnnl/2023.1.0/cpu_dpcpp_gpu_dpcpp'
+#ENV DPL_ROOT='/opt/intel/oneapi/dpl/2022.1.0'
+#ENV FI_PROVIDER_PATH='/opt/intel/oneapi/mpi/2021.9.0//libfabric/lib/prov:/usr/lib64/libfabric'
+#ENV FPGA_VARS_ARGS=''
+#ENV FPGA_VARS_DIR='/opt/intel/oneapi/compiler/2023.1.0/linux/lib/oclfpga'
+#ENV GDB_INFO='/opt/intel/oneapi/debugger/2023.1.0/documentation/info/'
+#ENV INFOPATH='/opt/intel/oneapi/debugger/2023.1.0/gdb/intel64/lib'
+#ENV INTELFPGAOCLSDKROOT='/opt/intel/oneapi/compiler/2023.1.0/linux/lib/oclfpga'
+#ENV INTEL_PYTHONHOME='/opt/intel/oneapi/debugger/2023.1.0/dep'
+#ENV IPPCP_TARGET_ARCH='intel64'
+#ENV IPPCRYPTOROOT='/opt/intel/oneapi/ippcp/2021.7.0'
+#ENV IPPROOT='/opt/intel/oneapi/ipp/2021.8.0'
+#ENV IPP_TARGET_ARCH='intel64'
+#ENV I_MPI_ROOT='/opt/intel/oneapi/mpi/2021.9.0'
+#ENV LD_LIBRARY_PATH='/opt/intel/oneapi/tbb/2021.9.0/env/../lib/intel64/gcc4.8:/opt/intel/oneapi/mpi/2021.9.0//libfabric/lib:/opt/intel/oneapi/mpi/2021.9.0//lib/release:/opt/intel/oneapi/mpi/2021.9.0//lib:/opt/intel/oneapi/mkl/2023.1.0/lib/intel64:/opt/intel/oneapi/ippcp/2021.7.0/lib/intel64:/opt/intel/oneapi/ipp/2021.8.0/lib/intel64:/opt/intel/oneapi/dnnl/2023.1.0/cpu_dpcpp_gpu_dpcpp/lib:/opt/intel/oneapi/debugger/2023.1.0/gdb/intel64/lib:/opt/intel/oneapi/debugger/2023.1.0/libipt/intel64/lib:/opt/intel/oneapi/debugger/2023.1.0/dep/lib:/opt/intel/oneapi/dal/2023.1.0/lib/intel64:/opt/intel/oneapi/compiler/2023.1.0/linux/lib:/opt/intel/oneapi/compiler/2023.1.0/linux/lib/x64:/opt/intel/oneapi/compiler/2023.1.0/linux/lib/oclfpga/host/linux64/lib:/opt/intel/oneapi/compiler/2023.1.0/linux/compiler/lib/intel64_lin:/opt/intel/oneapi/ccl/2021.9.0/lib/cpu_gpu_dpcpp:$LD_LIBRARY_PATH'
+#ENV LIBRARY_PATH='/opt/intel/oneapi/tbb/2021.9.0/env/../lib/intel64/gcc4.8:/opt/intel/oneapi/mpi/2021.9.0//libfabric/lib:/opt/intel/oneapi/mpi/2021.9.0//lib/release:/opt/intel/oneapi/mpi/2021.9.0//lib:/opt/intel/oneapi/mkl/2023.1.0/lib/intel64:/opt/intel/oneapi/ippcp/2021.7.0/lib/intel64:/opt/intel/oneapi/ipp/2021.8.0/lib/intel64:/opt/intel/oneapi/dnnl/2023.1.0/cpu_dpcpp_gpu_dpcpp/lib:/opt/intel/oneapi/dal/2023.1.0/lib/intel64:/opt/intel/oneapi/compiler/2023.1.0/linux/compiler/lib/intel64_lin:/opt/intel/oneapi/compiler/2023.1.0/linux/lib:/opt/intel/oneapi/ccl/2021.9.0/lib/cpu_gpu_dpcpp'
+#ENV MANPATH='/opt/intel/oneapi/mpi/2021.9.0/man:/opt/intel/oneapi/debugger/2023.1.0/documentation/man:/opt/intel/oneapi/compiler/2023.1.0/documentation/en/man/common::'
+#ENV MKLROOT='/opt/intel/oneapi/mkl/2023.1.0'
+#ENV NLSPATH='/opt/intel/oneapi/mkl/2023.1.0/lib/intel64/locale/%l_%t/%N:/opt/intel/oneapi/compiler/2023.1.0/linux/compiler/lib/intel64_lin/locale/%l_%t/%N'
+#ENV OCL_ICD_FILENAMES='libintelocl_emu.so:libalteracl.so:/opt/intel/oneapi/compiler/2023.1.0/linux/lib/x64/libintelocl.so'
+#ENV ONEAPI_ROOT='/opt/intel/oneapi'
+#ENV PATH='/opt/intel/oneapi/vtune/2023.1.0/bin64:/opt/intel/oneapi/mpi/2021.9.0//libfabric/bin:/opt/intel/oneapi/mpi/2021.9.0//bin:/opt/intel/oneapi/mkl/2023.1.0/bin/intel64:/opt/intel/oneapi/dev-utilities/2021.9.0/bin:/opt/intel/oneapi/debugger/2023.1.0/gdb/intel64/bin:/opt/intel/oneapi/compiler/2023.1.0/linux/lib/oclfpga/bin:/opt/intel/oneapi/compiler/2023.1.0/linux/bin/intel64:/opt/intel/oneapi/compiler/2023.1.0/linux/bin:/opt/intel/oneapi/advisor/2023.1.0/bin64:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$PATH'
+#ENV PKG_CONFIG_PATH='/opt/intel/oneapi/vtune/2023.1.0/include/pkgconfig/lib64:/opt/intel/oneapi/tbb/2021.9.0/env/../lib/pkgconfig:/opt/intel/oneapi/mpi/2021.9.0/lib/pkgconfig:/opt/intel/oneapi/mkl/2023.1.0/lib/pkgconfig:/opt/intel/oneapi/ippcp/2021.7.0/lib/pkgconfig:/opt/intel/oneapi/dpl/2022.1.0/lib/pkgconfig:/opt/intel/oneapi/dnnl/2023.1.0/cpu_dpcpp_gpu_dpcpp/../lib/pkgconfig:/opt/intel/oneapi/dal/2023.1.0/lib/pkgconfig:/opt/intel/oneapi/compiler/2023.1.0/lib/pkgconfig:/opt/intel/oneapi/ccl/2021.9.0/lib/pkgconfig:/opt/intel/oneapi/advisor/2023.1.0/include/pkgconfig/lib64:'
+#ENV PYTHONPATH='/opt/intel/oneapi/advisor/2023.1.0/pythonapi'
+#ENV SETVARS_COMPLETED='1'
+#ENV TBBROOT='/opt/intel/oneapi/tbb/2021.9.0/env/..'
+#ENV VTUNE_PROFILER_2023_DIR='/opt/intel/oneapi/vtune/2023.1.0'
+#ENV VTUNE_PROFILER_DIR='/opt/intel/oneapi/vtune/2023.1.0'
+#

--- a/containers/daphne.Dockerfile
+++ b/containers/daphne.Dockerfile
@@ -64,7 +64,7 @@ LABEL "org.opencontainers.image.version"="$TIMESTAMP"
 LABEL "org.opencontainers.image.created"="${CREATION_DATE}"
 LABEL "org.opencontainers.image.revision"="${GIT_HASH}"
 RUN apt-get -qq -y update && apt-get -y upgrade && apt-get -y --no-install-recommends install  \
-    libtinfo6 libssl1.1 zlib1g \
+    libtinfo6 libssl1.1 zlib1g python3-numpy python3-pandas \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 COPY --from=daphne-build $DAPHNE_DIR/bin/* /usr/local/bin
 COPY --from=daphne-build $DAPHNE_DIR/lib/* /usr/local/lib
@@ -73,6 +73,9 @@ COPY --from=daphne-build /usr/local/lib/libarrow.so* /usr/local/lib
 COPY --from=daphne-build /usr/local/lib/libantlr*.so* /usr/local/lib
 COPY --from=daphne-build /usr/local/lib/libopen*.so* /usr/local/lib
 COPY --from=daphne-build /usr/local/lib/libmpi*.so* /usr/local/lib
+COPY --from=daphne-build /usr/local/lib/libpapi*.so* /usr/local/lib
+COPY --from=daphne-build /usr/local/lib/libpapi*.so* /usr/local/lib
+
 RUN ldconfig
 ENTRYPOINT ["/usr/local/bin/daphne"]
 CMD ["--help"]

--- a/containers/entrypoint-interactive.sh
+++ b/containers/entrypoint-interactive.sh
@@ -14,10 +14,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+time unminimize
+/usr/sbin/sshd -f /etc/ssh/sshd_config
 /usr/sbin/groupadd -g "$GID" dockerusers
 /usr/sbin/useradd -c 'Docker Container User' -u $UID -g "$GID" -G sudo -m -s /bin/bash -d /home/"$USER" "$USER"
 printf "${USER} ALL=(ALL:ALL) NOPASSWD:ALL" | sudo EDITOR="tee -a" visudo #>> /dev/null
+mkdir -p /home/"$USER"/.ssh
+chmod 700 /home/"$USER"/.ssh
 touch /home/"$USER"/.sudo_as_admin_successful
-exec su "$USER"
 # set a default password
-#echo ${USER}:Docker! | chpasswd
+SALT=$(date +%M%S)
+PASS=Docker!"$SALT"
+echo "${USER}":"$PASS" | chpasswd
+echo
+echo "Use "$USER" with password "$PASS" for SSH login"
+echo "Docker Container IP address(es):"
+awk '/32 host/ { print f } {f=$2}' <<< "$(</proc/net/fib_trie)" | grep -vE "127.0." | sort -u
+# shellcheck disable=SC2068
+#exec su "$USER" -c $@
+sudo --preserve-env=PATH,LD_LIBRARY_PATH,TERM -u $USER $@

--- a/containers/quickstart.sh
+++ b/containers/quickstart.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 The DAPHNE Consortium
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# user info to set up your user inside the container (to avoid creating files that then belong to the root user)
+USERNAME=$(id -n -u)
+GID=$(id -g)
+docker run --rm -w /daphne -v $PWD:/daphne -e GID=$GID -e USER=$USERNAME -e UID=$UID daphneeu/daphne:latest_BASE $*

--- a/containers/run-docker-example.sh
+++ b/containers/run-docker-example.sh
@@ -17,21 +17,37 @@
 echo "Use this as an example to start DAPHNE docker containers. Copy and customize for the various flavors."
 
 DOCKER_IMAGE=daphneeu/daphne-dev
-#DOCKER_TAG=latest
-DOCKER_TAG=2023-05-05_cuda-12.1.1-cudnn8-devel-ubuntu20.04
+DOCKER_TAG=latest_BASE
+#DOCKER_TAG=latest_CUDA
 
 # run this script from the base path of your DAPHNE source tree
 DAPHNE_ROOT=$PWD
+
+# the directory used *inside* the container to bind-mount your source directory
 DAPHNE_ROOT_CONTAINER=/daphne
 
+# user info to set up your user inside the container (to avoid creating files that then belong to the root user)
 USERNAME=$(id -n -u)
 GID=$(id -g)
+
+# some environment setup
 CUDA_PATH=/usr/local/cuda
 LD_LIBRARY_PATH=$CUDA_PATH/lib64:$DAPHNE_ROOT/lib:/usr/local/lib:$LD_LIBRARY_PATH
 PATH=$CUDA_PATH/bin:$DAPHNE_ROOT/bin:$PATH
-# uncomment to pass GPU devices to the container
-DEVICE_FLAGS="--gpus all"
-DEBUG_FLAGS="--cap-add=SYS_PTRACE --security-opt seccomp=unconfined"
+
+# uncomment the appropriate to pass GPU devices to the container (goes hand in hand with DOCKER_TAG)
+DEVICE_FLAGS=""
+#DEVICE_FLAGS="--gpus all"
+
+# this might be needed if a debugging session is run in the container
+DEBUG_FLAGS=""
+#DEBUG_FLAGS="--cap-add=SYS_PTRACE --security-opt seccomp=unconfined"
+
+# set bash as the default command if none is provided
+command=$*
+if [ "$#" -eq 0 ]; then
+    command=bash
+fi
 
 # non-interactive: launch with PWD mounted
 #docker run $DEVICE_FLAGS --user=$UID:$GID --rm -w "$DAPHNE_ROOT" -v "$DAPHNE_ROOT:$DAPHNE_ROOT" \
@@ -42,7 +58,7 @@ DEBUG_FLAGS="--cap-add=SYS_PTRACE --security-opt seccomp=unconfined"
 docker run $DEBUG_FLAGS $DEVICE_FLAGS -it --rm --hostname daphne-container -w $DAPHNE_ROOT_CONTAINER \
     -v "$DAPHNE_ROOT:$DAPHNE_ROOT_CONTAINER" -e GID=$GID -e TERM=screen-256color -e PATH -e LD_LIBRARY_PATH \
     -e USER=$USERNAME -e UID=$UID \
-    "$DOCKER_IMAGE:$DOCKER_TAG" $@
+    "$DOCKER_IMAGE:$DOCKER_TAG" $command
 
 # move this up to above the DOCKER_IMAGE line to override the entrypoint:
 #    --entrypoint /daphne/containers/entrypoint-interactive.sh

--- a/containers/run-docker-example.sh
+++ b/containers/run-docker-example.sh
@@ -17,19 +17,32 @@
 echo "Use this as an example to start DAPHNE docker containers. Copy and customize for the various flavors."
 
 DOCKER_IMAGE=daphneeu/daphne-dev
-#DOCKER_IMAGE=daphneeu/daphne-dev-interactive
-DOCKER_TAG=latest
-#DOCKER_TAG=cuda-12.0.1-cudnn8-devel-ubuntu20.04_2023-04-03
-DAPHNE_ROOT=$PWD
+#DOCKER_TAG=latest
+DOCKER_TAG=2023-05-05_cuda-12.1.1-cudnn8-devel-ubuntu20.04
 
+# run this script from the base path of your DAPHNE source tree
+DAPHNE_ROOT=$PWD
+DAPHNE_ROOT_CONTAINER=/daphne
+
+USERNAME=$(id -n -u)
+GID=$(id -g)
 CUDA_PATH=/usr/local/cuda
-LD_LIBRARY_PATH=$CUDA_PATH/lib64:$DAPHNE_ROOT/lib:$LD_LIBRARY_PATH
+LD_LIBRARY_PATH=$CUDA_PATH/lib64:$DAPHNE_ROOT/lib:/usr/local/lib:$LD_LIBRARY_PATH
 PATH=$CUDA_PATH/bin:$DAPHNE_ROOT/bin:$PATH
 # uncomment to pass GPU devices to the container
-#DEVICE_FLAGS=--gpus all
+DEVICE_FLAGS="--gpus all"
+DEBUG_FLAGS="--cap-add=SYS_PTRACE --security-opt seccomp=unconfined"
 
-# shellcheck disable=SC2046
-# shellcheck disable=SC2068
-docker run "$DEVICE_FLAGS" --user=$(id -u):$(id -g) --rm -w "$DAPHNE_ROOT" -v "$DAPHNE_ROOT:$DAPHNE_ROOT" \
-    -e TERM=screen-256color -e PATH="$PATH" -e LD_LIBRARY_PATH="$LD_LIBRARY_PATH" -e USER=$(id -n -u) -e UID=$(id -u) \
+# non-interactive: launch with PWD mounted
+#docker run $DEVICE_FLAGS --user=$UID:$GID --rm -w "$DAPHNE_ROOT" -v "$DAPHNE_ROOT:$DAPHNE_ROOT" \
+#    -e TERM=screen-256color -e PATH="$PATH" -e LD_LIBRARY_PATH="$LD_LIBRARY_PATH" -e USER=$USERNAME -e UID=$UID \
+#    "$DOCKER_IMAGE:$DOCKER_TAG" $@
+
+# for interactive use:
+docker run $DEBUG_FLAGS $DEVICE_FLAGS -it --rm --hostname daphne-container -w $DAPHNE_ROOT_CONTAINER \
+    -v "$DAPHNE_ROOT:$DAPHNE_ROOT_CONTAINER" -e GID=$GID -e TERM=screen-256color -e PATH -e LD_LIBRARY_PATH \
+    -e USER=$USERNAME -e UID=$UID \
     "$DOCKER_IMAGE:$DOCKER_TAG" $@
+
+# move this up to above the DOCKER_IMAGE line to override the entrypoint:
+#    --entrypoint /daphne/containers/entrypoint-interactive.sh

--- a/doc/GettingStarted.md
+++ b/doc/GettingStarted.md
@@ -171,11 +171,16 @@ for accelerated ops (see [software requirements](#software) above and [build ins
 For further flags that can be set at runtime to activate additional functionality, run ``daphne --help``.
 
 ### Building and running with containers [Alternative path for building and running the system and the tests]
-If one wants to avoid installing dependencies and avoid conflicting with his/her existing installed libraries, one may use containers.
-- you need to install Docker or Singularity: Docker version 20.10.2 or higher | Singularity version 3.7.0-1.el7 or higher are sufficient
+If one wants to avoid installing dependencies and avoid conflicting with his/her existing installed libraries, one may 
+use containers.
+- you need to install Docker or Singularity: Docker version 20.10.2 or higher | Singularity version 3.7.0-1.el7 or 
+higher are sufficient
 - you can use the provided docker files and scripts to create and run DAPHNE.
 
-The following creates two images (daphneeu/daphne-dev; daphneeu/daphne-dev-interactive):
+**A full description on containers is available in the [containers](containers) subdirectory.**
+
+
+The following recreates all images provided by [daphneeu](https://hub.docker.com/u/daphneeu) 
 ```bash
 cd container
 ./build-containers.sh
@@ -184,26 +189,12 @@ cd container
 Running in an interactive container can be done with this run script, which takes care of mounting your 
 current directory and handling permissions:
 ```bash
-cd container
-./run-daphne-dev-interactive.sh
+# please customize this script first
+./containers/run-docker-example.sh
 ```
- - you can also use Singularity containers instead of Docker as follows:
-  ```bash
-#one can also use [Singularity python](https://singularityhub.github.io/singularity-cli/)
-#to convert the provided Dockerfile into Singularity recipe 
-singularity build <ImageName.sif> docker://daphneeu/daphne-dev
-
-# This command will place you in a shell in the container, your home directory and /tmp mounted. 
-singularity shell <ImageName.sif>
-Singularity> cd <your/daphne/directory>
-Singularity> ./build.sh #or ./test.sh
-```
-- Because the container instance works on the same folder, if one already built the system outside the container, it is recommended to clean all build files to avoid conflicts.
-- One may also do the commits from within the containers as normal (this holds for Singularity. With Docker images, your home
-directory and therefore your .gitconfig is usually not available).
-
-For more about building and running with containers, refer to the directory `containers/` and its [README.md](/containers/README.md). 
-For documentation of using containers in conjunction with our cluster deployment scripts, refer to [Deploy.md](/doc/Deploy.md).
+For more about building and running with containers, refer (once again) to the directory `containers/` and its 
+[README.md](/containers/README.md).
+For documentation about using containers in conjunction with our cluster deployment scripts, refer to [Deploy.md](/doc/Deploy.md).
 
 ### Exploring the Source Code
 
@@ -213,13 +204,13 @@ On the top-level, there are the following directories:
 
 - `bin`: after compilation, generated binaries will be placed here (e.g., daphne)
 - `build`: temporary build output
-- `containers`: scripts and configuration files to get/build/run with Docker or Singularity containers
-- `deploy`: shell scripts to ease deployment in SLURM clusters
-- `doc`: documentation written in markdown (e.g., what you are reading at the moment)
+- [`containers`:](containers) scripts and configuration files to get/build/run with Docker or Singularity containers
+- [`deploy`:](deploy) shell scripts to ease deployment in SLURM clusters
+- [`doc`:](doc) documentation written in markdown (e.g., what you are reading at the moment)
 - `lib`: after compilation, generated library files will be placed here (e.g., libAllKernels.so, libCUDAKernels.so, ...)
-- `scripts`: a collection of algorithms and examples written in DAPHNE's own domain specific language ([DaphneDSL](DaphneDSLLanguageRef.md))
-- `src`: the actual source code, subdivided into the individual components of the system
-- `test`: test cases
+- [`scripts`:](scripts) a collection of algorithms and examples written in DAPHNE's own domain specific language ([DaphneDSL](DaphneDSLLanguageRef.md))
+- [`src`:](src) the actual source code, subdivided into the individual components of the system
+- [`test`:](test) test cases
 - `thirdparty`: required external software
 
 ### What Next?

--- a/src/compiler/lowering/MarkCUDAOpsPass.cpp
+++ b/src/compiler/lowering/MarkCUDAOpsPass.cpp
@@ -151,7 +151,7 @@ struct MarkCUDAOpsPass : public PassWrapper<MarkCUDAOpsPass, OperationPass<func:
     }
     
     bool checkUseCUDA(Operation* op) const {
-//        std::cout << "checkUseCUDA: " << op->getName().getStringRef().str() << std::endl;
+        std::cout << "checkUseCUDA: " << op->getName().getStringRef().str() << std::endl;
         bool use_cuda = op->hasTrait<mlir::OpTrait::CUDASupport>();
 #ifndef NDEBUG
         std::string name(op->getName().getStringRef().str());


### PR DESCRIPTION
* reduced to two images:
  - daphneeu/daphne - ready-to-run daphne precompiled with minimal deps
  - daphneeu/daphne-dev - everything needed for developing DAPHNE itself
* ssh access for daphne-dev: this comes handy when using IDE extensions like VSCode Remote SSH or CLion
* CUDA 12.1
* CUDNN 8.9
* building deps from future-deps branch to already include upcoming libraries
* a few new deps like pandas (for DaphneLIB)

Closes #530