### PR TITLE
[DAPHNE-#606] Some INT/FLOAT literal suffixes from C++ in DaphneDSL

### DIFF
--- a/src/ir/daphneir/DaphneOps.td
+++ b/src/ir/daphneir/DaphneOps.td
@@ -1534,9 +1534,9 @@ def Daphne_ConstantOp : Daphne_Op<"constant", [ConstantLike, Pure]> {
         OpBuilder<(ins "double":$value), [{
             build($_builder, $_state, $_builder.getF64Type(), $_builder.getF64FloatAttr(value));
         }]>,
-        //OpBuilder<(ins "float":$value), [{
-        //    build($_builder, $_state, $_builder.getF32Type(), $_builder.getF32FloatAttr(value));
-        //}]>,
+        OpBuilder<(ins "float":$value), [{
+            build($_builder, $_state, $_builder.getF32Type(), $_builder.getF32FloatAttr(value));
+        }]>,
         OpBuilder<(ins "int64_t":$value), [{
             Type t = $_builder.getIntegerType(64, true);
             build($_builder, $_state, t, $_builder.getIntegerAttr(t, value));

--- a/src/parser/daphnedsl/DaphneDSLGrammar.g4
+++ b/src/parser/daphnedsl/DaphneDSLGrammar.g4
@@ -153,10 +153,10 @@ VALUE_TYPE:
     ) ;
 
 INT_LITERAL:
-    ('0' | '-'? NON_ZERO_DIGIT DIGIT*) ;
+    ('0' | '-'? NON_ZERO_DIGIT DIGIT* ('l' | 'u' | 'ull' | 'z')?);
 
 FLOAT_LITERAL:
-    ('nan' | '-'? 'inf' | '-'? ('0' | NON_ZERO_DIGIT DIGIT*) '.' DIGIT+ );
+    ('nan' | 'nanf' | '-'? ('inf' | 'inff') | '-'? ('0' | NON_ZERO_DIGIT DIGIT*) '.' DIGIT+ 'f'? );
 
 STRING_LITERAL:
     '"' (ESCAPE_SEQ | ~["\\])* '"';


### PR DESCRIPTION
This change introduces some of the C++ literal suffixes that make writing single precision floats or unsigned integers way more convenient than ``x = as.f32(5.0);`` -> ``x = 5.0f;``

Yes, there should be test cases :see_no_evil: 