### PR TITLE
GPU codegen backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,7 @@ if(USE_MPI)
 endif()    
 ##########
 
-option(USE_CUDA "Whether to activate compilation of CUDA features" OFF)
+option(USE_CUDA "Whether to activate compilation of CUDA features" ON)
 include(CheckLanguage)
 check_language(CUDA)
 if(USE_CUDA AND CMAKE_CUDA_COMPILER)

--- a/build.sh
+++ b/build.sh
@@ -964,8 +964,9 @@ if [ $WITH_DEPS -gt 0 ]; then
         echo "Need to build MLIR/LLVM."
         cmake -G Ninja -S llvm -B "$buildPrefix/$llvmName" \
             -DLLVM_ENABLE_PROJECTS=mlir \
-            -DLLVM_BUILD_EXAMPLES=OFF \
-            -DLLVM_TARGETS_TO_BUILD="$LLVM_ARCH" \
+            -DLLVM_BUILD_EXAMPLES=ON \
+            -DMLIR_ENABLE_CUDA_RUNNER=ON \
+            -DLLVM_TARGETS_TO_BUILD="$LLVM_ARCH;NVPTX" \
             -DCMAKE_BUILD_TYPE=Release \
             -DLLVM_ENABLE_ASSERTIONS=ON \
             -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DLLVM_ENABLE_LLD=ON \

--- a/build.sh
+++ b/build.sh
@@ -964,9 +964,10 @@ if [ $WITH_DEPS -gt 0 ]; then
         echo "Need to build MLIR/LLVM."
         cmake -G Ninja -S llvm -B "$buildPrefix/$llvmName" \
             -DLLVM_ENABLE_PROJECTS=mlir \
-            -DLLVM_BUILD_EXAMPLES=ON \
+            -DLLVM_BUILD_EXAMPLES=OFF \
             -DMLIR_ENABLE_CUDA_RUNNER=ON \
-            -DLLVM_TARGETS_TO_BUILD="$LLVM_ARCH;NVPTX" \
+            -DLLVM_TARGETS_TO_BUILD="X86;NVPTX" \
+            -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc \
             -DCMAKE_BUILD_TYPE=Release \
             -DLLVM_ENABLE_ASSERTIONS=ON \
             -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DLLVM_ENABLE_LLD=ON \
@@ -1004,6 +1005,7 @@ daphne_msg "Build Daphne"
 
 cmake -S "$projectRoot" -B "$daphneBuildDir" -G Ninja -DANTLR_VERSION="$antlrVersion" \
     -DCMAKE_PREFIX_PATH="$installPrefix" \
+    -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc \
     $BUILD_CUDA $BUILD_FPGAOPENCL $BUILD_DEBUG $BUILD_MPI
 
 cmake --build "$daphneBuildDir" --target "$target"

--- a/daphne-opt/daphne-opt.cpp
+++ b/daphne-opt/daphne-opt.cpp
@@ -19,25 +19,16 @@
 #include <mlir/Dialect/LLVMIR/LLVMDialect.h>
 
 #include "ir/daphneir/Passes.h"
-#include "llvm/Support/CommandLine.h"
-#include "llvm/Support/InitLLVM.h"
-#include "llvm/Support/SourceMgr.h"
-#include "llvm/Support/ToolOutputFile.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Affine/Passes.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/LLVMIR/NVVMDialect.h"
 #include "mlir/Dialect/Linalg/Passes.h"
 #include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
-#include "mlir/IR/Dialect.h"
-#include "mlir/IR/MLIRContext.h"
-#include "mlir/InitAllDialects.h"
 #include "mlir/InitAllPasses.h"
