### PR TITLE
Address Wrong results using Integer Matmul Kernels after Matrix resizing

### DIFF
--- a/src/runtime/local/kernels/MatMul.cpp
+++ b/src/runtime/local/kernels/MatMul.cpp
@@ -18,6 +18,8 @@
 
 #include <cblas.h>
 #include <Eigen/Dense>
+#include <Eigen/src/Core/util/Constants.h>
+#include <cstdint>
 #include <spdlog/spdlog.h>
 
 // ****************************************************************************
@@ -38,16 +40,22 @@ double launch_dot(const int32_t n, const double* x, const int32_t incx, const do
 
 template<>
 int32_t launch_dot(const int32_t n, const int32_t* x, const int32_t incx, const int32_t* y, const int32_t incy) {
-    Eigen::Map<const Eigen::Vector<int32_t, Eigen::Dynamic>, Eigen::Unaligned> eigenX(x, n);
-    Eigen::Map<const Eigen::Vector<int32_t, Eigen::Dynamic>, Eigen::Unaligned> eigenY(y, n);
-    return eigenX.dot(eigenY);
+    auto e_x = Eigen::Vector<int32_t, Eigen::Dynamic>::Map(x, n, 1,
+                                                                                  Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>(1, incx));
+
+    auto e_y = Eigen::Vector<int32_t, Eigen::Dynamic>::Map(y, n, 1,
+                                                                                  Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>(1, incy));
+    return e_x.dot(e_y);
 }
 
 template<>
 int64_t launch_dot(const int32_t n, const int64_t* x, const int32_t incx, const int64_t* y, const int32_t incy) {
-    Eigen::Map<const Eigen::Vector<int64_t, Eigen::Dynamic>, Eigen::Unaligned> eigenX(x, n);
-    Eigen::Map<const Eigen::Vector<int64_t, Eigen::Dynamic>, Eigen::Unaligned> eigenY(y, n);
-    return eigenX.dot(eigenY);
+    auto e_x = Eigen::Vector<int64_t, Eigen::Dynamic>::Map(x, n, 1,
+                                                                                  Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>(1, incx));
+
+    auto e_y = Eigen::Vector<int64_t, Eigen::Dynamic>::Map(y, n, 1,
+                                                                                  Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>(1, incy));
+    return e_x.dot(e_y);
 }
 
 
@@ -75,21 +83,27 @@ void launch_gemv(bool transa, bool transb, size_t m, size_t n, const int32_t alp
                  const int32_t* x, const int32_t incx, const int32_t beta, int32_t* y, const int32_t incy) {
     if(transa) {
         auto e_A = Eigen::Matrix<int32_t, Eigen::Dynamic, Eigen::Dynamic>::Map(A, m, n,
-                Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>(1, n)).transpose();
+                Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>(1, lda)).transpose();
 
-        Eigen::Map<const Eigen::Vector<int32_t, Eigen::Dynamic>> e_x(x, m);
-        Eigen::Map<Eigen::Vector<int32_t, Eigen::Dynamic>> e_y(y, n);
+        auto e_x = Eigen::Matrix<int32_t, Eigen::Dynamic, Eigen::Dynamic>::Map(x, m, 1,
+                                                                                  Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>(1, incx));
+
+        auto e_y = Eigen::Matrix<int32_t, Eigen::Dynamic, Eigen::Dynamic>::Map(y, n, 1,
+                                                                                  Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>(1, incy));
         e_y.noalias() = e_A * e_x;
 
     }
     else {
         auto e_A = Eigen::Matrix<int32_t, Eigen::Dynamic, Eigen::Dynamic>::Map(A, m, n,
-                Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>(1, n));
+                Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>(1, lda));
 
-        Eigen::Map<const Eigen::Vector<int32_t, Eigen::Dynamic>> e_x(x, n);
-        Eigen::Map<Eigen::Vector<int32_t, Eigen::Dynamic>> e_y(y, m);
+        auto e_x = Eigen::Matrix<int32_t, Eigen::Dynamic, Eigen::Dynamic>::Map(x, n, 1,
+                                                                                  Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>(1, incx));
+
+        auto e_y = Eigen::Matrix<int32_t, Eigen::Dynamic, Eigen::Dynamic>::Map(y, m, 1,
+                                                                                  Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>(1, incy));
+
         e_y.noalias() = e_A * e_x;
-
     }
 }
 
