### PR TITLE
#650 fix get topology

### DIFF
--- a/src/runtime/local/vectorized/MTWrapper.h
+++ b/src/runtime/local/vectorized/MTWrapper.h
@@ -85,14 +85,16 @@ protected:
     }
 
     void get_topology(std::vector<int> &physicalIds, std::vector<int> &uniqueThreads, std::vector<int> &responsibleThreads) {
-	hwloc_topology_t topology;
+        hwloc_topology_t topology;
 
-	hwloc_topology_init(&topology);
-	hwloc_topology_load(topology);
+        hwloc_topology_init(&topology);
+        hwloc_topology_load(topology);
 
-	physicalIds.resize(hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_PACKAGE));
-	uniqueThreads.resize(hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_CORE));
-	responsibleThreads.resize(hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_PU));
+        physicalIds.resize(hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_PACKAGE));
+        uniqueThreads.resize(hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_CORE));
+        responsibleThreads.resize(hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_PU));
+
+        hwloc_topology_destroy(topology);
     }
 
     void initCPPWorkers(std::vector<TaskQueue *> &qvector, uint32_t batchSize, const bool verbose = false,


### PR DESCRIPTION
The `get_topology` function is returning weird values since the usage of `hwloc` #563.

https://github.com/daphne-eu/daphne/blob/ccba9387a9b33e5c6b46df0aa3477d3bbab0fbfd/src/runtime/local/vectorized/MTWrapper.h#L87-L96

Namely, the function was just constructing vectors of the correct sizes, but not actually setting the information.

This PR uses `hwloc` to return the same information as before #563 and fix #650