### PR TITLE
[DAPHNE-#575] Error logger, meaningful default log level, cleanup

### DIFF
--- a/UserConfig.json
+++ b/UserConfig.json
@@ -20,25 +20,18 @@
     "library_paths": [],
     "daphnedsl_import_paths": {},
     "logging": [
-        { "log-level-limit": "OFF" },
-        {
-            "comment": "ToDo: multiple sinks and loggers could be configurable here",
-            "name": "default",
-            "level": "INFO",
-            "filename": "daphne-output.txt",
-            "format": "[%H:%M:%S] [%n] [%^---%L---%$] %v"
-        },
+        { "log-level-limit": "ERROR" },
         {
             "comment": "This configuration controls logging in the GPU compiler pass only",
             "name": "compiler::cuda",
-            "level": "TRACE",
+            "level": "DEBUG",
             "filename": "compiler-trace-cuda.txt",
             "format": "%^[%L %n]:%$ %v"
         },
         {
             "comment": "general runtime CUDA debug log",
             "name": "runtime::cuda",
-            "level": "DEBUG",
+            "level": "INFO",
             "filename": "compiler-debug-cuda.txt",
             "format": "%^[%L %n]:%$ %v"
         }

--- a/containers/run-docker-example.sh
+++ b/containers/run-docker-example.sh
@@ -19,8 +19,8 @@ echo "Add sudo to docker invocation if needed in your setup"
 
 ARCH=X86-64
 DOCKER_IMAGE=daphneeu/daphne-dev
-#DOCKER_TAG=latest_${ARCH}_BASE
-DOCKER_TAG=latest_${ARCH}_CUDA
+DOCKER_TAG=latest_${ARCH}_BASE
+#DOCKER_TAG=latest_${ARCH}_CUDA
 
 #on some installations docker can only be run with sudo
 USE_SUDO=
@@ -42,8 +42,8 @@ LD_LIBRARY_PATH=$CUDA_PATH/lib64:$DAPHNE_ROOT/lib:/usr/local/lib:$LD_LIBRARY_PAT
 PATH=$CUDA_PATH/bin:$DAPHNE_ROOT/bin:$PATH
 
 # uncomment the appropriate to pass GPU devices to the container (goes hand in hand with DOCKER_TAG)
-#DEVICE_FLAGS=""
-DEVICE_FLAGS="--gpus all"
+DEVICE_FLAGS=""
+#DEVICE_FLAGS="--gpus all"
 
 # this might be needed if a debugging session is run in the container
 DEBUG_FLAGS=""

--- a/containers/run-docker-example.sh
+++ b/containers/run-docker-example.sh
@@ -19,8 +19,8 @@ echo "Add sudo to docker invocation if needed in your setup"
 
 ARCH=X86-64
 DOCKER_IMAGE=daphneeu/daphne-dev
-DOCKER_TAG=latest_${ARCH}_BASE
-#DOCKER_TAG=latest_${ARCH}_CUDA
+#DOCKER_TAG=latest_${ARCH}_BASE
+DOCKER_TAG=latest_${ARCH}_CUDA
 
 #on some installations docker can only be run with sudo
 USE_SUDO=
@@ -42,8 +42,8 @@ LD_LIBRARY_PATH=$CUDA_PATH/lib64:$DAPHNE_ROOT/lib:/usr/local/lib:$LD_LIBRARY_PAT
 PATH=$CUDA_PATH/bin:$DAPHNE_ROOT/bin:$PATH
 
 # uncomment the appropriate to pass GPU devices to the container (goes hand in hand with DOCKER_TAG)
-DEVICE_FLAGS=""
-#DEVICE_FLAGS="--gpus all"
+#DEVICE_FLAGS=""
+DEVICE_FLAGS="--gpus all"
 
 # this might be needed if a debugging session is run in the container
 DEBUG_FLAGS=""

--- a/doc/development/Logging.md
+++ b/doc/development/Logging.md
@@ -34,10 +34,14 @@ via context creation in case of the libs). All setup is handled by the class Dap
     - ``spdlog::get("default")->warn("my warning");``
 
     The two statements have the same effect. But while the former is a short form for using the default logger, the latter
-    explicitly chooses the logger via the static get() method.
+    explicitly chooses the logger via the static ``get()`` method. This ``get()`` method is to be used with **caution** as 
+    it involves acquiring a lock, which is to be avoided **in performance critical sections** of the code. In the initial 
+    implementation there is a logger for runtime kernels provided by the context object to work around this limitation.
+    See the matrix multiplication kernel in ``src/runtime/local/kernels/MatMult.cpp`` for example usage. 
 
 1. We can have several loggers, which can be configured differently. For example, to control how messages are logged
-in the CUDA compiler pass MarkCUDAOpsPass, a logger named "compiler::cuda" is used. For each used logger, an entry
+in the CUDA compiler pass ``MarkCUDAOpsPass``, a logger named "compiler::cuda" is used. Additionally, avoiding the use of
+``spdlog::get()`` is demonstrated there. For each used logger, an entry
 in ``fallback_loggers`` (see DaphneLogger.cpp) must exist to prevent crashing when using an unconfigured logger.
 1. To configure log levels, formatting and output options, the DaphneUserConfig and ConfigParser have been extended.
 See an example of this in the ``UserConfig.json`` in the root directory of the DAPHNE code base.

--- a/run-daphne.sh
+++ b/run-daphne.sh
@@ -15,5 +15,5 @@
 # limitations under the License.
 
 DAPHNE_ROOT=$PWD
-export LD_LIBRARY_PATH=$DAPHNE_ROOT/lib:$DAPHNE_ROOT/thirdparty/installed/lib:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$DAPHNE_ROOT/lib:$LD_LIBRARY_PATH
 $DAPHNE_ROOT/bin/daphne --config UserConfig.json $@

--- a/src/api/cli/DaphneUserConfig.h
+++ b/src/api/cli/DaphneUserConfig.h
@@ -68,8 +68,8 @@ struct DaphneUserConfig {
     ALLOCATION_TYPE distributedBackEndSetup= ALLOCATION_TYPE::DIST_MPI; // default value
     int numberOfThreads = -1;
     int minimumTaskSize = 1;
-    // minimum considered log level (e.g., no logging below INFO (essentially suppressing DEBUG and TRACE)
-    spdlog::level::level_enum log_level_limit = spdlog::level::off;
+    // minimum considered log level (e.g., no logging below ERROR (essentially suppressing WARN, INFO, DEBUG and TRACE)
+    spdlog::level::level_enum log_level_limit = spdlog::level::err;
     std::vector<LogConfig> loggers;
     DaphneLogger* log_ptr{};
     

--- a/src/api/internal/daphne_internal.cpp
+++ b/src/api/internal/daphne_internal.cpp
@@ -209,7 +209,7 @@ int startDAPHNE(int argc, const char** argv, DaphneLibResult* daphneLibRes, int 
     );
     
     // Other options
-    
+
     static opt<bool> noObjRefMgnt(
             "no-obj-ref-mgnt", cat(daphneOptions),
             desc(
@@ -343,20 +343,20 @@ int startDAPHNE(int argc, const char** argv, DaphneLibResult* daphneLibRes, int 
     // Initialize user configuration.
     DaphneUserConfig user_config{};
 
-    // This log line would unconditionally be printed as no logger is configured yet
-//    spdlog::info("Reading user config");
-
     try {
         if (configFile != configFileInitValue && ConfigParser::fileExists(configFile)) {
             ConfigParser::readUserConfig(configFile, user_config);
         }
     }
     catch(std::exception & e) {
-        spdlog::error("Error while reading user config:\n{}", e.what());
+        spdlog::error("Parser error while reading user config:\n{}", e.what());
         return StatusCode::PARSER_ERROR;
     }
-    
-//    user_config.debug_llvm = true;
+
+    // initialize logging facility
+    if(not logger)
+        logger = std::make_unique<DaphneLogger>(user_config);
+
     user_config.use_vectorized_exec = useVectorizedPipelines;
     user_config.use_distributed = useDistributedRuntime; 
     user_config.use_obj_ref_mgnt = !noObjRefMgnt;
@@ -377,7 +377,7 @@ int startDAPHNE(int argc, const char** argv, DaphneLibResult* daphneLibRes, int 
     if(user_config.use_distributed)
     {
         if(user_config.distributedBackEndSetup!=ALLOCATION_TYPE::DIST_MPI &&  user_config.distributedBackEndSetup!=ALLOCATION_TYPE::DIST_GRPC)
-            std::cout<<"No backend has been selected. Wiil use the default 'MPI'\n";
+            spdlog::warn("No backend has been selected. Wiil use the default 'MPI'");
     }
     for (auto explain : explainArgList) {
         switch (explain) {
@@ -442,7 +442,7 @@ int startDAPHNE(int argc, const char** argv, DaphneLibResult* daphneLibRes, int 
         CHECK_CUDART(cudaGetDeviceCount(&device_count));
 #endif
         if(device_count < 1)
-            std::cerr << "WARNING: CUDA ops requested by user option but no suitable device found" << std::endl;
+            spdlog::warn("CUDA ops requested by user option but no suitable device found");
         else {
             user_config.use_cuda = true;
         }
@@ -470,12 +470,9 @@ int startDAPHNE(int argc, const char** argv, DaphneLibResult* daphneLibRes, int 
         parseScriptArgs(scriptArgs1, scriptArgsFinal);
     }
     catch(exception& e) {
-        std::cerr << "Parser error: " << e.what() << std::endl;
+        spdlog::error("Parser error: {}", e.what());
         return StatusCode::PARSER_ERROR;
     }
-
-    if(not logger)
-        logger = std::make_unique<DaphneLogger>(user_config);
 
     // ************************************************************************
     // Parse, compile and execute DaphneDSL script
@@ -502,7 +499,7 @@ int startDAPHNE(int argc, const char** argv, DaphneLibResult* daphneLibRes, int 
         parser.parseFile(builder, inputFile);
     }
     catch(std::exception & e) {
-        std::cerr << "Parser error: " << e.what() << std::endl;
+        spdlog::error("Parser error: {}", e.what());
         return StatusCode::PARSER_ERROR;
     }
 
@@ -514,19 +511,12 @@ int startDAPHNE(int argc, const char** argv, DaphneLibResult* daphneLibRes, int 
             return StatusCode::PASS_ERROR;
         }
     }
-    catch(std::runtime_error & re) {
-        spdlog::error("Pass std::runtime_error: {}", re.what());
-        cerr << "Pass error: " << re.what() << endl;
-        return StatusCode::PASS_ERROR;
-    }
     catch(std::exception & e) {
-        spdlog::error("Pass std::exception: {}", e.what());
-        cerr << "Pass error: " << e.what() << endl;
+        spdlog::error("Pass error: {}", e.what());
         return StatusCode::PASS_ERROR;
     }
     catch(...) {
-        spdlog::error("Pass error caught by ellipsis(...)");
-        cerr << "Pass error: (no message)" << endl;
+        spdlog::error("Pass error: Unknown exception");
         return StatusCode::PASS_ERROR;
     }
 
@@ -546,16 +536,16 @@ int startDAPHNE(int argc, const char** argv, DaphneLibResult* daphneLibRes, int 
             }
         }
         else {
-            spdlog::error("Execution error! Returning from signal {}", gSignalStatus);
+            spdlog::error("Execution error: Returning from signal {}", gSignalStatus);
             return StatusCode::EXECUTION_ERROR;
         }
     }
     catch (std::runtime_error& re) {
-        spdlog::error("Execution error!\nFinal catch std::runtime_error in {}:{}: \n{}",__FILE__, __LINE__, re.what());
+        spdlog::error("Execution error: {}", re.what());
         return StatusCode::EXECUTION_ERROR;
     }
     catch(std::exception & e){
-        std::cerr << "Execution error: " << e.what() << std::endl;
+        spdlog::error("Execution error: {}", e.what());
         return StatusCode::EXECUTION_ERROR;
     }
     clock::time_point tpEnd = clock::now();
@@ -567,6 +557,7 @@ int startDAPHNE(int argc, const char** argv, DaphneLibResult* daphneLibRes, int 
         double durComp  = chrono::duration_cast<chrono::duration<double>>(tpBegExec - tpBegComp).count();
         double durExec  = chrono::duration_cast<chrono::duration<double>>(tpEnd     - tpBegExec).count();
         double durTotal = chrono::duration_cast<chrono::duration<double>>(tpEnd     - tpBeg    ).count();
+        // ToDo: use logger
         // Output durations in JSON.
         std::cerr << "{";
         std::cerr << "\"startup_seconds\": "     << durStrt  << ", ";

--- a/src/compiler/inference/InferencePass.cpp
+++ b/src/compiler/inference/InferencePass.cpp
@@ -162,7 +162,7 @@ class InferencePass : public PassWrapper<InferencePass, OperationPass<func::Func
                 daphne::setInferedTypes(op, cfg.partialInferenceAllowed);
         }
         catch (std::runtime_error& re) {
-            spdlog::error("Final catch std::runtime_error in {}:{}: \n{}",__FILE__, __LINE__, re.what());
+            spdlog::error("Exception in {}:{}: \n{}",__FILE__, __LINE__, re.what());
             signalPassFailure();
         }
         // Inference of interesting properties.
@@ -466,7 +466,7 @@ public:
             f.walk<WalkOrder::PreOrder>(walkOp);
         }
         catch (std::runtime_error& re) {
-            spdlog::error("Final catch std::runtime_error in {}:{}: \n{}",__FILE__, __LINE__, re.what());
+            spdlog::error("Exception in {}:{}: \n{}",__FILE__, __LINE__, re.what());
             return;
         }
         // infer function return types

--- a/src/compiler/lowering/RewriteSqlOpPass.cpp
+++ b/src/compiler/lowering/RewriteSqlOpPass.cpp
@@ -69,7 +69,7 @@ namespace
                     result_op = parser.parseStreamFrame(rewriter, sql_query, sourceName);
                 }
                 catch (std::runtime_error& re) {
-                    spdlog::error("Final catch std::runtime_error in {}:{}: \n{}",__FILE__, __LINE__, re.what());
+                    spdlog::error("Exception in {}:{}: \n{}",__FILE__, __LINE__, re.what());
                     return failure();
                 }
                 rewriter.replaceOp(op, result_op);

--- a/src/compiler/lowering/RewriteToCallKernelOpPass.cpp
+++ b/src/compiler/lowering/RewriteToCallKernelOpPass.cpp
@@ -142,9 +142,7 @@ namespace
         {
         }
 
-        LogicalResult matchAndRewrite(Operation *op,
-                                      PatternRewriter &rewriter) const override
-        {
+        LogicalResult matchAndRewrite(Operation *op, PatternRewriter &rewriter) const override {
             Location loc = op->getLoc();
 
             // Determine the name of the kernel function to call by convention
@@ -153,21 +151,12 @@ namespace
             std::stringstream callee;
 
             // check CUDA support and valid device ID
-//            auto attr = op->getAttr("cuda_device");
-//            if(attr && attr.dyn_cast<IntegerAttr>().getInt() > -1) {
             if(op->hasAttr("cuda_device")) {
-//                op->hasTrait<mlir::OpTrait::CUDASupport>() &&
-//                auto attr = op->getAttr("cuda_device");
-//                if(attr && attr.dyn_cast<IntegerAttr>().getInt() > -1) {
-//                if(attr.dyn_cast<IntegerAttr>().getInt() > -1)
-                    callee << "CUDA";
-//                else
-//                    std::cout << "attr = null: " << op->getName().getStringRef().str() << std::endl;
+                callee << "CUDA";
             }
-	    else if(op->hasAttr("fpgaopencl_device")) {
-		 callee << "FPGAOPENCL";
-	    }
-		    
+	        else if(op->hasAttr("fpgaopencl_device")) {
+		        callee << "FPGAOPENCL";
+	        }
 
             callee << '_' << op->getName().stripDialect().data();
 

--- a/src/compiler/lowering/RewriteToCallKernelOpPass.cpp
+++ b/src/compiler/lowering/RewriteToCallKernelOpPass.cpp
@@ -154,9 +154,9 @@ namespace
             if(op->hasAttr("cuda_device")) {
                 callee << "CUDA";
             }
-	        else if(op->hasAttr("fpgaopencl_device")) {
-		        callee << "FPGAOPENCL";
-	        }
+            else if(op->hasAttr("fpgaopencl_device")) {
+                callee << "FPGAOPENCL";
+            }
 
             callee << '_' << op->getName().stripDialect().data();
 

--- a/src/ir/daphneir/DaphneInferTypesOpInterface.cpp
+++ b/src/ir/daphneir/DaphneInferTypesOpInterface.cpp
@@ -423,11 +423,11 @@ void daphne::setInferedTypes(Operation* op, bool partialInferenceAllowed) {
         types = daphne::tryInferType(op);
     }
     catch (std::runtime_error& re) {
-        spdlog::error("Caught std::runtime_error in {}:{}: \n{}",__FILE__, __LINE__, re.what());
+        spdlog::error("Exception in {}:{}: \n{}",__FILE__, __LINE__, re.what());
         throw;
     }
     catch (...) {
-        spdlog::error("Caught an unspecified exception in {}:{}",__FILE__, __LINE__);
+        spdlog::error("Unknown exception in {}:{}",__FILE__, __LINE__);
         throw;
     }
     const size_t numRes = op->getNumResults();
@@ -438,7 +438,7 @@ void daphne::setInferedTypes(Operation* op, bool partialInferenceAllowed) {
                 std::to_string(types.size()) + " types, but the op has " +
                 std::to_string(numRes) + " results"
         );
-    // Set the infered types on all results of this operation.
+    // Set the inferred types on all results of this operation.
     for(size_t i = 0; i < numRes; i++) {
         if (types[i].isa<daphne::UnknownType>() && !partialInferenceAllowed)
             // TODO As soon as the run-time can handle unknown

--- a/src/parser/config/ConfigParser.cpp
+++ b/src/parser/config/ConfigParser.cpp
@@ -39,7 +39,6 @@ void ConfigParser::readUserConfig(const std::string& filename, DaphneUserConfig&
     std::ifstream ifs(filename);
     auto jf = nlohmann::json::parse(ifs);
 
-//try {
     checkAnyUnexpectedKeys(jf, filename);   // raise an error if the config JSON file contains any unexpected keys
 
     if (keyExists(jf, DaphneConfigJsonParams::USE_CUDA_))
@@ -113,8 +112,9 @@ void ConfigParser::readUserConfig(const std::string& filename, DaphneUserConfig&
                         val.at("format")}));
             }
             else {
-                spdlog::error("Not handling log config entry {}", key);
+                spdlog::error("Not handling unknown/malformed log config entry {}", key);
                 for (const auto&[key2, val2]: val.items()) {
+                    // not using spdlog::get() here as loggers are most likely not configured yet
                     spdlog::error(key2);
                     spdlog::error(val2);
                 }
@@ -122,13 +122,6 @@ void ConfigParser::readUserConfig(const std::string& filename, DaphneUserConfig&
 
         }
     }
-//} catch (const nlohmann::detail::type_error& ex) {
-//    std::cerr << ex.what() << std::endl;
-//} catch (const nlohmann::detail::out_of_range& ex) {
-//    std::cerr << ex.what() << std::endl;
-//} catch (const std::invalid_argument& ex) {
-//    std::cerr << ex.what() << std::endl;
-//}
 }
 
 bool ConfigParser::keyExists(const nlohmann::json& j, const std::string& key) {

--- a/src/parser/daphnedsl/DaphneDSLVisitor.cpp
+++ b/src/parser/daphnedsl/DaphneDSLVisitor.cpp
@@ -470,9 +470,18 @@ antlrcpp::Any DaphneDSLVisitor::visitIfStatement(DaphneDSLGrammarParser::IfState
     for(auto it = owUnion.begin(); it != owUnion.end(); it++) {
         mlir::Value valThen = symbolTable.get(*it, owThen).value;
         mlir::Value valElse = symbolTable.get(*it, owElse).value;
-        if(valThen.getType() != valElse.getType())
+        if(valThen.getType() != valElse.getType()) {
             // TODO We could try to cast the types.
-            throw std::runtime_error("type mismatch");
+            std::string s;
+            llvm::raw_string_ostream stream(s);
+            loc.print(stream);
+            stream << ":\n    ";
+            valThen.print(stream);
+            stream << "\n      is not equal to \n    ";
+            valElse.print(stream);
+            throw std::runtime_error(fmt::format("in {}:{}:\n  type mismatch near script location: {}",
+                    __FILE__, __LINE__, stream.str()));
+        }
         resultsThen.push_back(valThen);
         resultsElse.push_back(valElse);
     }

--- a/src/parser/sql/SQLParser.cpp
+++ b/src/parser/sql/SQLParser.cpp
@@ -55,7 +55,7 @@ mlir::Value SQLParser::parseStreamFrame(mlir::OpBuilder & builder, std::istream 
             a = visitor.visitSql(ctx);
         }
         catch (std::runtime_error& re) {
-            spdlog::error("Caught std::runtime_error in {}:{}: \n{}",__FILE__, __LINE__, re.what());
+            spdlog::error("Exception in {}:{}: \n{}",__FILE__, __LINE__, re.what());
             throw;
         }
 

--- a/src/runtime/distributed/worker/CMakeLists.txt
+++ b/src/runtime/distributed/worker/CMakeLists.txt
@@ -41,7 +41,7 @@ set(LIBS
         DaphneMetaDataParser
         Arrow::arrow_shared
         Parquet::parquet_shared
-        )
+        Util)
 
 add_library(WorkerImpl ${SOURCES})
 #llvm_update_compile_flags(WorkerImpl)

--- a/src/runtime/distributed/worker/MPIWorker.h
+++ b/src/runtime/distributed/worker/MPIWorker.h
@@ -28,7 +28,7 @@
 
 class MPIWorker : WorkerImpl {
     public:
-        MPIWorker(){//TODO
+        MPIWorker(DaphneUserConfig& _cfg) : WorkerImpl(_cfg) {//TODO
             MPI_Comm_rank(MPI_COMM_WORLD, &id);
         }
         

--- a/src/runtime/distributed/worker/WorkerImpl.cpp
+++ b/src/runtime/distributed/worker/WorkerImpl.cpp
@@ -20,8 +20,6 @@
 #include <mlir/ExecutionEngine/ExecutionEngine.h>
 #include <mlir/IR/AsmState.h>
 #include <mlir/Parser/Parser.h>
-#include <mlir/Pass/PassManager.h>
-#include <mlir/Transforms/Passes.h>
 #include <llvm/Support/SourceMgr.h>
 
 #include <ir/daphneir/Daphne.h>
@@ -38,14 +36,7 @@
 
 const std::string WorkerImpl::DISTRIBUTED_FUNCTION_NAME = "dist";
 
-WorkerImpl::WorkerImpl() : tmp_file_counter_(0), localData_()
-{
-}
-
-WorkerImpl::~WorkerImpl(){
-
-}
-
+WorkerImpl::WorkerImpl(DaphneUserConfig& _cfg) : cfg(_cfg), tmp_file_counter_(0), localData_() {}
 
 template<>
 WorkerImpl::StoredInfo WorkerImpl::Store<Structure>(Structure *mat)
@@ -69,16 +60,14 @@ WorkerImpl::StoredInfo WorkerImpl::Store<double>(double *val)
     localData_[identifier] = valPtr;
     return StoredInfo({identifier, 0, 0});
 }
-    
-    
 
 
-WorkerImpl::Status WorkerImpl::Compute(std::vector<WorkerImpl::StoredInfo> *outputs, const std::vector<WorkerImpl::StoredInfo> &inputs, const std::string &mlirCode)
+WorkerImpl::Status WorkerImpl::Compute(std::vector<WorkerImpl::StoredInfo> *outputs,
+        const std::vector<WorkerImpl::StoredInfo> &inputs, const std::string &mlirCode)
 {
-    // ToDo: user config
-    DaphneUserConfig cfg;
     cfg.use_vectorized_exec = true;
     cfg.use_distributed = false;
+
     // TODO Decide if vectorized pipelines should be used on this worker.
     // TODO Decide if selectMatrixReprs should be used on this worker.
     // TODO Once we hand over longer pipelines to the workers, we might not

--- a/src/runtime/distributed/worker/WorkerImpl.h
+++ b/src/runtime/distributed/worker/WorkerImpl.h
@@ -38,9 +38,11 @@ public:
     };
     
     const static std::string DISTRIBUTED_FUNCTION_NAME;
-   
-    WorkerImpl();
-    ~WorkerImpl();
+
+    DaphneUserConfig& cfg;
+
+    WorkerImpl(DaphneUserConfig& _cfg);
+    ~WorkerImpl() = default;
     
     virtual void Wait() { };
    
@@ -69,7 +71,8 @@ public:
      * @param mlirCode mlir code fragment
      * @return WorkerImpl::Status contains if everything went fine, with an optional error message
      */
-    WorkerImpl::Status Compute(std::vector<WorkerImpl::StoredInfo> *outputs, const std::vector<WorkerImpl::StoredInfo> &inputs, const std::string &mlirCode) ;
+    WorkerImpl::Status Compute(std::vector<WorkerImpl::StoredInfo> *outputs,
+            const std::vector<WorkerImpl::StoredInfo> &inputs, const std::string &mlirCode);
 
     /**
      * @brief Returns a matrix stored in worker's memory

--- a/src/runtime/distributed/worker/WorkerImplGRPC.cpp
+++ b/src/runtime/distributed/worker/WorkerImplGRPC.cpp
@@ -24,7 +24,7 @@
 #include <grpcpp/grpcpp.h>
 #include <grpcpp/server_builder.h>
 
-WorkerImplGRPC::WorkerImplGRPC(std::string addr)
+WorkerImplGRPC::WorkerImplGRPC(const std::string& addr, DaphneUserConfig& _cfg) : WorkerImpl(_cfg)
 {
     builder.AddListeningPort(addr, grpc::InsecureServerCredentials());
     cq_ = builder.AddCompletionQueue();
@@ -79,10 +79,8 @@ grpc::Status WorkerImplGRPC::StoreGRPC(::grpc::ServerContext *context,
     return ::grpc::Status::OK;
 }
 
-grpc::Status WorkerImplGRPC::ComputeGRPC(::grpc::ServerContext *context,
-                         const ::distributed::Task *request,
-                         ::distributed::ComputeResult *response)
-{
+grpc::Status WorkerImplGRPC::ComputeGRPC(::grpc::ServerContext *context, const ::distributed::Task *request,
+        ::distributed::ComputeResult *response) {
     std::vector<StoredInfo> inputs;
     inputs.reserve(request->inputs().size());
 

--- a/src/runtime/distributed/worker/WorkerImplGRPC.h
+++ b/src/runtime/distributed/worker/WorkerImplGRPC.h
@@ -32,14 +32,16 @@ private:
     grpc::ServerBuilder builder;
     std::unique_ptr<grpc::Server> server;
 public:
-    WorkerImplGRPC(std::string addr);
+    explicit WorkerImplGRPC(const std::string& addr, DaphneUserConfig& _cfg);
+
     void Wait() override;
+
     grpc::Status StoreGRPC(::grpc::ServerContext *context,
                          const ::distributed::Data *request,
                          ::distributed::StoredData *response) ;
     grpc::Status ComputeGRPC(::grpc::ServerContext *context,
                          const ::distributed::Task *request,
-                         ::distributed::ComputeResult *response) ;
+                         ::distributed::ComputeResult *response);
     grpc::Status TransferGRPC(::grpc::ServerContext *context,
                           const ::distributed::StoredData *request,
                          ::distributed::Data *response) ;

--- a/src/runtime/distributed/worker/main.cpp
+++ b/src/runtime/distributed/worker/main.cpp
@@ -27,8 +27,8 @@ int main(int argc, char *argv[])
     auto logger = std::make_unique<DaphneLogger>(user_config);
 
     if (argc != 2) {
-         std::cout << "Usage: " << argv[0] << " <Address:Port>" << std::endl;
-         exit(1);
+        std::cout << "Usage: " << argv[0] << " <Address:Port>" << std::endl;
+        exit(1);
     }
     auto addr = argv[1];
 

--- a/src/runtime/distributed/worker/main.cpp
+++ b/src/runtime/distributed/worker/main.cpp
@@ -20,16 +20,20 @@
 #include "WorkerImpl.h"
 #include "WorkerImplGRPC.h"
 
+
 int main(int argc, char *argv[])
 {
+    DaphneUserConfig user_config{};
+    auto logger = std::make_unique<DaphneLogger>(user_config);
+
     if (argc != 2) {
-        std::cout << "Usage: " << argv[0] << " <Address:Port>" << std::endl;
-        exit(1);
+         std::cout << "Usage: " << argv[0] << " <Address:Port>" << std::endl;
+         exit(1);
     }
     auto addr = argv[1];
 
     // TODO choose specific implementation based on arguments or config file
-    WorkerImpl *service = new WorkerImplGRPC(addr);
+    WorkerImpl *service = new WorkerImplGRPC(addr, user_config);
     
     std::cout << "Started Distributed Worker on `" << addr << "`\n";
     service->Wait();

--- a/src/runtime/local/context/CUDAContext.h
+++ b/src/runtime/local/context/CUDAContext.h
@@ -83,6 +83,16 @@ public:
 
     void free(size_t id);
 
+    template<typename T>
+    static void debugPrintCUDABuffer(const CUDAContext& ctx, std::string_view title, const T* data, size_t num_items) {
+        std::vector<T> tmp(num_items);
+        CHECK_CUDART(cudaMemcpy(tmp.data(), data, num_items * sizeof(T), cudaMemcpyDeviceToHost));
+        auto out = fmt::memory_buffer();
+        fmt::format_to(std::back_inserter(out),"{} \n", title);
+        fmt::format_to(std::back_inserter(out), fmt::join(tmp, ", "));
+        ctx.logger->debug(out);
+    }
+
     int conv_algorithm = -1;
     cudnnPoolingDescriptor_t pooling_desc{};
     cudnnTensorDescriptor_t src_tensor_desc{}, dst_tensor_desc{}, bn_tensor_desc{};
@@ -95,5 +105,7 @@ public:
     // A block size of 256 works well in many cases.
     // Putting it here to avoid hard coding things elsewhere.
     const uint32_t default_block_size = 256;
-    
+
+    // cuda runtime logger
+    std::shared_ptr<spdlog::logger> logger;
 };

--- a/src/runtime/local/context/DaphneContext.h
+++ b/src/runtime/local/context/DaphneContext.h
@@ -68,8 +68,10 @@ struct DaphneContext {
      */
     DaphneUserConfig& config;
 
+    std::shared_ptr<spdlog::logger> logger;
+
     explicit DaphneContext(DaphneUserConfig& config) : config(config) {
-        //
+        logger = spdlog::get("runtime");
     }
 
     ~DaphneContext() {

--- a/src/runtime/local/context/FPGAContext.cpp
+++ b/src/runtime/local/context/FPGAContext.cpp
@@ -37,36 +37,30 @@ using namespace aocl_utils;
 
 #define CHECK(status)                                       \
     if (status != CL_SUCCESS) {                             \
-        printf("error %d in line %d.\n", status, __LINE__); \
-        exit(1);                                            \
+        throw std::runtime_error(fmt::format("error {} in line {}", status, __LINE__)); \
     }
 
 void FPGAContext::destroy() {
-#ifndef NDEBUG
-    std::cout << "Destroying FPGA context..." << std::endl;
-#endif
+    spdlog::debug("Destroying FPGA context...");
 }
 
 void FPGAContext::init() {
-#ifndef NDEBUG
-    std::cout << "creating FPGA context..." << std::endl;
-    DPRINTF("\n===== Host-CPU setting up the OpenCL platform and device ======\n\n");
+    spdlog::debug("creating FPGA context...");
+    spdlog::debug("\n===== Host-CPU setting up the OpenCL platform and device ======\n\n");
     unsigned int buf_uint;
-#endif
     cl_int status;
     char buffer[4096];
     int device_found = 0;
 
     // Use clGetPlatformIDs() to retrieve the  number of platforms
     status = clGetPlatformIDs(0, NULL, &numPlatforms);
-#ifndef NDEBUG
-    DPRINTF("Number of platforms = %d\n", numPlatforms);
-#endif
+    spdlog::debug("Number of platforms = {}\n", numPlatforms);
+
     // Allocate enough space for each platform
     platforms = (cl_platform_id *)malloc(numPlatforms * sizeof(cl_platform_id));
-#ifndef NDEBUG
-    DPRINTF("Allocated space for Platform\n");
-#endif
+
+    spdlog::debug("Allocated space for Platform\n");
+
     status = clGetPlatformIDs(numPlatforms, platforms, NULL);
     CHECK(status);
 #ifndef NDEBUG

--- a/src/runtime/local/context/FPGAContext.h
+++ b/src/runtime/local/context/FPGAContext.h
@@ -16,10 +16,8 @@
 
 #pragma once
 
-//#include <api/cli/DaphneUserConfig.h>
+#include <spdlog/spdlog.h>
 #include "IContext.h"
-//#include <runtime/local/kernels/CUDA/HostUtils.h>
-//#include <cublasLt.h>
 #include <AOCLUtils/aocl_utils.h>
 #include <CL/opencl.h>
 #include <cassert>

--- a/src/runtime/local/datastructures/DenseMatrix.cpp
+++ b/src/runtime/local/datastructures/DenseMatrix.cpp
@@ -26,7 +26,7 @@ DenseMatrix<ValueType>::DenseMatrix(size_t maxNumRows, size_t numCols, bool zero
 {
     DataPlacement* new_data_placement;
     if(allocInfo != nullptr) {
-        spdlog::get("default")->debug("Creating {} x {} dense matrix of type: {}. Required memory: {} Mb",
+        spdlog::debug("Creating {} x {} dense matrix of type: {}. Required memory: {} Mb",
                 numRows, numCols, static_cast<int>(allocInfo->getType()),
                 static_cast<float>(getBufferSize()) / (1048576));
 
@@ -184,13 +184,13 @@ auto DenseMatrix<ValueType>::getValuesInternal(const IAllocationDescriptor* allo
                 std::get<2>(result) = startAddress();
             }
             if(std::get<2>(result) == nullptr)
-                throw std::runtime_error("Error: no object meta data in matrix");
+                throw std::runtime_error("No object meta data in matrix");
             else
                 return result;
         }
     }
     else
-        throw std::runtime_error("Error: range support under construction");
+        throw std::runtime_error("Range support under construction");
 }
 
 template <typename ValueType> void DenseMatrix<ValueType>::printValue(std::ostream & os, ValueType val) const {
@@ -235,10 +235,7 @@ size_t DenseMatrix<bool>::serialize(std::vector<char> &buf) const{
 DenseMatrix<const char*>::DenseMatrix(size_t maxNumRows, size_t numCols, bool zero, size_t strBufferCapacity_, ALLOCATION_TYPE type) :
         Matrix<const char*>(maxNumRows, numCols), rowSkip(numCols), lastAppendedRowIdx(0), lastAppendedColIdx(0)
 {
-#ifndef NDEBUG
-    std::cerr << "creating dense matrix of allocation type " << static_cast<int>(type) <<
-              ", dims: " << numRows << "x" << numCols << " req.mem.: " << printBufferSize() << "Mb" << " with at least " << strBufferCapacity_ << " bytes for strings" <<  std::endl;
-#endif
+    spdlog::debug("creating dense matrix of allocation type {}, dims: {}x{} req.mem.: {}Mb with at least {} bytes for strings",  static_cast<int>(type), numRows, numCols, printBufferSize(), strBufferCapacity_);
     if (type == ALLOCATION_TYPE::HOST) {
         alloc_shared_values();
         alloc_shared_strings(nullptr, strBufferCapacity_);

--- a/src/runtime/local/io/utils.h
+++ b/src/runtime/local/io/utils.h
@@ -14,15 +14,13 @@
  * limitations under the License.
  */
 
-#ifndef SRC_RUNTIME_LOCAL_IO_UTILS_H
-#define SRC_RUNTIME_LOCAL_IO_UTILS_H
+#pragma once
 
-#include <iostream>
 #include <limits>
 #include <stdexcept>
 #include <string>
 
-#include <cstdint>
+#include <spdlog/spdlog.h>
 
 // Conversion of std::string.
 
@@ -43,9 +41,7 @@ inline void convertStr(std::string const &x, float *v) {
   catch (const std::out_of_range& e) {
       // handling subnormal values (too small)
       *v = std::numeric_limits<float>::min();
-#ifndef NDEBUG
-      std::cerr << "Warning: setting subnormal float value " << x << " to std::numeric_limits<float>::min() -> " << std::numeric_limits<float>::min() << std::endl;
-#endif
+      spdlog::warn("setting subnormal float value {} to std::numeric_limits<float>::min() -> {}", x, std::numeric_limits<float>::min());
   }
 }
 inline void convertStr(std::string const &x, int8_t *v) { *v = stoi(x); }
@@ -75,6 +71,4 @@ inline void convertCstr(const char * x, int64_t *v) { *v = atoi(x); }
 inline void convertCstr(const char * x, uint8_t *v) { *v = atoi(x); }
 inline void convertCstr(const char * x, uint32_t *v) { *v = atoi(x); }
 inline void convertCstr(const char * x, uint64_t *v) { *v = atoi(x); }
-
-#endif // SRC_RUNTIME_LOCAL_IO_UTILS_H
 

--- a/src/runtime/local/kernels/CUDA/AggCol.cu
+++ b/src/runtime/local/kernels/CUDA/AggCol.cu
@@ -81,8 +81,7 @@ namespace CUDA {
             agg_col<<<gridSize, blockSize>>>(res->getValues(&alloc_desc), arg->getValues(&alloc_desc), N, numCols, op);
         }
         else {
-            std::cerr << "opCode=" << static_cast<uint32_t>(opCode) << std::endl;
-            throw std::runtime_error("unknown operator for aggCol");
+            throw std::runtime_error(fmt::format("Unknown opCode {} for aggCol", static_cast<uint32_t>(opCode)));
         }
     }
     template struct AggCol<DenseMatrix<double>, DenseMatrix<double>>;

--- a/src/runtime/local/kernels/CUDA/ColBind.cu
+++ b/src/runtime/local/kernels/CUDA/ColBind.cu
@@ -67,12 +67,8 @@ namespace CUDA {
         size_t gridSize;
         CHECK_CUDART(cudaOccupancyMaxPotentialBlockSize( &minGridSize, &blockSize, cbind<VTres>, 0, 0));
         gridSize = (N + blockSize - 1) / blockSize;
-
-#ifndef NDEBUG
-        std::cerr << " ColBind: " << gridSize << " blocks x " << blockSize << " threads = " << gridSize*blockSize <<
-                " total threads for " << N << " items" << std::endl;
-#endif
-
+        spdlog::get("runtime::cuda")->debug("ColBind: {} blocks x {} threads = {} total threads for {} items", gridSize,
+                blockSize, gridSize*blockSize,N);
         cbind<<<gridSize, blockSize>>>(lhs->getValues(&alloc_desc), rhs->getValues(&alloc_desc), res->getValues(&alloc_desc),
                 numRowsLhs, numColsLhs, numRowsRhs, numColsRhs);
     }

--- a/src/runtime/local/kernels/CUDA/EwBinaryMat.cu
+++ b/src/runtime/local/kernels/CUDA/EwBinaryMat.cu
@@ -231,8 +231,7 @@ namespace CUDA {
             }
         }
         else {
-            std::cerr << "opCode=" << static_cast<uint32_t>(opCode) << std::endl;
-            throw std::runtime_error("unknown operator for EwBinaryMat");
+            throw std::runtime_error(fmt::format("Unknown opCode {} for EwBinaryMat", static_cast<uint32_t>(opCode)));
         }
         if(err) {
             assert(
@@ -241,11 +240,8 @@ namespace CUDA {
                              "width/height of the other"
             );
         }
-#ifndef NDEBUG
-        std::cerr << " EwBinMat[" << static_cast<int>(opCode) << "]: " << gridSize << " blocks x " << blockSize
-                  << " threads = " << gridSize * blockSize
-                  << " total threads for " << N << " items" << std::endl;
-#endif
+        spdlog::get("runtime::cuda")->debug("EwBinMat[{}]: {} blocks x {} threads = {} total threads for {} items",
+                static_cast<int>(opCode), gridSize, blockSize, gridSize*blockSize,N);
     }
 
     template struct EwBinaryMat<DenseMatrix<long>, DenseMatrix<long>, DenseMatrix<long>>;

--- a/src/runtime/local/kernels/CUDA/EwBinaryObjSca.cu
+++ b/src/runtime/local/kernels/CUDA/EwBinaryObjSca.cu
@@ -73,8 +73,7 @@ namespace CUDA {
         }
 
         else {
-            std::cerr << "opCode=" << static_cast<uint32_t>(opCode) << std::endl;
-            throw std::runtime_error("unknown operator for EwBinaryObjSca");
+            throw std::runtime_error(fmt::format("Unknown opCode {} for EwBinaryObjSca", static_cast<uint32_t>(opCode)));
         }
     }
     template struct EwBinaryObjSca<DenseMatrix<double>, DenseMatrix<double>, double>;

--- a/src/runtime/local/kernels/CUDA/ExtractCol.cu
+++ b/src/runtime/local/kernels/CUDA/ExtractCol.cu
@@ -18,8 +18,6 @@
 
 #include <runtime/local/datastructures/AllocationDescriptorCUDA.h>
 
-#include <cstdint>
-
 namespace CUDA {
     template<class DTRes, class DTArg, class DTSel>
     __global__ void extract_col(DTRes *res, const DTArg *arg, const DTSel *sel, const size_t sel_rows, const size_t arg_cols, const size_t cols) {
@@ -51,10 +49,8 @@ namespace CUDA {
         CHECK_CUDART(cudaOccupancyMaxPotentialBlockSize(&minGridSize, &blockSize, extract_col<DTRes, DTArg, DTSel>, 0, 0));
         gridSize = (N + blockSize - 1) / blockSize;
 
-#ifndef NDEBUG
-        std::cerr << " ExtractCol: " << gridSize << " blocks x " << blockSize << " threads = " << gridSize*blockSize
-                << " total threads for " << N << " items" << std::endl;
-#endif
+        spdlog::get("runtime::cuda")->debug("ExtractCol: {} blocks x {} threads = {} total threads for {} items",
+                gridSize, blockSize, gridSize*blockSize, N);
 
         extract_col<<<gridSize, blockSize>>>(res->getValues(&alloc_desc), arg->getValues(&alloc_desc),
                 sel->getValues(&alloc_desc), sel->getNumRows(), arg->getNumCols(), N);

--- a/src/runtime/local/kernels/CreateDaphneContext.cpp
+++ b/src/runtime/local/kernels/CreateDaphneContext.cpp
@@ -18,7 +18,7 @@
 
 void createDaphneContext(DaphneContext *& res, uint64_t configPtr) {
     auto config = reinterpret_cast<DaphneUserConfig *>(configPtr);
-    if(config->log_ptr)
+    if(config->log_ptr != nullptr)
         config->log_ptr->registerLoggers();
     res = new DaphneContext(*config);
 }

--- a/src/runtime/local/kernels/EwBinaryMat.h
+++ b/src/runtime/local/kernels/EwBinaryMat.h
@@ -104,8 +104,6 @@ struct EwBinaryMat<DenseMatrix<VTres>, DenseMatrix<VTlhs>, DenseMatrix<VTrhs>> {
                 "have the same dimensions, or one of them must be a row/column vector "
                 "with the width/height of the other");
         }
-//        auto end = std::chrono::high_resolution_clock::now();
-//        std::cout << "EwBinaryMat time=" << std::chrono::duration_cast<std::chrono::microseconds>(end - start).count() << "µs)" << std::endl;
     }
 };
 

--- a/src/runtime/local/kernels/MatMul.cpp
+++ b/src/runtime/local/kernels/MatMul.cpp
@@ -273,21 +273,21 @@ void MatMul<DenseMatrix<VT>, DenseMatrix<VT>, DenseMatrix<VT>>::apply(DenseMatri
     auto C = res->getValues();
 
     auto incy = static_cast<int>(res->getRowSkip());
-//    spdlog::get("default")->debug("m {}, n {} k {}", m, n, k);
-//    spdlog::debug("incy: {}", incy);
+//    dctx->logger->debug("m {}, n {} k {}", m, n, k);
+//    dctx->logger->debug("incy: {}", incy);
 
     if(nr1 == 1 && nc2 == 1) {// Vector-Vector
-        spdlog::get("default")->debug("launch_dot<{}>(a[{}], b[{}])", typeid(alpha).name(), m, n);
+        dctx->logger->debug("launch_dot<{}>(a[{}], b[{}])", typeid(alpha).name(), m, n);
         res->set(0, 0, launch_dot(nc1, A, 1, B, static_cast<int>(rhs->getRowSkip())));
     }
     else if(nc2 == 1) {      // Matrix-Vector
-//        spdlog::get("default")->debug("lda {}, ldb {} ldc {}", lda, ldb, ldc);
-        spdlog::get("default")->debug("launch_gemv<{}>(A[{},{}], x[{}])", typeid(alpha).name(), m, k, k);
+//        dctx->logger->debug("lda {}, ldb {} ldc {}", lda, ldb, ldc);
+        dctx->logger->debug("launch_gemv<{}>(A[{},{}], x[{}])", typeid(alpha).name(), m, k, k);
         launch_gemv<VT>(transa, transb, lhs->getNumRows(), lhs->getNumCols(), alpha, A, lda, B, 1, beta, C, incy);
     }
     else { // Matrix-Matrix
-//        spdlog::get("default")->debug("lda {}, ldb {} ldc {}", lda, ldb, ldc);
-        spdlog::get("default")->debug("launch_gemm<{}>(C[{}x{}], A[{},{}], B[{}x{}], transA:{}, transB:{})",
+//        dctx->logger->debug("lda {}, ldb {} ldc {}", lda, ldb, ldc);
+        dctx->logger->debug("launch_gemm<{}>(C[{}x{}], A[{},{}], B[{}x{}], transA:{}, transB:{})",
                 typeid(alpha).name(), m, n, m, k, k, n, transa, transb);
         launch_gemm<VT>(transa, transb, nr1, nc2, nc1, alpha, A, lda, B, ldb, beta, C, ldc);
     }

--- a/src/runtime/local/vectorized/MTWrapper_dense.cpp
+++ b/src/runtime/local/vectorized/MTWrapper_dense.cpp
@@ -43,10 +43,8 @@ template<typename VT>
     if(this->_numCUDAThreads) {
         this->initCUDAWorkers(q.get(), batchSize8M * 4, verbose);
         this->cudaPrefetchInputs(inputs, numInputs, mem_required, splits);
-#ifndef NDEBUG
-        std::cerr << "Required memory (ins/outs): " << mem_required << "\nRequired mem/row: " << row_mem << std::endl;
-        std::cerr << "batchsizeCPU=" << batchSize8M << " batchsizeGPU=" << batchSize8M*4 << std::endl;
-#endif
+        ctx->logger->info("MTWrapper_dense: \nRequired memory (ins/outs): {} Required mem/row: {}\n batchsizeCPU={} "
+                "batchsizeGPU={}", mem_required, row_mem, batchSize8M, batchSize8M*4);
     }
 #endif
 
@@ -207,10 +205,7 @@ template<typename VT>
 
     auto*** res_cuda = new DenseMatrix<VT>**[numOutputs];
     auto blksize = gpu_task_len / ctx->cuda_contexts.size();
-#ifndef NDEBUG
-    std::cerr << "gpu_task_len:  " << gpu_task_len << "\ntaskRatioCUDA: " << taskRatioCUDA << "\nBlock size: "
-              << blksize << std::endl;
-#endif
+    ctx->logger->debug("gpu_task_len: {}\ntaskRatioCUDA: {}\nBlock size: {}", gpu_task_len, taskRatioCUDA, blksize);
     for (size_t i = 0; i < numOutputs; ++i) {
         res_cuda[i] = new DenseMatrix<VT>*;
         if(combines[i] == mlir::daphne::VectorCombine::ROWS) {

--- a/src/runtime/local/vectorized/Worker.h
+++ b/src/runtime/local/vectorized/Worker.h
@@ -26,21 +26,25 @@ class Worker {
 protected:
     std::unique_ptr<std::thread> t;
 
+    DCTX(ctx);
+
     // Worker only used as derived class, which starts the thread after the class has been constructed (order matters).
-    Worker() : t() {}
+    explicit Worker(DCTX(dctx)) : t(), ctx(dctx) {}
+
 public:
     // Worker is move only due to std::thread. Therefore, we delete the copy constructor and the assignment operator.
     Worker(const Worker&) = delete;
     Worker& operator=(const Worker&) = delete;
 
     // move constructor
-    Worker(Worker&& obj)  noexcept : t(std::move(obj.t)) {}
+    Worker(Worker&& obj)  noexcept : t(std::move(obj.t)), ctx(obj.ctx) {}
 
     // move assignment operator
     Worker& operator=(Worker&& obj)  noexcept {
         if(t->joinable())
             t->join();
         t = std::move(obj.t);
+        ctx = obj.ctx;
         return *this;
     }
 

--- a/src/runtime/local/vectorized/WorkerGPU.h
+++ b/src/runtime/local/vectorized/WorkerGPU.h
@@ -25,8 +25,8 @@ class WorkerGPU : public Worker {
     uint32_t _fid;
     uint32_t _batchSize;
 public:
-    // this constructor is to be used in practice
-    WorkerGPU(TaskQueue* tq, bool verbose, uint32_t fid = 0, uint32_t batchSize = 100) : Worker(), _q(tq),
+    // ToDo: remove compile-time verbose parameter and use logger
+    WorkerGPU(TaskQueue* tq, DCTX(dctx), bool verbose, uint32_t fid = 0, uint32_t batchSize = 100) : Worker(dctx), _q(tq),
             _verbose(verbose), _fid(fid), _batchSize(batchSize) {
         // at last, start the thread
         t = std::make_unique<std::thread>(&WorkerGPU::run, this);
@@ -40,13 +40,13 @@ public:
         while( !isEOF(t) ) {
             //execute self-contained task
             if( _verbose )
-                std::cerr << "WorkerGPU: executing task." << std::endl;
+                ctx->logger->trace("WorkerGPU: executing task.");
             t->execute(_fid, _batchSize);
             delete t;
             //get next tasks (blocking)
             t = _q->dequeueTask();
         }
         if( _verbose )
-            std::cerr << "WorkerGPU: received EOF, finalized." << std::endl;
+            ctx->logger->trace("WorkerGPU: received EOF, finalized.");
     }
 };

--- a/src/util/DaphneLogger.cpp
+++ b/src/util/DaphneLogger.cpp
@@ -35,35 +35,43 @@
  * off = 6,
  *
  * fallback_loggers takes {str:name, str:filename, int:level, str:pattern} initializers
+ *
+ * special loggers:
+ *   - default: used if no named logger is fetched with spdlog::get("name")
  */
 const std::vector<LogConfig> DaphneLogger::fallback_loggers = {
-        {"default","", 6,"%^%L %H:%M:%S [%n]%$ %v"},
-        {"compiler::cuda", "", 6, "%^[%n %L]:%$ %v" },
-        {"runtime::cuda", "", 6, "%^[%n %L]:%$ %v" }
+        {"default","", 4,"%^[%l]:%$ %v"},
+        {"compiler::cuda", "", 4, "%^[%n %L]:%$ %v" },
+        {"runtime::cuda", "", 4, "%^[%n %L]:%$ %v" },
+        {"runtime", "", 4, "%^[%n %L]:%$ %v" }
 };
 
 void DaphneLogger::createLoggers(const LogConfig& config) {
+    auto logger = spdlog::get(config.name);
+    if(not logger) {
+        std::vector<spdlog::sink_ptr> sinks;
+        if (!config.filename.empty())
+            sinks.push_back(std::make_shared<spdlog::sinks::basic_file_sink_mt>(config.filename, true));
 
-            auto logger = spdlog::get(config.name);
-            if(not logger) {
-                std::vector<spdlog::sink_ptr> sinks;
-                if (!config.filename.empty()) {
-                    sinks.push_back(std::make_shared<spdlog::sinks::basic_file_sink_mt>(config.filename, true));
-                }
-                sinks.push_back(std::make_shared<spdlog::sinks::stdout_color_sink_mt>());
+        sinks.push_back(std::make_shared<spdlog::sinks::stdout_color_sink_mt>());
+        logger = std::make_shared<spdlog::async_logger>(config.name, sinks.begin(), sinks.end(), spdlog::thread_pool());
 
-                logger = std::make_shared<spdlog::async_logger>(config.name, sinks.begin(), sinks.end(),
-                                                                spdlog::thread_pool());
-                auto level = static_cast<spdlog::level::level_enum>(config.level);
-                logger->set_level(config.level >= level_limit ? level : spdlog::level::off);
-                logger->set_pattern(config.format);
-                loggers.push_back(logger);
-                spdlog::register_logger(loggers.back());
-                if (config.name == "default") {
-                    default_logger = loggers.back();
-                    spdlog::set_default_logger(loggers.back());
-                }
-            }
+        auto level = static_cast<spdlog::level::level_enum>(config.level);
+        logger->set_level(config.level >= level_limit ? level : spdlog::level::off);
+        logger->set_pattern(config.format);
+        spdlog::register_logger(logger);
+        loggers.push_back(logger);
+
+        // special treatment for the default logger
+        if (config.name == "default") {
+            // make sure errors will always be displayed
+            if (logger->level() < spdlog::level::err)
+                logger->set_level(spdlog::level::err);
+
+            default_logger = logger;
+            spdlog::set_default_logger(logger);
+        }
+    }
 }
 
 DaphneLogger::DaphneLogger(DaphneUserConfig& _config) : n_threads(1), queue_size(8192) {
@@ -81,7 +89,7 @@ DaphneLogger::DaphneLogger(DaphneUserConfig& _config) : n_threads(1), queue_size
         }
     }
     catch (const spdlog::spdlog_ex &ex) {
-        std::cout << "Log initialization failed: " << ex.what() << std::endl;
+        throw std::runtime_error(fmt::format("Log initialization failed: {}", + ex.what()));
     }
     _config.log_ptr = this;
 }

--- a/src/util/DaphneLogger.h
+++ b/src/util/DaphneLogger.h
@@ -22,7 +22,7 @@
 #include <api/cli/DaphneUserConfig.h>
 #include <vector>
 
-class DaphneUserConfig;
+struct DaphneUserConfig;
 
 class DaphneLogger {
     const static std::vector<LogConfig> fallback_loggers;

--- a/test/run_tests.cpp
+++ b/test/run_tests.cpp
@@ -26,11 +26,6 @@
 #include "run_tests.h"
 
 std::unique_ptr<DaphneContext> setupContextAndLogger() {
-//    ToDo: Setting precompiled log level here as passing user config at runtime is not supported in our test suite
-    auto loglevel = spdlog::level::off;
-    user_config.log_level_limit = loglevel;
-    user_config.loggers.push_back(LogConfig({"default", "daphne-tests.txt", static_cast<int>(loglevel),
-            "\">>>>>>>>> %H:%M:%S %z %v\""}));
     if(not logger)
         logger = std::make_unique<DaphneLogger>(user_config);
 

--- a/test/runtime/distributed/worker/WorkerTest.cpp
+++ b/test/runtime/distributed/worker/WorkerTest.cpp
@@ -19,6 +19,7 @@
 #include "runtime/distributed/worker/WorkerImpl.h"
 #include "runtime/local/kernels/EwBinaryMat.h"
 #include "runtime/local/kernels/CheckEq.h"
+#include "run_tests.h"
 
 #include <tags.h>
 
@@ -33,8 +34,9 @@ const std::string dirPath = "test/runtime/distributed/worker/";
 
 TEMPLATE_PRODUCT_TEST_CASE("Simple distributed worker functionality test", TAG_DISTRIBUTED, (DenseMatrix), (double))
 {
+    auto dctx = setupContextAndLogger();
     using DT = TestType;    
-    WorkerImpl workerImpl;
+    WorkerImpl workerImpl(user_config);
     
     WHEN ("Sending a task where no outputs are expected")
     {

--- a/test/runtime/local/kernels/SyrkTest.cpp
+++ b/test/runtime/local/kernels/SyrkTest.cpp
@@ -20,6 +20,7 @@
 #include <runtime/local/kernels/MatMul.h>
 #include <runtime/local/kernels/Transpose.h>
 #include <runtime/local/kernels/Syrk.h>
+#include "run_tests.h"
 
 #include <tags.h>
 
@@ -28,11 +29,11 @@
 #include <vector>
 
 template<class DT>
-void checkSyrk(const DT * arg) {
+void checkSyrk(const DT * arg, DCTX(dctx)) {
     DT * resExp = nullptr;
     DT * argT = nullptr;
-    transpose(argT, arg, nullptr);
-    matMul(resExp, argT, arg, false, false, nullptr);
+    transpose(argT, arg, dctx);
+    matMul(resExp, argT, arg, false, false, dctx);
 
     DT * resAct = nullptr;
     syrk(resAct, arg, nullptr);
@@ -43,7 +44,8 @@ void checkSyrk(const DT * arg) {
 
 TEMPLATE_PRODUCT_TEST_CASE("Syrk", TAG_KERNELS, (DenseMatrix), (float, double)) {
     using DT = TestType;
-    
+    auto dctx = setupContextAndLogger();
+
     auto m0 = genGivenVals<DT>(3, {
         0, 0, 0,
         0, 0, 0,
@@ -89,15 +91,15 @@ TEMPLATE_PRODUCT_TEST_CASE("Syrk", TAG_KERNELS, (DenseMatrix), (float, double)) 
         3
     });
 
-    checkSyrk(m0);
-    checkSyrk(m1);
-    checkSyrk(m2);
-    checkSyrk(m3);
-    checkSyrk(m4);
-    checkSyrk(m5);
-    checkSyrk(v0);
-    checkSyrk(v1);
-    checkSyrk(v2);
+    checkSyrk(m0, dctx.get());
+    checkSyrk(m1, dctx.get());
+    checkSyrk(m2, dctx.get());
+    checkSyrk(m3, dctx.get());
+    checkSyrk(m4, dctx.get());
+    checkSyrk(m5, dctx.get());
+    checkSyrk(v0, dctx.get());
+    checkSyrk(v1, dctx.get());
+    checkSyrk(v2, dctx.get());
 
     DataObjectFactory::destroy(m0, m1, m2, m3, m4, m5, v0, v1, v2);
 }


### PR DESCRIPTION
This commit introduces the "error" logger that should be used upon quitting the program abnormally due to some error or exception. This logger ignores the log level limit to ensure that fatal error messages get through to the std err console output.

Furthermore, this commit contains a lot of replacements of std::cout and std::cerr (exceptions to this are the distributed code paths for example).
