### PR TITLE
Automated task grain size calculation (related to issue 567).

### DIFF
--- a/src/api/internal/daphne_internal.cpp
+++ b/src/api/internal/daphne_internal.cpp
@@ -153,7 +153,8 @@ int startDAPHNE(int argc, const char** argv, DaphneLibResult* daphneLibRes, int 
                 clEnumVal(PLS, "Performance loop-based self-scheduling"),
                 clEnumVal(MSTATIC, "Modified version of Static, i.e., instead of n/p, it uses n/(4*p) where n is number of tasks and p is number of threads"),
                 clEnumVal(MFSC, "Modified version of fixed size chunk self-scheduling, i.e., MFSC does not require profiling information as FSC"),
-                clEnumVal(PSS, "Probabilistic self-scheduling")
+                clEnumVal(PSS, "Probabilistic self-scheduling"),
+                clEnumVal(AUTO, "Automatic partitioning")
             ),
             init(STATIC)
     );

--- a/src/runtime/local/vectorized/LoadPartitioning.h
+++ b/src/runtime/local/vectorized/LoadPartitioning.h
@@ -21,6 +21,7 @@
 #include <cmath>
 #include <cstdlib>
 #include <string>
+#include <iostream>
 
 class LoadPartitioning {
 
@@ -52,21 +53,23 @@ private:
         return actual_step+1;
     }
 public:
-    LoadPartitioning(int method, uint64_t tasks, uint64_t chunk, uint32_t workers, bool autochunk){
-        
-        if(const char* env_m = std::getenv("DAPHNE_TASK_PARTITION")){
-            method= getMethod(env_m);
-        } 
+LoadPartitioning(int method, uint64_t tasks, uint64_t chunk, uint32_t workers, bool autoChunk){
         schedulingMethod = method;
         totalTasks = tasks;
         double tSize = (totalTasks+workers-1.0)/workers;
         mfscChunk = ceil(tSize*log(2.0)/log((1.0*tSize)));
         fissStages = getStages(totalTasks, workers);
-        if(!autochunk){    
+        if(!autoChunk){    
             chunkParam = chunk;
         }
         else{
-            chunkParam = mfscChunk; //indicate automatic chunk parameter
+            // calculate expertChunk
+            int mul = log2(totalTasks/workers)*0.618; 
+            chunkParam = (totalTasks)/((2<<mul)*workers);
+            method=SS;
+            if (chunkParam < 1){
+                chunkParam = 1;
+            }
         }
         totalWorkers = workers;
         remainingTasks = tasks;

--- a/src/runtime/local/vectorized/LoadPartitioningDefs.h
+++ b/src/runtime/local/vectorized/LoadPartitioningDefs.h
@@ -42,5 +42,6 @@ enum SelfSchedulingScheme {
     MSTATIC,
     MFSC,
     PSS,
+    AUTO,
     INVALID=-1 /* only for JSON enum conversion */
 };

--- a/src/runtime/local/vectorized/MTWrapper_dense.cpp
+++ b/src/runtime/local/vectorized/MTWrapper_dense.cpp
@@ -59,7 +59,10 @@ template<typename VT>
     int chunkParam = ctx->config.minimumTaskSize;
     if(chunkParam<=0)
         chunkParam=1;
-    LoadPartitioning lp(method, len, chunkParam, this->_numThreads, false);
+    bool autoChunk=false;
+    if(method==AUTO)
+        autoChunk = true;
+    LoadPartitioning lp(method, len, chunkParam, this->_numThreads, autoChunk);
     while (lp.hasNextChunk()) {
         endChunk += lp.getNextChunk();
         q->enqueueTask(new CompiledPipelineTask<DenseMatrix<VT>>(CompiledPipelineTaskData<DenseMatrix<VT>>{funcs,
@@ -149,7 +152,10 @@ template<typename VT>
             }
         }
     } else {
-        LoadPartitioning lp(method, len, chunkParam, this->_numThreads, false);
+        bool autoChunk=false;
+        if(method==AUTO)
+            autoChunk = true;
+        LoadPartitioning lp(method, len, chunkParam, this->_numThreads, autoChunk);
         if (ctx->getUserConfig().pinWorkers) {
             while (lp.hasNextChunk()) {
                 endChunk += lp.getNextChunk();
@@ -280,7 +286,11 @@ template<typename VT>
         int chunkParam = ctx->config.minimumTaskSize;
         if(chunkParam<=0)
             chunkParam=1;
-        LoadPartitioning lp(method, cpu_task_len, chunkParam, this->_numCPPThreads, true);
+        bool autoChunk=false;
+        if(method==AUTO)
+            autoChunk = true;
+
+        LoadPartitioning lp(method, cpu_task_len, chunkParam, this->_numCPPThreads, autoChunk);
         while (lp.hasNextChunk()) {
             endChunk += lp.getNextChunk();
             target = currentItr % this->_numQueues;

--- a/src/runtime/local/vectorized/MTWrapper_sparse.cpp
+++ b/src/runtime/local/vectorized/MTWrapper_sparse.cpp
@@ -102,7 +102,11 @@ void MTWrapper<CSRMatrix<VT>>::executeCpuQueues(std::vector<std::function<void(C
             }
         }
     } else {
-        LoadPartitioning lp(method, len, chunkParam, this->_numThreads, false);
+        bool autoChunk=false;
+        if(method==AUTO)
+            autoChunk = true;
+
+        LoadPartitioning lp(method, len, chunkParam, this->_numThreads, autoChunk);
         if (ctx->getUserConfig().pinWorkers) {
             while (lp.hasNextChunk()) {
                 endChunk += lp.getNextChunk();


### PR DESCRIPTION
This pull request includes the implementation for the automated task grain size selection in DAPHNE. Here we add a new option for partitioning strategy in DAPHNE called "AUTO". When a user selects AUTO, DAPHNE will automatically calculate a fixed task grain size which frequently achieves high performance.

@corepointer @pdamme This is my first pull request here. Please let me know if you need anything else from me.