### PR TITLE
[MINOR] Enable shape inference for frame type

### DIFF
--- a/src/compiler/inference/InferencePass.cpp
+++ b/src/compiler/inference/InferencePass.cpp
@@ -188,7 +188,8 @@ class InferencePass : public PassWrapper<InferencePass, OperationPass<func::Func
                         );
                     // Set the infered shapes on all results of this operation.
                     for(size_t i = 0 ; i < numRes ; i++) {
-                        if(op->getResultTypes()[i].isa<mlir::daphne::MatrixType>()) {
+                        if(op->getResultTypes()[i].isa<mlir::daphne::MatrixType>() ||
+                            op->getResultTypes()[i].isa<mlir::daphne::FrameType>()) {
                             const ssize_t numRows = shapes[i].first;
                             const ssize_t numCols = shapes[i].second;
                             Value rv = op->getResult(i);

--- a/src/compiler/inference/InferencePass.cpp
+++ b/src/compiler/inference/InferencePass.cpp
@@ -188,8 +188,10 @@ class InferencePass : public PassWrapper<InferencePass, OperationPass<func::Func
                         );
                     // Set the infered shapes on all results of this operation.
                     for(size_t i = 0 ; i < numRes ; i++) {
-                        if(op->getResultTypes()[i].isa<mlir::daphne::MatrixType>() ||
-                            op->getResultTypes()[i].isa<mlir::daphne::FrameType>()) {
+                        if(
+                            op->getResultTypes()[i].isa<mlir::daphne::MatrixType>() ||
+                            op->getResultTypes()[i].isa<mlir::daphne::FrameType>()
+                        ) {
                             const ssize_t numRows = shapes[i].first;
                             const ssize_t numCols = shapes[i].second;
                             Value rv = op->getResult(i);
@@ -222,7 +224,10 @@ class InferencePass : public PassWrapper<InferencePass, OperationPass<func::Func
                     // Set the inferred sparsities on all results of this operation.
                     for(size_t i = 0 ; i < numRes ; i++) {
                         const double sparsity = sparsities[i];
-                        if(op->getResultTypes()[i].isa<mlir::daphne::MatrixType>()) {
+                        if(
+                            op->getResultTypes()[i].isa<mlir::daphne::MatrixType>() ||
+                            op->getResultTypes()[i].isa<mlir::daphne::FrameType>()
+                        ) {
                             Value rv = op->getResult(i);
                             const Type rt = rv.getType();
                             auto mt = rt.dyn_cast<daphne::MatrixType>();


### PR DESCRIPTION
   - DAPHNE support shape inference for frame type but the feature was disabled.
   - The logic should be further revised as it is redundant to throw an error.