### PR TITLE
Pass errors are not only logged, but also printed again.

### DIFF
--- a/src/api/internal/daphne_internal.cpp
+++ b/src/api/internal/daphne_internal.cpp
@@ -516,14 +516,17 @@ int startDAPHNE(int argc, const char** argv, DaphneLibResult* daphneLibRes, int 
     }
     catch(std::runtime_error & re) {
         spdlog::error("Pass std::runtime_error: {}", re.what());
+        cerr << "Pass error: " << re.what() << endl;
         return StatusCode::PASS_ERROR;
     }
     catch(std::exception & e) {
         spdlog::error("Pass std::exception: {}", e.what());
+        cerr << "Pass error: " << e.what() << endl;
         return StatusCode::PASS_ERROR;
     }
     catch(...) {
-        spdlog::error("Pass error caught by ellipsis(...) {}");
+        spdlog::error("Pass error caught by ellipsis(...)");
+        cerr << "Pass error: (no message)" << endl;
         return StatusCode::PASS_ERROR;
     }
 


### PR DESCRIPTION
- For a long time, pass errors, which happen inside the DAPHNE compiler, used to be printed to std::cerr.
- Since a recent commit (4a8f003cf5b499bec4ecbb138441af8dfa2413f0), they are logged using the recently introduced logger, instead.
- Not printing the error messages to std::cerr anymore has at least two significant downsides:
  - Users don't see the error messages anymore. Instead, DaphneDSL scripts may just silently fail.
  - The error output captured by our script-level test cases is useless, since it is empty.
- This commit adds the printing of the error messages to std::cerr again, but also retains the logging of the errors.