### PR TITLE
[DAPHNE-#669] properly handle views in `WriteCsv` kernel

### DIFF
--- a/src/runtime/local/io/WriteCsv.h
+++ b/src/runtime/local/io/WriteCsv.h
@@ -64,15 +64,17 @@ struct WriteCsv<DenseMatrix<VT>> {
     static void apply(const DenseMatrix<VT> *arg, File* file) {
         assert(file != nullptr && "File required");
         const VT * valuesArg = arg->getValues();
-        size_t cell = 0;
+        const size_t rowSkip = arg->getRowSkip();
+        const size_t argNumCols = arg->getNumCols();
+
         for (size_t i = 0; i < arg->getNumRows(); ++i)
         {
-            for(size_t j = 0; j < arg->getNumCols(); ++j)
+            for(size_t j = 0; j < argNumCols; ++j)
             {
                 fprintf(
                         file->identifier,
                         std::is_floating_point<VT>::value ? "%f" : (std::is_same<VT, long int>::value ? "%ld" : "%d"),
-                        valuesArg[cell++]
+                        valuesArg[i*rowSkip + j]
                 );
                 if(j < (arg->getNumCols() - 1))
                     fprintf(file->identifier, ",");

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -30,6 +30,7 @@ set(TEST_SOURCES
         api/cli/functions/FunctionsTest.cpp
         api/cli/functions/RecursiveFunctionsTest.cpp
         api/cli/io/ReadTest.cpp
+        api/cli/io/WriteTest.cpp
         api/cli/import/ImportTest.cpp
         api/cli/indexing/IndexingTest.cpp
         api/cli/inference/InferenceTest.cpp

--- a/test/api/cli/io/.gitignore
+++ b/test/api/cli/io/.gitignore
@@ -1,0 +1,4 @@
+matrix_full.csv
+matrix_full.csv.meta
+matrix_view.csv
+matrix_view.csv.meta

--- a/test/api/cli/io/WriteTest.cpp
+++ b/test/api/cli/io/WriteTest.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024 The DAPHNE Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <api/cli/Utils.h>
+
+#include <tags.h>
+
+#include <catch.hpp>
+
+#include <filesystem>
+#include <string>
+
+const std::string dirPath = "test/api/cli/io/";
+
+TEST_CASE("writeMatrixCSV_Full", TAG_IO) {
+    std::string csvPath = dirPath + "matrix_full.csv";
+    std::filesystem::remove(csvPath); // remove old file if it still exists
+    checkDaphneStatusCode(StatusCode::SUCCESS, dirPath + "writeMatrix_full.daphne", "--args", std::string("outPath=\"" + csvPath + "\"").c_str());
+    compareDaphneToRef(dirPath + "matrix_full_ref.csv", dirPath + "readMatrix.daphne", "--args", std::string("inPath=\"" + csvPath + "\"").c_str());
+}
+
+TEST_CASE("writeMatrixCSV_View", TAG_IO) {
+    std::string csvPath = dirPath + "matrix_view.csv";
+    std::filesystem::remove(csvPath); // remove old file if it still exists
+    checkDaphneStatusCode(StatusCode::SUCCESS, dirPath + "writeMatrix_view.daphne", "--args", std::string("outPath=\"" + csvPath + "\"").c_str());
+    compareDaphneToRef(dirPath + "matrix_view_ref.csv", dirPath + "readMatrix.daphne", "--args", std::string("inPath=\"" + csvPath + "\"").c_str());
+}

--- a/test/api/cli/io/matrix_full_ref.csv
+++ b/test/api/cli/io/matrix_full_ref.csv
@@ -1,0 +1,4 @@
+DenseMatrix(3x2, int64_t)
+1 2
+3 4
+5 6

--- a/test/api/cli/io/matrix_view_ref.csv
+++ b/test/api/cli/io/matrix_view_ref.csv
@@ -1,0 +1,4 @@
+DenseMatrix(3x1, int64_t)
+2
+4
+6

--- a/test/api/cli/io/readMatrix.daphne
+++ b/test/api/cli/io/readMatrix.daphne
@@ -1,0 +1,4 @@
+// Read a matrix from the file $inPath and print it.
+
+X = readMatrix($inPath);
+print(X);

--- a/test/api/cli/io/writeMatrix_full.daphne
+++ b/test/api/cli/io/writeMatrix_full.daphne
@@ -1,0 +1,4 @@
+// Write an entire small matrix to the file $outPath.
+
+X = reshape(seq(1, 6, 1), 3, 2);
+write(X, $outPath);

--- a/test/api/cli/io/writeMatrix_view.daphne
+++ b/test/api/cli/io/writeMatrix_view.daphne
@@ -1,0 +1,5 @@
+// Write a view into a small matrix to the file $outPath.
+
+X = reshape(seq(1, 6, 1), 3, 2);
+X = X[, 1]; # only the 2nd column
+write(X, $outPath);


### PR DESCRIPTION
This PR fixes #669 for the case of `.csv` files.
Now `WriteCsv` takes the `rowSkip` argument of the matrix it's iterating over into account.