### PR TITLE
[DOC] Improvements to quickstart guide.

### DIFF
--- a/doc/Quickstart.md
+++ b/doc/Quickstart.md
@@ -1,5 +1,5 @@
 <!--
-Copyright 2021 The DAPHNE Consortium
+Copyright 2023 The DAPHNE Consortium
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,50 +14,62 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-# Quickstart
+# Quickstarting DAPHNE
 
-These reduced instructions should get you started by firing up a hello world script from the latest binary release.
+These reduced instructions should get you started by firing up a hello world script from the latest binary release. 
 
-**The recipe is as follows:**
+## Download a Binary Release
 
-1. Download and extract `daphne-<version>-bin.tgz` from the [release page](https://github.com/daphne-eu/daphne/releases).
-Optionally choose the `daphne-cuda-<version>-bin.tgz` archive if you want to run DAPHNE with CUDA support (Nvidia Pascal
-hardware or newer and an installed CUDA SDK are required)
-2. In a bash (or compatible) shell, from the extracted DAPHNE directory, execute this command
+Download and extract `daphne-<version>-bin.tgz` from the [release page](https://github.com/daphne-eu/daphne/releases).
+Optionally choose the `daphne-cuda-<version>-bin.tgz` archive if you want to run DAPHNE with CUDA support (Nvidia Pascal 
+hardware or newer and an installed CUDA SDK are required).
 
-    ```bash
-    ./run-daphne.sh scripts/examples/hello-world.daph
-    ```
+## Run DAPHNE
 
-    Optionally you can activate CUDA ops by including --cuda:
+DAPHNE offers two ways to define integrated data analysis pipelines:
 
-    ```bash
-    ./run-daphne.sh --cuda scripts/examples/hello-world.daph
-    ```
+- [DaphneDSL](/doc/DaphneDSLLanguageRef.md) (DAPHNE's domain-specific language)
+- [DaphneLib](/doc/DaphneLib.md) (DAPHNE's Python API)
 
-    Earning extra points: To see one level of intermediate representation that the DAPHNE compiler generates in its wealth of optimization passes run with the explain flag
+For both ways, we provide lightweight run-scripts that set up the required environment (so your system's shared library loader finds the required `.so` files) and pass the provided parameters to the `daphne`/`python3` executable. 
 
-    ```bash
-    ./run-daphne.sh --explain=kernels scripts/examples/hello-world.daph
-    ```
+### Running a DaphneDSL Script
 
-## Explanation
+In a bash (or compatible) shell, from the extracted DAPHNE directory, execute this command
 
-The ``run-daphne.sh`` script sets up the required environment (so your system's shared library loader finds the required
-.so files) and passes the provided parameters to the daphne executable.
+```bash
+./run-daphne.sh scripts/examples/hello-world.daph
+```
 
-Interesting things to look at:
+Optionally you can activate CUDA ops by including `--cuda`:
 
-- file ``run-daphne.sh``
-- file ``UserConfig.json``
-- file ``scripts/examples/hello-world.daph``
-- output of ``run-daphne.sh --help``
+```bash 
+./run-daphne.sh --cuda scripts/examples/hello-world.daph
+```
 
-### What Next?
+### Running a Python Script Using DaphneLib
+
+In a bash (or compatible) shell, from the extracted DAPHNE directory, execute this command
+
+```bash
+./run-python.sh scripts/examples/daphnelib/shift-and-scale.py
+```
+
+## More Details
+
+If you are interested in the details, you could have a look at
+
+* the run-scripts: `run-daphne.sh` and `run-python.sh`
+* the example DaphneDSL and DaphneLib scripts:
+    * `scripts/examples/hello-world.daph`
+    * `scripts/examples/daphnelib/shift-and-scale.py`
+* the DAPHNE user configuration: `UserConfig.json`
+* the DAPHNE help: `run-daphne.sh --help`
+
+## What Next?
 
 You might want to have a look at
 
 - a more elaborate [getting started guide](/doc/GettingStarted.md)
 - the [documentation](/doc)
-- the [contribution guidelines](/CONTRIBUTING.md)
-- the [open issues](https://github.com/daphne-eu/daphne/issues)
+- DaphneDSL and DaphneLib example scripts in `scripts/algorithms/` and `scripts/examples/`

--- a/run-python.sh
+++ b/run-python.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 The DAPHNE Consortium
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DAPHNE_ROOT=$PWD
+export LD_LIBRARY_PATH=$DAPHNE_ROOT/lib:$DAPHNE_ROOT/thirdparty/installed/lib:$LD_LIBRARY_PATH
+export PYTHONPATH="$PYTHONPATH:$PWD/src/"
+python3 $@


### PR DESCRIPTION
- Added information on DaphneLib.
- Clear separation between info on running DaphneDSL and DaphneLib scripts.
- Removed some information, which I think is not important for a user wanting to quickstart DAPHNE (e.g., --explain and pointers to development-related info).
- Added a run-script for DaphneLib (starting python3), analogous to the existing run-daphne.sh (starting daphne).