@@ -98,19 +112,26 @@ void launch_gemv(bool transa, bool transb, size_t m, size_t n, const int64_t alp
                  const int64_t* x, const int32_t incx, const int64_t beta, int64_t* y, const int32_t incy) {
     if(transa) {
         auto e_A = Eigen::Matrix<int64_t, Eigen::Dynamic, Eigen::Dynamic>::Map(A, m, n,
-                Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>(1, n)).transpose();
+                Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>(1, lda)).transpose();
 
-        Eigen::Map<const Eigen::Vector<int64_t, Eigen::Dynamic>> e_x(x, m);
-        Eigen::Map<Eigen::Vector<int64_t, Eigen::Dynamic>> e_y(y, n);
+        auto e_x = Eigen::Matrix<int64_t, Eigen::Dynamic, Eigen::Dynamic>::Map(x, m, 1,
+                                                                                  Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>(1, incx));
+
+        auto e_y = Eigen::Matrix<int64_t, Eigen::Dynamic, Eigen::Dynamic>::Map(y, n, 1,
+                                                                                  Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>(1, incy));
         e_y.noalias() = e_A * e_x;
 
     }
     else {
         auto e_A = Eigen::Matrix<int64_t, Eigen::Dynamic, Eigen::Dynamic>::Map(A, m, n,
-                Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>(1, n));
+                Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>(1, lda));
 
-        Eigen::Map<const Eigen::Vector<int64_t, Eigen::Dynamic>> e_x(x, n);
-        Eigen::Map<Eigen::Vector<int64_t, Eigen::Dynamic>> e_y(y, m);
+        auto e_x = Eigen::Matrix<int64_t, Eigen::Dynamic, Eigen::Dynamic>::Map(x, n, 1,
+                                                                                  Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>(1, incx));
+
+        auto e_y = Eigen::Matrix<int64_t, Eigen::Dynamic, Eigen::Dynamic>::Map(y, m, 1,
+                                                                                  Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>(1, incy));
+
         e_y.noalias() = e_A * e_x;
 
     }