-#include "mlir/Pass/Pass.h"
-#include "mlir/Pass/PassManager.h"
-#include "mlir/Support/FileUtilities.h"
 #include "mlir/Tools/mlir-opt/MlirOptMain.h"
 
 int main(int argc, char **argv) {
@@ -50,7 +41,8 @@ int main(int argc, char **argv) {
                     mlir::func::FuncDialect, mlir::scf::SCFDialect,
                     mlir::LLVM::LLVMDialect, mlir::AffineDialect,
                     mlir::memref::MemRefDialect, mlir::linalg::LinalgDialect,
-                    mlir::math::MathDialect>();
+                    mlir::math::MathDialect, mlir::gpu::GPUDialect,
+                    mlir::NVVM::NVVMDialect>();
     // Add the following to include *all* MLIR Core dialects, or selectively
     // include what you need like above. You only need to register dialects that
     // will be *parsed* by the tool, not the one generated

--- a/src/api/internal/daphne_internal.cpp
+++ b/src/api/internal/daphne_internal.cpp
@@ -487,8 +487,8 @@ int startDAPHNE(int argc, const char** argv, DaphneLibResult* daphneLibRes, int 
     }
 
     // add this after the cli args loop to work around args order
-    if(!user_config.libdir.empty() && user_config.use_cuda)
-            user_config.library_paths.push_back(user_config.libdir + "/libCUDAKernels.so");
+    // if(!user_config.libdir.empty() && user_config.use_cuda)
+    //         user_config.library_paths.push_back(user_config.libdir + "/libCUDAKernels.so");
 
     // For DaphneLib (Python API).
     user_config.result_struct = daphneLibRes;
@@ -556,7 +556,6 @@ int startDAPHNE(int argc, const char** argv, DaphneLibResult* daphneLibRes, int 
     try{
         auto engine = executor.createExecutionEngine(moduleOp);
         tpBegExec = clock::now();
-
         // set jump address for catching exceptions in kernel libraries via signal handling
         if(setjmp(return_from_handler) == 0) {
             auto error = engine->invoke("main");
@@ -569,6 +568,8 @@ int startDAPHNE(int argc, const char** argv, DaphneLibResult* daphneLibRes, int 
             spdlog::error("Execution error: Returning from signal {}", gSignalStatus);
             return StatusCode::EXECUTION_ERROR;
         }
+
+        engine->dumpToObjectFile("a.o");
     }
     catch (std::runtime_error& re) {
         spdlog::error("Execution error: {}", re.what());

--- a/src/compiler/execution/DaphneIrExecutor.h
+++ b/src/compiler/execution/DaphneIrExecutor.h
@@ -39,5 +39,6 @@ private:
     std::vector<std::string> sharedLibRefPaths;
 
     void buildCodegenPipeline(mlir::PassManager &);
+    void buildGPUCodegenPipeline(mlir::PassManager &);
 };
 

--- a/src/compiler/lowering/CMakeLists.txt
+++ b/src/compiler/lowering/CMakeLists.txt
@@ -33,6 +33,7 @@ add_mlir_dialect_library(MLIRDaphneTransforms
     MapOpLowering.cpp
     MatMulOpLowering.cpp
     AggAllOpLowering.cpp
+    LowerToGPU.cpp
 
     DEPENDS
     MLIRDaphneOpsIncGen

--- a/src/compiler/lowering/LowerToGPU.cpp
+++ b/src/compiler/lowering/LowerToGPU.cpp
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2023 The DAPHNE Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "compiler/utils/LoweringUtils.h"
+#include <compiler/utils/CompilerUtils.h>
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "api/cli/DaphneUserConfig.h"
+#include "ir/daphneir/Daphne.h"
+#include "ir/daphneir/Passes.h"
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+using namespace mlir;
+
+struct MatMulGPU : public OpRewritePattern<daphne::MatMulOp> {
+  using OpRewritePattern<daphne::MatMulOp>::OpRewritePattern;
+
+  mutable llvm::SmallDenseSet<mlir::Value> optimized;
+  LogicalResult matchAndRewrite(daphne::MatMulOp op,
+                                PatternRewriter &rewriter) const override {
+    auto loc = op->getLoc();
+    mlir::daphne::MatrixType lhsMatrixType =
+        op.getLhs().getType().dyn_cast<mlir::daphne::MatrixType>();
+    mlir::daphne::MatrixType rhsMatrixType =
+        op.getRhs().getType().dyn_cast<mlir::daphne::MatrixType>();
+
+    auto lhsRows = lhsMatrixType.getNumRows();
+    auto lhsCols = lhsMatrixType.getNumCols();
+
+    auto rhsRows = rhsMatrixType.getNumRows();
+    auto rhsCols = rhsMatrixType.getNumCols();
+
+    auto matrixElementType = lhsMatrixType.getElementType();
+
+    // TODO(phil): if shape is unknown, e.g., row/col = -1 we currently
+    // can't create a MemRefType
+    auto lhsMemRefType =
+        mlir::MemRefType::get({lhsRows, lhsCols}, matrixElementType);
+    auto rhsMemRefType =
+        mlir::MemRefType::get({rhsRows, rhsCols}, matrixElementType);
+
+    mlir::MemRefType outputMemRefType =
+        mlir::MemRefType::get({lhsRows, rhsCols}, matrixElementType);
+
+    // daphne::Matrix -> memref
+    mlir::Value lhs = rewriter.create<mlir::daphne::ConvertDenseMatrixToMemRef>(
+        op->getLoc(), lhsMemRefType, op.getLhs());
+    mlir::Value rhs = rewriter.create<mlir::daphne::ConvertDenseMatrixToMemRef>(
+        op->getLoc(), rhsMemRefType, op.getRhs());
+
+    // Alloc output memref
+    mlir::Value outputMemRef =
+        insertMemRefAlloc(outputMemRefType, loc, rewriter);
+
+    mlir::Type unranked = UnrankedMemRefType::get(matrixElementType, 0);
+
+    Value lhsC = rewriter.create<memref::CastOp>(loc, unranked, lhs);
+    Value rhsC = rewriter.create<memref::CastOp>(loc, unranked, rhs);
+    Value resC = rewriter.create<memref::CastOp>(loc, unranked, outputMemRef);
+
+    rewriter.create<gpu::HostRegisterOp>(loc, lhsC);
+    rewriter.create<gpu::HostRegisterOp>(loc, rhsC);
+    rewriter.create<gpu::HostRegisterOp>(loc, resC);
+
+    rewriter.create<linalg::MatmulOp>(loc,
+                                      ValueRange{lhs, rhs}, ValueRange{outputMemRef});
+
+    mlir::Value DM = convertMemRefToDenseMatrix(loc, rewriter, outputMemRef,
+                                                op.getType());
+    rewriter.replaceOp(op, DM);
+    return mlir::success();
+  }
+};
+
+struct GPULoweringPass
+    : public PassWrapper<GPULoweringPass, OperationPass<ModuleOp>> {
+  GPULoweringPass() = default;
+  void runOnOperation() final;
+  StringRef getArgument() const final { return "gpu"; }
+  StringRef getDescription() const final { return ""; }
+};
+
+void GPULoweringPass::runOnOperation() {
+  RewritePatternSet patterns(&getContext());
+  patterns.insert<MatMulGPU>(&getContext());
+
+  if (failed(applyPatternsAndFoldGreedily(getOperation(), std::move(patterns))))
+    signalPassFailure();
+}
+
+std::unique_ptr<Pass>
+daphne::createGPULoweringPass(const DaphneUserConfig &cfg) {
+  return std::make_unique<GPULoweringPass>();
+}

--- a/src/compiler/lowering/MarkCUDAOpsPass.cpp
+++ b/src/compiler/lowering/MarkCUDAOpsPass.cpp
@@ -180,6 +180,9 @@ void MarkCUDAOpsPass::runOnOperation() {
         else {
             if((!llvm::isa<daphne::VectorizedPipelineOp>(op->getParentOp()) && checkUseCUDA(op)) ||
                  llvm::isa<daphne::CreateCUDAContextOp>(op)) {
+                 // || llvm::isa<daphne::MatMulOp>(op)) { // TODO(phil): why
+                                                       // is nothing being
+                                                       // lowered to GPU calls
                 op->setAttr("cuda_device", builder.getI32IntegerAttr(0));
             }
         }

--- a/src/compiler/lowering/RewriteToCallKernelOpPass.cpp
+++ b/src/compiler/lowering/RewriteToCallKernelOpPass.cpp
@@ -21,6 +21,7 @@
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
@@ -515,7 +516,8 @@ void RewriteToCallKernelOpPass::runOnOperation()
     target.addLegalDialect<mlir::AffineDialect, LLVM::LLVMDialect,
                            scf::SCFDialect, memref::MemRefDialect,
                            mlir::linalg::LinalgDialect,
-                           mlir::arith::ArithDialect, mlir::BuiltinDialect>();
+                           mlir::arith::ArithDialect, mlir::BuiltinDialect,
+                           mlir::gpu::GPUDialect>();
 
     target.addLegalOp<ModuleOp, func::FuncOp, func::CallOp, func::ReturnOp>();
     target.addIllegalDialect<daphne::DaphneDialect>();

--- a/src/compiler/utils/LoweringUtils.cpp
+++ b/src/compiler/utils/LoweringUtils.cpp
@@ -109,7 +109,7 @@ void affineFillMemRef(double value, mlir::ConversionPatternRewriter &rewriter,
 }
 
 mlir::Value convertMemRefToDenseMatrix(
-    mlir::Location loc, mlir::ConversionPatternRewriter &rewriter,
+    mlir::Location loc, mlir::PatternRewriter &rewriter,
     mlir::Value memRef, mlir::Type type) {
     auto extractStridedMetadataOp =
         rewriter.create<mlir::memref::ExtractStridedMetadataOp>(loc, memRef);

--- a/src/compiler/utils/LoweringUtils.cpp
+++ b/src/compiler/utils/LoweringUtils.cpp
@@ -76,7 +76,7 @@ void affineFillMemRefInt(int value, mlir::ConversionPatternRewriter &rewriter,
     rewriter.setInsertionPointAfter(outerLoop);
 }
 
-void affineFillMemRef(double value, mlir::ConversionPatternRewriter &rewriter,
+void affineFillMemRef(double value, mlir::PatternRewriter &rewriter,
                       mlir::Location loc, mlir::ArrayRef<int64_t> shape,
                       mlir::MLIRContext *ctx, mlir::Value memRef,
                       mlir::Type elemType) {
@@ -88,23 +88,15 @@ void affineFillMemRef(double value, mlir::ConversionPatternRewriter &rewriter,
     llvm::SmallVector<mlir::Value, 4> loopIvs;
 
     auto outerLoop = rewriter.create<mlir::AffineForOp>(loc, 0, shape[ROW], 1);
-    for (mlir::Operation &nested : *outerLoop.getBody()) {
-        rewriter.eraseOp(&nested);
-    }
     loopIvs.push_back(outerLoop.getInductionVar());
 
     // outer loop body
     rewriter.setInsertionPointToStart(outerLoop.getBody());
     auto innerLoop = rewriter.create<mlir::AffineForOp>(loc, 0, shape[COL], 1);
-    for (mlir::Operation &nested : *innerLoop.getBody()) {
-        rewriter.eraseOp(&nested);
-    }
     loopIvs.push_back(innerLoop.getInductionVar());
-    rewriter.create<mlir::AffineYieldOp>(loc);
     rewriter.setInsertionPointToStart(innerLoop.getBody());
     rewriter.create<mlir::AffineStoreOp>(loc, fillValue, memRef, loopIvs);
 
-    rewriter.create<mlir::AffineYieldOp>(loc);
     rewriter.setInsertionPointAfter(outerLoop);
 }
 

--- a/src/compiler/utils/LoweringUtils.h
+++ b/src/compiler/utils/LoweringUtils.h
@@ -45,7 +45,7 @@ void affineFillMemRef(double value, mlir::ConversionPatternRewriter &rewriter,
                       mlir::Type elemType);
 
 mlir::Value convertMemRefToDenseMatrix(mlir::Location,
-                                       mlir::ConversionPatternRewriter &,
+                                       mlir::PatternRewriter &,
                                        mlir::Value memRef, mlir::Type);
 
 llvm::Optional<mlir::Value> materializeCastFromIllegal(mlir::OpBuilder &builder,

--- a/src/compiler/utils/LoweringUtils.h
+++ b/src/compiler/utils/LoweringUtils.h
@@ -39,7 +39,7 @@ void affineFillMemRefInt(int value, mlir::ConversionPatternRewriter &rewriter,
                          mlir::MLIRContext *ctx, mlir::Value memRef,
                          mlir::Type elemType);
 
-void affineFillMemRef(double value, mlir::ConversionPatternRewriter &rewriter,
+void affineFillMemRef(double value, mlir::PatternRewriter &rewriter,
                       mlir::Location loc, mlir::ArrayRef<int64_t> shape,
                       mlir::MLIRContext *ctx, mlir::Value memRef,
                       mlir::Type elemType);

--- a/src/ir/daphneir/Passes.h
+++ b/src/ir/daphneir/Passes.h
@@ -17,6 +17,7 @@
 #ifndef SRC_IR_DAPHNEIR_PASSES_H
 #define SRC_IR_DAPHNEIR_PASSES_H
 
+#include <memory>
 #pragma once
 
 #include <api/cli/DaphneUserConfig.h>
@@ -65,6 +66,7 @@ namespace mlir::daphne {
     std::unique_ptr<Pass> createWhileLoopInvariantCodeMotionPass();
 #ifdef USE_CUDA
     std::unique_ptr<Pass> createMarkCUDAOpsPass(const DaphneUserConfig& cfg);
+    std::unique_ptr<Pass> createGPULoweringPass(const DaphneUserConfig& cfg);
 #endif
 
 #ifdef USE_FPGAOPENCL

--- a/src/runtime/local/kernels/CUDA/Fill.cu
+++ b/src/runtime/local/kernels/CUDA/Fill.cu
@@ -47,4 +47,5 @@ namespace CUDA {
     template struct Fill<DenseMatrix<double>, double>;
     template struct Fill<DenseMatrix<int64_t>, int64_t>;
     template struct Fill<DenseMatrix<uint8_t>, uint8_t>;
+    template struct Fill<DenseMatrix<uint64_t>, uint64_t>;
 }


### PR DESCRIPTION
This is a draft PR, _not_ intended to be merged atm.

The PR description is also WIP and will be updated with more information.

## Description

This PR introduces an experimental code generation pipeline to target the GPU.
Instead of lowering DaphneOps to calls to the precompiled CUDA/cuDNN kernels, this work aims to generate code that can be lowered to target the GPU directly.

Currently only the `daphne.matMul` operation is supported. In the `GPULoweringPass` the `daphne.matMul` operation is rewritten to a set of operations from the `Linalg`, `MemRef` and `GPU` dialect.

Input to `GPULoweringPass`

```mlir
%26 = "daphne.matMul"(%12, %24, %25, %25) : (!daphne.Matrix<?x?xf32>, !daphne.Matrix<?x?xf32>, i1, i1) -> !daphne.Matrix<?x?xf32>
```


Output of `GPULoweringPass` 

```mlir
%cst = arith.constant 0.000000e+00 : f32
%alloc = memref.alloc() : memref<256x256xf32>
%11 = "daphne.createDaphneContext"(%0) : (ui64) -> !daphne.DaphneContext
"daphne.createCUDAContext"() {cuda_device = 0 : i32} : () -> ()
%12 = "daphne.randMatrix"(%4, %4, %6, %5, %3, %9) : (index, index, f32, f32, f64, si64) -> !daphne.Matrix<256x256xf32:sp[1.000000e+00]>
%13 = "daphne.randMatrix"(%4, %4, %6, %5, %3, %10) : (index, index, f32, f32, f64, si64) -> !daphne.Matrix<256x256xf32:sp[1.000000e+00]>
%14 = "daphne.convertDenseMatrixToMemRef"(%12) : (!daphne.Matrix<256x256xf32:sp[1.000000e+00]>) -> memref<256x256xf32>
%15 = "daphne.convertDenseMatrixToMemRef"(%13) : (!daphne.Matrix<256x256xf32:sp[1.000000e+00]>) -> memref<256x256xf32>
linalg.fill ins(%cst : f32) outs(%alloc : memref<256x256xf32>)
%cast = memref.cast %14 : memref<256x256xf32> to memref<*xf32>
%cast_0 = memref.cast %15 : memref<256x256xf32> to memref<*xf32>
%cast_1 = memref.cast %alloc : memref<256x256xf32> to memref<*xf32>
gpu.host_register %cast : memref<*xf32>
gpu.host_register %cast_0 : memref<*xf32>
gpu.host_register %cast_1 : memref<*xf32>
linalg.matmul ins(%14, %15 : memref<256x256xf32>, memref<256x256xf32>) outs(%alloc : memref<256x256xf32>)
%intptr = memref.extract_aligned_pointer_as_index %alloc : memref<256x256xf32> -> index
%16 = "daphne.convertMemRefToDenseMatrix"(%intptr, %c0, %c256, %c256, %c256, %c1) : (index, index, index, index, index, index) -> !daphne.Matrix<256x256xf32:sp[1.000000e+00]>
```

The `gpu.host_register` op registers the memref for access from the device. The inputs to these `gpu.host_register` ops have to be cast to an unranked memref. We create `linalg.fill` and `linalg.matmul` ops which will be lowered by the pipeline. Additionally, we insert input and output conversion to, and from our C++ runtime.

After this initial rewrite, the IR is passed to a lowering pipeline to produce code that can directly be run on the GPU.
This includes lowering to the GPU dialect, producing NVVM IR, and generation of CUBIN which is embedde in the IR as attribute.

<details>
<summary>Pipeline visualization</summary>

```mermaid
graph TD;
	Input-->LowerToGPU;
	LowerToGPU--> LinalgToParallelLoops;
	LinalgToParallelLoops --> RewriteToCallKernel;
	RewriteToCallKernel-->GPUMapParallelLoops;
	GPUMapParallelLoops-->ParallelLoopsToGPU;
	ParallelLoopsToGPU-->GPUKernelOutlining;
	GPUKernelOutlining-->LowerAffine;
	LowerAffine-->ArithToLLVM;
	ArithToLLVM-->CanonicalizeAndCSE;
	CanonicalizeAndCSE-->SCFToCF;
	SCFToCF-->CFToLLVM;
	CFToLLVM-->LowerGPUOpsToLLVMOps;
	LowerGPUOpsToLLVMOps-->ArithToLLVM;
	ArithToLLVM-->GpuSerializeToCubinPass;
	GpuSerializeToCubinPass-->LowerToLLVM;
	LowerToLLVM-->ReconcileUnrealizedCasts;
```
</details>

At the moment no optimizations are applied to the matmul operator resulting in a less than optimal performance. I'll add optimization passes to improve performance.

The pipeline is currently not very stable, changes in the order of passes can introduce problems, I hope to either make the pipeline simpler or make it more obvious in which order stuff has to happen.

## How to run

- LLVM needs to be compiled with the `NVPTX` target enabled.
- `-DCMAKE_CUDA_COMPILER` needs to be set for that (these are currently hardcoded in the PR)
- DAPHNE needs to be build with CUDA support

#### Minimal working example

Note: currently only tested/supported are single precision matrices and simple scripts (the provided example).

Run by executing `bin/daphne --cuda gpu.daphne`

```cpp
N = 256;
X = rand(N, N, as.f32(0.0), as.f32(1.0), 1, 1);
V = rand(N, N, as.f32(0.0), as.f32(1.0), 1, 2);

RES = X @ V;
print(RES[0,0]);
//print(RES);
```

 
## TODO

- [ ] Some hardcoded values in `build.sh`
- [ ] Hardcoded target triple (`mlir::createGpuSerializeToCubinPass("nvptx64-nvidia-cuda", "sm_86", "+ptx76"))`
- [ ] Lots of temporary code and comments
- [ ] Provide benchmarks
- [ ] Improve perf
- [ ] Remove limitations on types
- [ ] Remove limitations on other ops
- [ ] Provide switch between CUDA precompiled and codegen
- [ ] Tests
- [ ] Documentation
- [ ] Support for multiple GPUs, currently only tested on an RTX A2000 with `Driver Version: 545.23.06, CUDA Version: 12.3`