### PR TITLE
615-Constant_folding_EwlogOp

### DIFF
--- a/src/ir/daphneir/DaphneDialect.cpp
+++ b/src/ir/daphneir/DaphneDialect.cpp
@@ -703,14 +703,25 @@ mlir::OpFoldResult mlir::daphne::EwModOp::fold(FoldAdaptor adaptor) {
     return {};
 }
 
+// mlir::OpFoldResult mlir::daphne::EwLogOp::fold(FoldAdaptor adaptor) {
+//     ArrayRef<Attribute> operands = adaptor.getOperands();
+//     auto floatOp = [](const llvm::APFloat &a, const llvm::APFloat &b) {
+//         // TODO This is a bug (see #615).
+//         // Equivalent to log_b(a)
+//         return ilogb(a) / ilogb(b);
+//     };
+//     if(auto res = constFoldBinaryOp<FloatAttr>(getType(), operands, floatOp))
+//         return res;
+//     return {};
+// }
 mlir::OpFoldResult mlir::daphne::EwLogOp::fold(FoldAdaptor adaptor) {
     ArrayRef<Attribute> operands = adaptor.getOperands();
     auto floatOp = [](const llvm::APFloat &a, const llvm::APFloat &b) {
-        // TODO This is a bug (see #615).
+        // Compute the element-wise logarithm of a to the base b
         // Equivalent to log_b(a)
-        return ilogb(a) / ilogb(b);
+        return log(a.convertToDouble()) / log(b.convertToDouble());
     };
-    if(auto res = constFoldBinaryOp<FloatAttr>(getType(), operands, floatOp))
+    if (auto res = constFoldBinaryOp<FloatAttr>(getType(), operands, floatOp))
         return res;
     return {};
 }

--- a/src/ir/daphneir/DaphneDialect.cpp
+++ b/src/ir/daphneir/DaphneDialect.cpp
@@ -703,17 +703,6 @@ mlir::OpFoldResult mlir::daphne::EwModOp::fold(FoldAdaptor adaptor) {
     return {};
 }
 
-// mlir::OpFoldResult mlir::daphne::EwLogOp::fold(FoldAdaptor adaptor) {
-//     ArrayRef<Attribute> operands = adaptor.getOperands();
-//     auto floatOp = [](const llvm::APFloat &a, const llvm::APFloat &b) {
-//         // TODO This is a bug (see #615).
-//         // Equivalent to log_b(a)
-//         return ilogb(a) / ilogb(b);
-//     };
-//     if(auto res = constFoldBinaryOp<FloatAttr>(getType(), operands, floatOp))
-//         return res;
-//     return {};
-// }
 mlir::OpFoldResult mlir::daphne::EwLogOp::fold(FoldAdaptor adaptor) {
     ArrayRef<Attribute> operands = adaptor.getOperands();
     auto floatOp = [](const llvm::APFloat &a, const llvm::APFloat &b) {

--- a/test/api/python/scalar_ewbinary.daphne
+++ b/test/api/python/scalar_ewbinary.daphne
@@ -2,8 +2,7 @@ s1 = 2.2;
 s2 = 3.3;
 
 print(pow(s1, s2));
-# TODO The constant folding of EwLogOp has a bug in DAPHNE (see #615).
-# print(log(s1, s2));
+print(log(s1, s2));
 print(mod(s1, s2));
 print(min(s1, s2));
 print(max(s1, s2));

--- a/test/api/python/scalar_ewbinary.py
+++ b/test/api/python/scalar_ewbinary.py
@@ -9,8 +9,7 @@ s1 = dc.fill(2.2, 1, 1)
 s2 = 3.3
 
 s1.sum().pow(s2).print().compute()
-# TODO The constant folding of EwLogOp has a bug in DAPHNE (see #615).
-# s1.sum().log(s2).print().compute()
+s1.sum().log(s2).print().compute()
 s1.sum().mod(s2).print().compute()
 s1.sum().min(s2).print().compute()
 s1.sum().max(s2).print().compute()


### PR DESCRIPTION
_**Bug:**_
The EwLogOp implementation currently computes the element-wise logarithm of x to the base b using the `ilogb` function, which returns an integer value.

**_Solution:_**
This pull request proposes a fix to the issue by replacing the use of `ilogb` with the standard C++ logarithm function `log` to correctly compute the element-wise logarithm in floating-point. The code changes involve converting the `llvm::APFloat` values to standard double-precision floating-point numbers using the `convertToDouble` method and applying the `log` function for the correct result.

After testing the following script:
```
print(log(2.2, 3.3));
```
with the flags `--explain parsing,parsing_simplified`, i got this back:

```
IR after parsing:
module {
  func.func @main() {
    %0 = "daphne.constant"() {value = 2.200000e+00 : f64} : () -> f64
    %1 = "daphne.constant"() {value = 3.300000e+00 : f64} : () -> f64
    %2 = "daphne.ewLog"(%0, %1) : (f64, f64) -> f64
    %3 = "daphne.constant"() {value = true} : () -> i1
    %4 = "daphne.constant"() {value = false} : () -> i1
    "daphne.print"(%2, %3, %4) : (f64, i1, i1) -> ()
    "daphne.return"() : () -> ()
  }
}
IR after parsing and some simplifications:
module {
  func.func @main() {
    %0 = "daphne.constant"() {value = 0.66039243014922311 : f64} : () -> f64
    %1 = "daphne.constant"() {value = false} : () -> i1
    %2 = "daphne.constant"() {value = true} : () -> i1
    "daphne.print"(%0, %2, %1) : (f64, i1, i1) -> ()
    "daphne.return"() : () -> ()
  }
}
0.660392
```


The changes are in file `src/ir/daphneir/DaphneDialect.cpp`