@@ -147,47 +168,47 @@ template<>
     if(transa && transb) {
         auto eigenA = Eigen::Matrix<int32_t, Eigen::Dynamic, Eigen::Dynamic>::Map(A, k, m,
                                                                                   Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>(
-                                                                                          1, m)).transpose();
+                                                                                          1, lda)).transpose();
         auto eigenB = Eigen::Matrix<int32_t, Eigen::Dynamic, Eigen::Dynamic>::Map(B, n, k,
                                                                                   Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>(
-                                                                                          1, k)).transpose();
+                                                                                          1, ldb)).transpose();
         auto eigenC = Eigen::Matrix<int32_t, Eigen::Dynamic, Eigen::Dynamic>::Map(C, n, m,
                                                                                   Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>(
-                                                                                          1, m));
+                                                                                          1, ldc));
         eigenC.noalias() = eigenA * eigenB;
 
     }
     else if (transa) {
         auto eigenA = Eigen::Matrix<int32_t, Eigen::Dynamic, Eigen::Dynamic>::Map(A, k, m,
                                                                                   Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>(
-                                                                                          1, m)).transpose();
+                                                                                          1, lda)).transpose();
         auto eigenB = Eigen::Matrix<int32_t, Eigen::Dynamic, Eigen::Dynamic>::Map(B, n, k,
                                                                                   Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>(
-                                                                                          1, k));
+                                                                                          1, ldb));
         auto eigenC = Eigen::Matrix<int32_t, Eigen::Dynamic, Eigen::Dynamic>::Map(C, n, m,
                                                                                   Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>(
-                                                                                          1, m));
+                                                                                          1, ldc));
         eigenC.noalias() = eigenA * eigenB;
     }
     else if (transb) {
         auto eigenA = Eigen::Matrix<int32_t, Eigen::Dynamic, Eigen::Dynamic>::Map(A, m, k,
                                                                                   Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>(
-                                                                                          1, k));
+                                                                                          1, lda));
         auto eigenB = Eigen::Matrix<int32_t, Eigen::Dynamic, Eigen::Dynamic>::Map(B, n, k,
                                                                                   Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>(
-                                                                                          1, k)).transpose();
+                                                                                          1, ldb)).transpose();
         auto eigenC = Eigen::Matrix<int32_t, Eigen::Dynamic, Eigen::Dynamic>::Map(C, m, n,
                                                                                   Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>(
-                                                                                          1, n));
+                                                                                          1, ldc));
         eigenC.noalias() = eigenA * eigenB;
     }
     else {
         auto eigenA = Eigen::Matrix<int32_t, Eigen::Dynamic, Eigen::Dynamic>::Map(A, m, k,
-                                                                                  Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>(1, k));
+                                                                                  Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>(1, lda));
         auto eigenB = Eigen::Matrix<int32_t, Eigen::Dynamic, Eigen::Dynamic>::Map(B, k, n,
-                                                                                  Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>(1, n));
+                                                                                  Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>(1, ldb));
         auto eigenC = Eigen::Matrix<int32_t, Eigen::Dynamic, Eigen::Dynamic>::Map(C, m, n,
-                                                                                  Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>(1, n));
+                                                                                  Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>(1, ldc));
         eigenC.noalias() = eigenA * eigenB;
 
     }
@@ -200,49 +221,48 @@ template<>
     if(transa && transb) {
         auto eigenA = Eigen::Matrix<int64_t, Eigen::Dynamic, Eigen::Dynamic>::Map(A, k, m,
                                                                                   Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>(
-                                                                                          1, m)).transpose();
+                                                                                          1, lda)).transpose();
         auto eigenB = Eigen::Matrix<int64_t, Eigen::Dynamic, Eigen::Dynamic>::Map(B, n, k,
                                                                                   Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>(
-                                                                                          1, k)).transpose();
+                                                                                          1, ldb)).transpose();
         auto eigenC = Eigen::Matrix<int64_t, Eigen::Dynamic, Eigen::Dynamic>::Map(C, n, m,
                                                                                   Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>(
-                                                                                          1, m));
+                                                                                          1, ldc));
         eigenC.noalias() = eigenA * eigenB;
 
     }
     else if (transa) {
         auto eigenA = Eigen::Matrix<int64_t, Eigen::Dynamic, Eigen::Dynamic>::Map(A, k, m,
                                                                                   Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>(
-                                                                                          1, m)).transpose();
+                                                                                          1, lda)).transpose();
         auto eigenB = Eigen::Matrix<int64_t, Eigen::Dynamic, Eigen::Dynamic>::Map(B, n, k,
                                                                                   Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>(
-                                                                                          1, k));
+                                                                                          1, ldb));
         auto eigenC = Eigen::Matrix<int64_t, Eigen::Dynamic, Eigen::Dynamic>::Map(C, n, m,
                                                                                   Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>(
-                                                                                          1, m));
+                                                                                          1, ldc));
         eigenC.noalias() = eigenA * eigenB;
     }
     else if (transb) {
         auto eigenA = Eigen::Matrix<int64_t, Eigen::Dynamic, Eigen::Dynamic>::Map(A, m, k,
                                                                                   Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>(
-                                                                                          1, k));
+                                                                                          1, lda));
         auto eigenB = Eigen::Matrix<int64_t, Eigen::Dynamic, Eigen::Dynamic>::Map(B, n, k,
                                                                                   Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>(
-                                                                                          1, k)).transpose();
+                                                                                          1, ldb)).transpose();
         auto eigenC = Eigen::Matrix<int64_t, Eigen::Dynamic, Eigen::Dynamic>::Map(C, m, n,
                                                                                   Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>(
-                                                                                          1, n));
+                                                                                          1, ldc));
         eigenC.noalias() = eigenA * eigenB;
     }
     else {
         auto eigenA = Eigen::Matrix<int64_t, Eigen::Dynamic, Eigen::Dynamic>::Map(A, m, k,
-                                                                                  Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>(1, k));
+                                                                                  Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>(1, lda));
         auto eigenB = Eigen::Matrix<int64_t, Eigen::Dynamic, Eigen::Dynamic>::Map(B, k, n,
-                                                                                  Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>(1, n));
+                                                                                  Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>(1, ldb));
         auto eigenC = Eigen::Matrix<int64_t, Eigen::Dynamic, Eigen::Dynamic>::Map(C, m, n,
-                                                                                  Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>(1, n));
+                                                                                  Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>(1, ldc));
         eigenC.noalias() = eigenA * eigenB;
