### PR TITLE
[MINOR] Parsing IR fix.

### DIFF
--- a/src/ir/daphneir/DaphneDialect.cpp
+++ b/src/ir/daphneir/DaphneDialect.cpp
@@ -108,7 +108,7 @@ mlir::Type mlir::daphne::DaphneDialect::parseType(mlir::DialectAsmParser &parser
         }
         // additional properties (only print/read them when present, as this will probably get more and more)
         while (succeeded(parser.parseOptionalColon())) {
-            if (succeeded(parser.parseKeyword("sp"))) {
+            if (succeeded(parser.parseOptionalKeyword("sp"))) {
                 if (sparsity != -1.0) {
                     // read sparsity twice
                     return nullptr;
@@ -117,7 +117,7 @@ mlir::Type mlir::daphne::DaphneDialect::parseType(mlir::DialectAsmParser &parser
                     return nullptr;
                 }
             }
-            else if (succeeded(parser.parseKeyword("rep"))) {
+            else if (succeeded(parser.parseOptionalKeyword("rep"))) {
                 llvm::StringRef repName;
                 if (parser.parseLSquare() || parser.parseKeyword(&repName) || parser.parseRSquare()) {
                     return nullptr;

--- a/test/api/cli/parser/simple.daphne
+++ b/test/api/cli/parser/simple.daphne
@@ -6,3 +6,8 @@ m = rand(2, 3, 100.0, 200.0, 1.0, -1);
 print(m);
 print(m + m);
 print(t(m));
+
+m2 = rand(2, 3, 100.0, 200.0, 0.01, -1);
+print(m2);
+print(m2 + m2);
+print(t(m2));


### PR DESCRIPTION
While parsing a matrix object the "sparsity" and "rerpesentation" arguments can both exist. In that case trying to parse one of them while multiple exist, can make the parser emmit errors. We should consider them optional while trying to parse them in the loop.

This is currently an issue for the distributed runtime, since distributed workers emmit errors while parsing the IR sent by the coordinator. 

Example IR that a matrix contains both "sparsity" and "representation" and parsing it emits errors:
```
func.func @dist(%arg0: !daphne.Matrix<?x403394xf64:sp[2.0816421641779212E-5]:rep[sparse]>, %arg1: !daphne.Matrix<?x?xf64>, %arg2: !daphne.Matrix<?x1xf64>) -> (!daphne.Matrix<?x?xf64>, !daphne.Matrix<?x?xf64>) {
  %0 = "daphne.ewMul"(%arg0, %arg1) : (!daphne.Matrix<?x403394xf64:sp[2.0816421641779212E-5]:rep[sparse]>, !daphne.Matrix<?x?xf64>) -> !daphne.Matrix<?x?xf64:sp[2.0816421641779212E-5]:rep[sparse]>
  %1 = "daphne.maxRow"(%0) : (!daphne.Matrix<?x?xf64:sp[2.0816421641779212E-5]:rep[sparse]>) -> !daphne.Matrix<?x?xf64>
  %2 = "daphne.ewMax"(%1, %arg2) : (!daphne.Matrix<?x?xf64>, !daphne.Matrix<?x1xf64>) -> !daphne.Matrix<?x?xf64>
  %3 = "daphne.ewNeq"(%2, %arg2) : (!daphne.Matrix<?x?xf64>, !daphne.Matrix<?x1xf64>) -> !daphne.Matrix<?x?xf64>
  "daphne.return"(%2, %3) : (!daphne.Matrix<?x?xf64>, !daphne.Matrix<?x?xf64>) -> ()
}
```