### PR TITLE
[doc] fix md flaws and add newely added docs to html page

### DIFF
--- a/doc/DaphneDSL/Builtins.md
+++ b/doc/DaphneDSL/Builtins.md
@@ -143,8 +143,8 @@ The built-in functions all follow the same scheme:
   
     Applies the respective binary function (see table below) to the corresponding pairs of a value in the left-hand-side argument `lhs` and the right-hand-side argument `rhs`.
     Regarding the combinations of scalars and matrices, the same broadcasting semantics apply as for binary operations like `+`, `*`, etc. (see the [DaphneDSL Language Reference](/doc/DaphneDSL/LanguageRef.md)).
-  
-Note that DaphneDSL support various other elementwise binary functions via operators in infix notation (see [DaphneDSL](/doc/DaphneDSL/LanguageRef.md)), e.g., `^`, `%`, `*`, `/`, `+`, `-`, `==`, `!=`, `<`, `<=`, `>`, `>=`, `&&`, `||`.
+
+### Arithmetic
 
 | function | operator | meaning |
 | ----- | ----- | ----- |
@@ -282,9 +282,9 @@ The following built-in functions all follow the same scheme:
 The following built-in functions all follow the same scheme:
 
 - **`cumAgg`**`(arg:matrix)`
-  
-  Cumulative aggregation over each column of the matrix `arg`.
-  Returns a matrix of the same shape as `arg`.
+
+    Cumulative aggregation over each column of the matrix `arg`.
+    Returns a matrix of the same shape as `arg`.
 
 | function | meaning |
 | ----- | ------ |
@@ -390,14 +390,14 @@ Note that most of these operations only have a CUDNN-based kernel for GPU execut
 
     Returns the contingency table of two *(n x 1)* column-matrices `ys` and `xs`.
     The resulting matrix `res` consists of `max(ys) + 1` rows and `max(xs) + 1` columns.
-    More precisely, *`res[x, y] `= |{ k | `ys[k, 0]` = y and `xs[k, 0]` = x, 0 ≤ k ≤ n-1 }| * `weight`*.
+    More precisely, *`res[x, y]` = |{ k | `ys[k, 0]` = y and `xs[k, 0]` = x, 0 ≤ k ≤ n-1 }| * `weight`*.
   
     In other words, starting with an all-zero result matrix, `ys` and `xs` can be thought of as lists of `y`/`x`-coordinates which indicate the result matrix's cells whose value shall be increased by `weight`.
     Note that `ys` and `xs` must not contain negative numbers.
   
     The scalar weight is an optional argument and defaults to 1.0.
     The weight also determines the value type of the result.
-    
+
     Moreover, optionally, the result shape in terms of the number of rows and columns can be specified.
     If omited, it defaults to the smallest numbers required to accommodate all given `y`/`x`-coordinates, as expressed above.
     If specified, the result can be either cropped or padded with zeros to the desired shape.

--- a/doc/Profiling.md
+++ b/doc/Profiling.md
@@ -15,19 +15,21 @@ limitations under the License.
 -->
 
 # Profiling DAPHNE using PAPI
+
 You can profile your DAPHNE script by using the ```--enable-profiling``` CLI
 switch.
 
 DAPHNE supports profiling via the [PAPI](https://github.com/icl-utk-edu/papi)
 profiling library, specifically the
-[high-level (HL) PAPI API](https://github.com/icl-utk-edu/papi/wiki/PAPI-HL)).
+[high-level (HL) PAPI API](https://github.com/icl-utk-edu/papi/wiki/PAPI-HL).
 
 When run with profiling enabled, the DAPHNE compiler will generate code that
 automatically starts and stops profiling (via PAPI) at the start and end of the
 DAPHNE script.
 
-You can configure which events to profile via the ```PAPI_EVENTS```
+You can configure which events to profile via the `PAPI_EVENTS`
 environmental variable, e.g.:
+
 ```bash
 $ PAPI_EVENTS="perf::CYCLES,perf::INSTRUCTIONS,perf::CACHE-REFERENCES,perf::CACHE MISSES,perf::BRANCHES,perf::BRANCH-MI SSES" PAPI_REPORT=1 ./daphne --enable-profiling script.daph
 ```
@@ -36,5 +38,5 @@ For more details about the supported events as well as other PAPI-HL configurati
 options you can check the
 [PAPI HL API documentation](https://github.com/icl-utk-edu/papi/wiki/PAPI-HL#overview-of-environment-variables).
 You can also get a list of the supported events on your machine via the
-```papi_native_avail``` PAPI utility (included in the ```papi-tools``` package
+`papi_native_avail` PAPI utility (included in the `papi-tools` package
 on Debian-based systems).

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,7 +1,5 @@
 # Overview
 
-![DAPHNE Logo](assets/logo_medium.png)
-
 - [Quickstart](/doc/Quickstart.md)
 - [Getting Started](/doc/GettingStarted.md)
 

--- a/doc/development/Profiling.md
+++ b/doc/development/Profiling.md
@@ -15,21 +15,23 @@ limitations under the License.
 -->
 
 # Profiling in DAPHNE
+
 For a general overview of the profiling support in DAPHNE see the [user
-profiling documentation](../Profiling.md).
+profiling documentation](/doc/Profiling.md).
 
 Profiling is implemented via an instrumentation pass that injects calls to the
 ```StartProfiling``` and ```StopProfiling``` kernels at the start and end of
 each block. In turn, the kernels call the PAPI-HL API start and stop functions.
 
-### Known Issues / TODO:
+## Known Issues / TODO
+
 * For scripts with multiple blocks (e.g. UDFs), the compiler will generate
-  profiling passes for each block seperately instead of a single script-wide
+  profiling passes for each block separately instead of a single script-wide
   profiling pass.
 * The profiling kernels should be exposed at the DSL / IR level, so that users
   can instrument / profile specific parts of their script. This will also need
   compiler cooperation, to make sure that the profiled bock is not rearranged /
   fused with other operations.
 * To aid with the development and regression tracking of the runtime, the
-  profiling kernels could also be extended to suport profiling specific
+  profiling kernels could also be extended to support profiling specific
   kernels or parts of kernels.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,6 +59,7 @@ nav:
       - tutorial/sqlTutorial.md
     - FPGAconfiguration.md
     - MPI-Usage.md
+    - Profiling.md
   - 'Developers':
     - development/Contributing.md
     - development/BuildingDaphne.md
@@ -70,4 +71,5 @@ nav:
     - development/ExtendingSchedulingKnobs.md
     - development/HandlingPRs.md
     - development/ImplementBuiltinKernel.md
+    - development/Profiling.md
     - development/WriteDocs.md


### PR DESCRIPTION
Hey @corepointer 

this fixes some stuff which went wrong during conflictr solving (it was not much)

Additionally, newely added docs are added.

@pdamme @corepointer it is documented how to write and add docs (/doc/development/writeDocs.md). It would be nice to raise attention for this of the other developers. I wont fix the md documents all the time ;)