-
     }
 }
 
@@ -276,13 +296,14 @@ void MatMul<DenseMatrix<VT>, DenseMatrix<VT>, DenseMatrix<VT>>::apply(DenseMatri
 
     if(nr1 == 1 && nc2 == 1) {// Vector-Vector
         dctx->logger->debug("launch_dot<{}>(a[{}x{}], b[{}x{}])", typeid(alpha).name(), m, k, k, n);
-        res->set(0, 0, launch_dot(nc1, A, 1, B, rhs->isView() ? (transb ? 1 : rhs->getRowSkip()) : 1));
+        res->set(0, 0, launch_dot(nc1, A, transa ?  lda : 1,
+                            B, transb ? 1 : ldb));
     }
     else if(nc2 == 1) {      // Matrix-Vector
         dctx->logger->debug("launch_gemv<{}>(A[{},{}], x[{}])", typeid(alpha).name(), m, k, k);
-        launch_gemv<VT>(transa, transb, lhs->getNumRows(), lhs->getNumCols(), alpha, A, lda, B, 1, beta, C, 1);
-    }
-    else { // Matrix-Matrix
+        launch_gemv<VT>(transa, transb, lhs->getNumRows(), lhs->getNumCols(), alpha, A, lda, B, transb ? 1 : ldb, beta, C, ldc);
+  }
+  else { // Matrix-Matrix
         dctx->logger->debug("launch_gemm<{}>(C[{}x{}], A[{},{}], B[{}x{}], transA:{}, transB:{})",
                 typeid(alpha).name(), m, n, m, k, k, n, transa, transb);
         launch_gemm<VT>(transa, transb, nr1, nc2, nc1, alpha, A, lda, B, ldb, beta, C, ldc);

--- a/test/runtime/local/kernels/MatMulTest.cpp
+++ b/test/runtime/local/kernels/MatMulTest.cpp
@@ -16,11 +16,15 @@
 
 #include "run_tests.h"
 
+#include <cstdint>
 #include <runtime/local/context/DaphneContext.h>
 #include <runtime/local/datagen/GenGivenVals.h>
 #include <runtime/local/datastructures/DenseMatrix.h>
 #include <runtime/local/kernels/CheckEq.h>
 #include <runtime/local/kernels/MatMul.h>
+#include <runtime/local/kernels/SliceRow.h>
+#include <runtime/local/kernels/SliceCol.h>
+
 
 #include <tags.h>
 
@@ -43,7 +47,7 @@ TEMPLATE_PRODUCT_TEST_CASE("MatMul", TAG_KERNELS, (DATA_TYPES), (VALUE_TYPES)) {
     auto dctx = setupContextAndLogger();
 
     using DT = TestType;
-    
+
     auto m0 = genGivenVals<DT>(3, {
         0, 0, 0,
         0, 0, 0,
@@ -208,6 +212,11 @@ TEMPLATE_PRODUCT_TEST_CASE("MatMul Transposed", TAG_KERNELS, (DATA_TYPES), (VALU
         5,
         0
     });
+    auto v7 = genGivenVals<DT>(1, {
+        1, 2, 3
+    });
+    auto v8 = genGivenVals<DT>(1, {14});
+
 
     checkMatMul(m0, m0, m1,  dctx.get(), true, true);
     checkMatMul(m2, m3, m4,  dctx.get(), true, true);
@@ -215,8 +224,50 @@ TEMPLATE_PRODUCT_TEST_CASE("MatMul Transposed", TAG_KERNELS, (DATA_TYPES), (VALU
     checkMatMul(m3, v3, v4,  dctx.get(), true);
     checkMatMul(m2, v5, v6,  dctx.get(), true);
     checkMatMul(m3, m3, m5,  dctx.get(), false, true);
-
+    checkMatMul(v1, v7, v8,  dctx.get(), true, true);
 
     DataObjectFactory::destroy(m0, m1, m2, m3, m4, m5, v0, v1, v2, v3, v4, v5, v6);
+}
+
+TEMPLATE_PRODUCT_TEST_CASE("MatMul after slicing", TAG_KERNELS "[new]", (DenseMatrix), (float, double, int32_t, int64_t)){
+    using DT = TestType;
+    auto dctx = setupContextAndLogger();
+    auto argMatrix = genGivenVals<DT>(4, {
+        1, 2, 3, 4,
+        5, 6, 7, 8,
+        9, 10, 11, 12,
+        13, 14, 15, 16
+        });
+    DT*  resMatrix3x4=nullptr;
+    DT*  resMatrix3x3=nullptr;
+    DT*  resMatrix3x1=nullptr;
+    DT*  resMatrix1x3=nullptr;
+    sliceRow(resMatrix3x4, argMatrix, 0, 3, nullptr);
+    sliceCol(resMatrix3x3, resMatrix3x4, 0, 3, nullptr);
+    sliceCol(resMatrix3x1, resMatrix3x4, 0, 1, nullptr);
+    sliceRow(resMatrix1x3, resMatrix3x3, 0, 1, nullptr);
+
+    auto exp0 = genGivenVals<DT>(3, {
+        38,  44,  50,
+        98, 116, 134,
+        158, 188, 218,
+    });
+    auto exp1 = genGivenVals<DT>(3, {
+        38,  98, 158,
+    });
+    auto exp2 = genGivenVals<DT>(1, {
+        107
+    });
+    auto exp3 = genGivenVals<DT>(1, {
+        38
+    });
+
+
+    checkMatMul(resMatrix3x3, resMatrix3x3, exp0,  dctx.get(), false, false);
+    checkMatMul(resMatrix3x3, resMatrix3x1, exp1,  dctx.get(), false, false);
+    checkMatMul(resMatrix3x1, resMatrix3x1, exp2,  dctx.get(), true, false);
+    checkMatMul(resMatrix3x1, resMatrix1x3, exp3,  dctx.get(), true, true);
+    DataObjectFactory::destroy(argMatrix);
+    DataObjectFactory::destroy(resMatrix3x3);
 }
 


### PR DESCRIPTION
Fixes #700 
#700 mentions an error in the integer MatMul kernels. This PR gives the following correct result for the mentioned example:
```
DenseMatrix(3x3, int64_t)
1 0 0
0 2 0
0 0 3
DenseMatrix(3x3, int64_t)
1 0 0
0 4 0
0 0 9
DenseMatrix(3x3, int64_t)
1 0 0
0 4 0
0 0 9
DenseMatrix(3x1, int64_t)
1
2
3
```