### PR TITLE
[doc] fix typo in links within Readme

### DIFF
--- a/containers/README.md
+++ b/containers/README.md
@@ -80,7 +80,7 @@ your command line.
 
 
 ## Building a Docker container
-To build the DAPHNE containers, use the provided [``containers/build-containers.sh``](containers/build-containers.sh) 
+To build the DAPHNE containers, use the provided [``containers/build-containers.sh``](/containers/build-containers.sh) 
 script contained in this directory.
 Edit the script to customize the repository and branch where DAPHNE is fetched from or to comment out one build command
 (e.g., if you don't want/need the interactive container).

--- a/doc/README.md
+++ b/doc/README.md
@@ -30,7 +30,7 @@
 - [Extending the DAPHNE Distributed Runtime](/doc/development/ExtendingDistributedRuntime.md)
 - [Building DAPHNE with the build.sh script](/doc/development/BuildingDaphne.md)
 - [Logging in DAPHNE](/doc/development/Logging.md)
-- [Profiling in DAPHNE](/doc/development/Profling.md)
+- [Profiling in DAPHNE](/doc/development/Profiling.md)
 
 ### Source Code Documentation
 


### PR DESCRIPTION
2 links in `containers/README.md` and `doc/README.md` had small typos.
They now redirect to the intended directories.