### PR TITLE
Add AggAll kernels for missing value types

### DIFF
--- a/src/runtime/local/kernels/kernels.json
+++ b/src/runtime/local/kernels/kernels.json
@@ -41,11 +41,21 @@
                     ["float", ["DenseMatrix", "float"]],
                     ["double", ["DenseMatrix", "double"]],
                     ["int64_t", ["DenseMatrix", "int64_t"]],
+                    ["int32_t", ["DenseMatrix", "int32_t"]],
+                    ["int8_t", ["DenseMatrix", "int8_t"]],
+                    ["uint64_t", ["DenseMatrix", "uint64_t"]],
+                    ["uint32_t", ["DenseMatrix", "uint32_t"]],
+                    ["uint8_t", ["DenseMatrix", "uint8_t"]],
                     ["double", ["DenseMatrix", "int64_t"]],
                     ["float", ["DenseMatrix", "int64_t"]],
                     ["double", ["CSRMatrix", "double"]],
                     ["float", ["CSRMatrix", "float"]],
                     ["int64_t", ["CSRMatrix", "int64_t"]],
+                    ["int32_t", ["CSRMatrix", "int32_t"]],
+                    ["int8_t", ["CSRMatrix", "int8_t"]],
+                    ["uint64_t", ["CSRMatrix", "uint64_t"]],
+                    ["uint32_t", ["CSRMatrix", "uint32_t"]],
+                    ["uint8_t", ["CSRMatrix", "uint8_t"]],
                     ["double", ["CSRMatrix", "int64_t"]],
                     ["float", ["CSRMatrix", "int64_t"]]
                 ],
@@ -880,7 +890,11 @@
         },
         "instantiations": [
             ["int64_t"],
+            ["int32_t"],
+            ["int8_t"],
             ["uint64_t"],
+            ["uint32_t"],
+            ["uint8_t"],
             ["float"],
             ["double"]
         ]
@@ -905,7 +919,11 @@
         },
         "instantiations": [
             ["int64_t"],
+            ["int32_t"],
+            ["int8_t"],
             ["uint64_t"],
+            ["uint32_t"],
+            ["uint8_t"],
             ["float"],
             ["double"]
         ]

--- a/test/codegen/sum_agg.mlir
+++ b/test/codegen/sum_agg.mlir
@@ -27,7 +27,7 @@ module {
 }
 
 module {
-  func.func @single() {
+  func.func @float() {
     %0 = "daphne.constant"() {value = true} : () -> i1
     %1 = "daphne.constant"() {value = 10 : index} : () -> index
     %2 = "daphne.constant"() {value = 1000000 : si64} : () -> si64

--- a/test/runtime/local/kernels/AggAllTest.cpp
+++ b/test/runtime/local/kernels/AggAllTest.cpp
@@ -29,7 +29,7 @@
 
 #define TEST_NAME(opName) "AggAll (" opName ")"
 #define DATA_TYPES DenseMatrix, CSRMatrix, Matrix
-#define VALUE_TYPES double, uint32_t
+#define VALUE_TYPES double, float, uint8_t, uint32_t, uint64_t, int8_t, int32_t, int64_t
 
 template<typename VTRes, class DTArg>
 void checkAggAll(AggOpCode opCode, const DTArg * arg, VTRes exp) {
@@ -60,7 +60,13 @@ void checkAggAll(AggOpCode opCode, const DTArg * arg, VTRes exp) {
     DataObjectFactory::destroy(m1); \
 }
 SUM_TEST_CASE(int64_t)
+SUM_TEST_CASE(int32_t)
+SUM_TEST_CASE(uint64_t)
+SUM_TEST_CASE(uint32_t)
+SUM_TEST_CASE(int8_t)
+SUM_TEST_CASE(uint8_t)
 SUM_TEST_CASE(double)
+SUM_TEST_CASE(float)
 
 // The value types of argument and result can be assumed to be the same.
 TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("min"), TAG_KERNELS, (DATA_TYPES), (VALUE_TYPES)) {


### PR DESCRIPTION
Closes #662 and #663

The new tests in test/runtime/local/kernels/AggAllTest.cpp confirm that the kernel implementations of the SumAll operation are working correctly for all combinations of the value types double, float, uint8_t, uint32_t, uint64_t, int8_t, int32_t, int64_t. They only need to be pre-compiled to be available to Daphne scripts.

Changes to src/compiler/lowering/AggAllOpLowering.cpp are extracted from my LDE PR #653 and enable SumAll to be called with MLIR code generation for the value types listed above.
