### PR TITLE
#720 replace asserts in codebase with exceptions

### DIFF
--- a/src/compiler/inference/InferencePass.cpp
+++ b/src/compiler/inference/InferencePass.cpp
@@ -313,7 +313,7 @@ class InferencePass : public PassWrapper<InferencePass, OperationPass<func::Func
 
                 // Get the ConditionOp.
                 Operation * condOp = beforeBlock.getTerminator();
-                // TODO Make this an assertion?
+
                 if(!llvm::isa<scf::ConditionOp>(condOp))
                     throw ErrorHandler::compilerError(op, "InferencePass", "WhileOp terminator is not a ConditionOp");
 
@@ -334,7 +334,7 @@ class InferencePass : public PassWrapper<InferencePass, OperationPass<func::Func
 
                 // Get the YieldOp.
                 Operation * yieldOp = afterBlock.getTerminator();
-                // TODO Make this an assertion?
+
                 if(whileOp->getNumOperands() != yieldOp->getNumOperands())
                     throw ErrorHandler::compilerError(
                         op, "InferencePass",

--- a/src/compiler/lowering/MatMulOpLowering.cpp
+++ b/src/compiler/lowering/MatMulOpLowering.cpp
@@ -15,14 +15,15 @@
  */
 
 #include <algorithm>
-#include <cassert>
 #include <cmath>
 #include <cstdint>
 #include <memory>
+#include <string>
 #include <utility>
 #include <vector>
 
 #include "compiler/utils/LoweringUtils.h"
+#include <util/ErrorHandler.h>
 #include "hwloc.h"
 #include "ir/daphneir/Daphne.h"
 #include "ir/daphneir/Passes.h"
@@ -395,7 +396,7 @@ public:
         tile_sizes = getTileSizesFromCache(matrixElementType,
                                            loops[1].getStep(), lhsRows);
       }
-      tile_loops(loops, tile_sizes);
+      tile_loops(loc, loops, tile_sizes);
     } else if (options.invert_loops){
       permuteLoops(loops, {0, 2, 1});
     }
@@ -476,9 +477,10 @@ public:
   }
 
   // Tile the affine loop nest generated from MatMulOp with the specified tile
-  // sizes. Includes asserts to follow the movement and creation of the tile
+  // sizes. Includes validations to follow the movement and creation of the tile
   // loops.
-  void tile_loops(SmallVector<AffineForOp, 3> loops,
+  void tile_loops(mlir::Location loc,
+                  SmallVector<AffineForOp, 3> loops,
                   SmallVector<unsigned, 5> tile_sizes) const {
     unsigned NC = tile_sizes[4];
     unsigned MC = tile_sizes[3];
@@ -494,14 +496,22 @@ public:
     if (failed(tilePerfectlyNested(loopNest, {MC, NC, KC}, &tiledNest))) {
       spdlog::warn("Could not tile the loop nest in MatMulLowering");
     };
-    assert(tiledNest[0].getStep() == MC && "0 should have step size MC.");
-    assert(tiledNest[1].getStep() == NC * vec_size &&
-           "1 should have step size NC * vec_size.");
-    assert(tiledNest[2].getStep() == KC && "2 should have step size KC.");
-    assert(tiledNest[3].getStep() == 1 && "3 should have step size 1.");
-    assert(tiledNest[4].getStep() == 1 * vec_size &&
-           "4 should have step size vec_size.");
-    assert(tiledNest[5].getStep() == 1 && "5 should have step size 1.");
+
+    #define GEN_ERR_MSG(name, size, expected) \
+      std::string(name) + " should have step size " + std::string(expected) + " but is " + std::to_string(size)
+
+    if (tiledNest[0].getStep() != MC)
+      throw ErrorHandler::compilerError(loc, "MatMulOpLowering (tile_loops)", GEN_ERR_MSG("tiledNest 0", tiledNest[0].getStep(), "MC (" + std::to_string(MC) + ")"));
+    if (tiledNest[1].getStep() != NC * vec_size)
+      throw ErrorHandler::compilerError(loc, "MatMulOpLowering (tile_loops)", GEN_ERR_MSG("tiledNest 1", tiledNest[1].getStep(), "NC * vec_size (" + std::to_string(NC * vec_size) + ")"));
+    if (tiledNest[2].getStep() != KC)
+      throw ErrorHandler::compilerError(loc, "MatMulOpLowering (tile_loops)", GEN_ERR_MSG("tiledNest 2", tiledNest[2].getStep(), "KC (" + std::to_string(KC) + ")"));
+    if (tiledNest[3].getStep() != 1)
+      throw ErrorHandler::compilerError(loc, "MatMulOpLowering (tile_loops)", GEN_ERR_MSG("tiledNest 3", tiledNest[3].getStep(), "1"));
+    if (tiledNest[4].getStep() != vec_size)
+      throw ErrorHandler::compilerError(loc, "MatMulOpLowering (tile_loops)", GEN_ERR_MSG("tiledNest 4", tiledNest[4].getStep(), "vec_size (" + std::to_string(vec_size) + ")"));
+    if (tiledNest[5].getStep() != 1)
+      throw ErrorHandler::compilerError(loc, "MatMulOpLowering (tile_loops)", GEN_ERR_MSG("tiledNest 5", tiledNest[5].getStep(), "1"));
 
     // Further tile the i mod MC loop with MR
     if (failed(tilePerfectlyNested(tiledNest[3], {MR}))) {
@@ -509,30 +519,35 @@ public:
     };
 
     // Further tile the j mod NC loop with NR
-    assert(tiledNest[4].getStep() == 1 * vec_size &&
-           "4 should have step size vec_size.");
+    if (tiledNest[4].getStep() != vec_size)
+      throw ErrorHandler::compilerError(loc, "MatMulOpLowering (tile_loops)", GEN_ERR_MSG("tiledNest 4", tiledNest[4].getStep(), "vec_size (" + std::to_string(vec_size) + ")"));
     if (failed(tilePerfectlyNested(tiledNest[4], {NR}))) {
       spdlog::warn("Could not tile the second j loop in MatMulLowering");
     };
 
     llvm::SmallVector<AffineForOp> twiceTiledNest;
     getPerfectlyNestedLoops(twiceTiledNest, tiledNest[0]);
-    assert(twiceTiledNest[0].getStep() == MC &&
-           "tTN: 0 should have step size MC."); // i loops
-    assert(twiceTiledNest[3].getStep() == MR &&
-           "tTN: 3 should have step size MR.");
-    assert(twiceTiledNest[4].getStep() == 1 &&
-           "tTN: 4 should have step size 1.");
-    assert(twiceTiledNest[1].getStep() == NC * vec_size &&
-           "tTN: 1 should have step size NC * vec_size."); // j loops
-    assert(twiceTiledNest[5].getStep() == NR * vec_size &&
-           "tTN: 5 should have step size NR.");
-    assert(twiceTiledNest[6].getStep() == 1 * vec_size &&
-           "tTN: 6 should have step size vec_size.");
-    assert(twiceTiledNest[2].getStep() == KC &&
-           "tTN: 2 should have step size 1."); // k loops
-    assert(twiceTiledNest[7].getStep() == 1 &&
-           "tTN: 7 should have step size 1.");
+    // i loops
+    if (twiceTiledNest[0].getStep() != MC)
+      throw ErrorHandler::compilerError(loc, "MatMulOpLowering (tile_loops)", GEN_ERR_MSG("twiceTiledNest 0", twiceTiledNest[0].getStep(), "MC (" +  std::to_string(MC) + ")"));
+    if (twiceTiledNest[3].getStep() != MR)
+      throw ErrorHandler::compilerError(loc, "MatMulOpLowering (tile_loops)", GEN_ERR_MSG("twiceTiledNest 3", twiceTiledNest[3].getStep(), "MR (" +  std::to_string(MR) + ")"));
+    if (twiceTiledNest[4].getStep() != 1)
+      throw ErrorHandler::compilerError(loc, "MatMulOpLowering (tile_loops)", GEN_ERR_MSG("twiceTiledNest 4", twiceTiledNest[4].getStep(), "1"));
+
+    // j loops
+    if (twiceTiledNest[1].getStep() != NC * vec_size)
+      throw ErrorHandler::compilerError(loc, "MatMulOpLowering (tile_loops)", GEN_ERR_MSG("twiceTiledNest 1", twiceTiledNest[1].getStep(), "NC * vec_size (" +  std::to_string(NC * vec_size) + ")"));
+    if (twiceTiledNest[5].getStep() != NR * vec_size)
+      throw ErrorHandler::compilerError(loc, "MatMulOpLowering (tile_loops)", GEN_ERR_MSG("twiceTiledNest 5", twiceTiledNest[5].getStep(), "NR * vec_size (" +  std::to_string(NR * vec_size) + ")"));
+    if (twiceTiledNest[6].getStep() != vec_size)
+      throw ErrorHandler::compilerError(loc, "MatMulOpLowering (tile_loops)", GEN_ERR_MSG("twiceTiledNest 6", twiceTiledNest[6].getStep(), "vec_size (" +  std::to_string(vec_size) + ")"));
+
+    // k loops
+    if (twiceTiledNest[2].getStep() != KC)
+      throw ErrorHandler::compilerError(loc, "MatMulOpLowering (tile_loops)", GEN_ERR_MSG("twiceTiledNest 2", twiceTiledNest[2].getStep(), "KC (" + std::to_string(KC) + ")"));
+    if (twiceTiledNest[7].getStep() != 1)
+      throw ErrorHandler::compilerError(loc, "MatMulOpLowering (tile_loops)", GEN_ERR_MSG("twiceTiledNest 7", twiceTiledNest[7].getStep(), "1"));
 
     // permute loops to final order (i / MC, j / NC, k / KC, i / MR, i mod MR, j
     // / NR, j mod NR, k mod KC) ->
@@ -543,22 +558,30 @@ public:
     // Unroll and jam
     llvm::SmallVector<AffineForOp> blisTiledLoops;
     getPerfectlyNestedLoops(blisTiledLoops, twiceTiledNest[root_idx]);
-    assert(blisTiledLoops[2].getStep() == MC &&
-           "blisTiled: 2 should have step size MC."); // i loops
-    assert(blisTiledLoops[4].getStep() == MR &&
-           "blisTiled: 4 should have step size MR.");
-    assert(blisTiledLoops[7].getStep() == 1 &&
-           "blisTiled: 7 should have step size 1.");
-    assert(blisTiledLoops[0].getStep() == NC * vec_size &&
-           "blisTiled: 0 should have step size NC * vec_size."); // j loops
-    assert(blisTiledLoops[3].getStep() == NR * vec_size &&
-           "blisTiled: 3 should have step size NR * vec_size.");
-    assert(blisTiledLoops[6].getStep() == vec_size &&
-           "blisTiled: 6 should have step size vec_size.");
-    assert(blisTiledLoops[1].getStep() == KC &&
-           "blisTiled: 1 should have step size 1."); // k loops
-    assert(blisTiledLoops[5].getStep() == 1 &&
-           "blisTiled: 5 should have step size 1.");
+    // i loops
+    if (blisTiledLoops[2].getStep() != MC)
+      throw ErrorHandler::compilerError(loc, "MatMulOpLowering (tile_loops)", GEN_ERR_MSG("blisTiled 2", blisTiledLoops[2].getStep(), "MC (" + std::to_string(MC) + ")"));
+    if (blisTiledLoops[4].getStep() != MR)
+      throw ErrorHandler::compilerError(loc, "MatMulOpLowering (tile_loops)", GEN_ERR_MSG("blisTiled 4", blisTiledLoops[4].getStep(), "MR (" + std::to_string(MR) + ")"));
+    if (blisTiledLoops[7].getStep() != 1)
+      throw ErrorHandler::compilerError(loc, "MatMulOpLowering (tile_loops)", GEN_ERR_MSG("blisTiled 7", blisTiledLoops[7].getStep(), "1"));
+
+    // j loops
+    if (blisTiledLoops[0].getStep() != NC * vec_size)
+      throw ErrorHandler::compilerError(loc, "MatMulOpLowering (tile_loops)", GEN_ERR_MSG("blisTiled 0", blisTiledLoops[0].getStep(), "NC * vec_size (" + std::to_string(NC * vec_size) + ")"));
+    if (blisTiledLoops[3].getStep() != NR * vec_size)
+      throw ErrorHandler::compilerError(loc, "MatMulOpLowering (tile_loops)", GEN_ERR_MSG("blisTiled 3", blisTiledLoops[3].getStep(), "NR * vec_size (" + std::to_string(NR * vec_size) + ")"));
+    if (blisTiledLoops[6].getStep() != vec_size)
+      throw ErrorHandler::compilerError(loc, "MatMulOpLowering (tile_loops)", GEN_ERR_MSG("blisTiled 6", blisTiledLoops[6].getStep(), "vec_size (" + std::to_string(vec_size) + ")"));
+    
+    // k loops
+    if (blisTiledLoops[1].getStep() != KC)
+      throw ErrorHandler::compilerError(loc, "MatMulOpLowering (tile_loops)", GEN_ERR_MSG("blisTiled 1", blisTiledLoops[1].getStep(), "KC (" + std::to_string(KC) + ")"));
+    if (blisTiledLoops[5].getStep() != 1)
+      throw ErrorHandler::compilerError(loc, "MatMulOpLowering (tile_loops)", GEN_ERR_MSG("blisTiled 5", blisTiledLoops[5].getStep(), "1"));
+
+    #undef GEN_ERR_MSG
+
     // Unroll jam causes Segfault, if called in a way where the loop is not
     // cleanly divided.
     if (options.unroll_jam_factor > 0 &&

--- a/src/ir/daphneir/DaphneDialect.cpp
+++ b/src/ir/daphneir/DaphneDialect.cpp
@@ -58,6 +58,9 @@
 #include <llvm/ADT/APSInt.h>
 #include <llvm/ADT/DenseMap.h>
 
+#include <stdexcept>
+#include <string>
+
 struct DaphneInlinerInterface : public mlir::DialectInlinerInterface {
   using DialectInlinerInterface::DialectInlinerInterface;
 
@@ -79,7 +82,14 @@ struct DaphneInlinerInterface : public mlir::DialectInlinerInterface {
     auto returnOp = mlir::dyn_cast<mlir::daphne::ReturnOp>(op);
 
     // Replace the values directly with the return operands.
-    assert(returnOp.getNumOperands() == valuesToRepl.size());
+    if (returnOp.getNumOperands() != valuesToRepl.size()) {
+      throw ErrorHandler::compilerError(op, "DaphneInlinerInterface (handleTerminator)",
+                                      "number of operands " + std::to_string(returnOp.getNumOperands())
+                                      + " from " + op->getName().getStringRef().str()
+                                      + " do not match size " + std::to_string(valuesToRepl.size())
+                                      );
+    }
+
     for (const auto &it : llvm::enumerate(returnOp.getOperands()))
       valuesToRepl[it.index()].replaceAllUsesWith(it.value());
   }
@@ -396,7 +406,11 @@ namespace mlir::daphne {
 
 mlir::OpFoldResult mlir::daphne::ConstantOp::fold(FoldAdaptor adaptor)
 {
-    assert(adaptor.getOperands().empty() && "constant has no operands");
+    if (!adaptor.getOperands().empty())
+        throw ErrorHandler::compilerError(
+                this->getLoc(), "CanonicalizerPass (mlir::daphne::ConstantOp::fold)",
+                "constant has no operands but " + std::to_string(adaptor.getOperands().size()) + " were given");
+
     return getValue();
 }
 
@@ -555,9 +569,13 @@ mlir::LogicalResult mlir::daphne::VectorizedPipelineOp::canonicalize(mlir::daphn
 template<class AttrElementT,
     class ElementValueT = typename AttrElementT::ValueType,
     class CalculationT = std::function<ElementValueT(const ElementValueT &, const ElementValueT &)>>
-mlir::Attribute constFoldBinaryOp(mlir::Type resultType, llvm::ArrayRef<mlir::Attribute> operands,
+mlir::Attribute constFoldBinaryOp(mlir::Location loc, mlir::Type resultType, llvm::ArrayRef<mlir::Attribute> operands,
                                   const CalculationT &calculate) {
-    assert(operands.size() == 2 && "binary op takes two operands");
+    if (operands.size() != 2)
+        throw ErrorHandler::compilerError(loc,
+                    "CanonicalizerPass (constFoldBinaryOp)", 
+                    "binary op takes two operands but " + std::to_string(operands.size()) + " were given");
+
     if(!operands[0] || !operands[1])
         return {};
 
@@ -572,9 +590,13 @@ mlir::Attribute constFoldBinaryOp(mlir::Type resultType, llvm::ArrayRef<mlir::At
 template<class AttrElementT,
     class ElementValueT = typename AttrElementT::ValueType,
     class CalculationT = std::function<bool(const ElementValueT &, const ElementValueT &)>>
-mlir::Attribute constFoldBinaryCmpOp(llvm::ArrayRef<mlir::Attribute> operands,
+mlir::Attribute constFoldBinaryCmpOp(mlir::Location loc, llvm::ArrayRef<mlir::Attribute> operands,
                                      const CalculationT &calculate) {
-    assert(operands.size() == 2 && "binary op takes two operands");
+    if (operands.size() != 2)
+        throw ErrorHandler::compilerError(loc,
+                    "CanonicalizerPass (constFoldBinaryCmpOp)",
+                    "binary op takes two operands but " + std::to_string(operands.size()) + " were given");
+
     if(!operands[0] || !operands[1])
         return {};
 
@@ -655,9 +677,9 @@ mlir::OpFoldResult mlir::daphne::EwAddOp::fold(FoldAdaptor adaptor) {
     auto floatOp = [](const llvm::APFloat &a, const llvm::APFloat &b) { return a + b; };
     // TODO: we could check overflows
     auto intOp = [](const llvm::APInt &a, const llvm::APInt &b) { return a + b; };
-    if(auto res = constFoldBinaryOp<FloatAttr>(getType(), operands, floatOp))
+    if(auto res = constFoldBinaryOp<FloatAttr>(getLoc(), getType(), operands, floatOp))
         return res;
-    if(auto res = constFoldBinaryOp<IntegerAttr>(getType(), operands, intOp))
+    if(auto res = constFoldBinaryOp<IntegerAttr>(getLoc(), getType(), operands, intOp))
         return res;
     return {};
 }
@@ -666,9 +688,9 @@ mlir::OpFoldResult mlir::daphne::EwSubOp::fold(FoldAdaptor adaptor) {
     ArrayRef<Attribute> operands = adaptor.getOperands();
     auto floatOp = [](const llvm::APFloat &a, const llvm::APFloat &b) { return a - b; };
     auto intOp = [](const llvm::APInt &a, const llvm::APInt &b) { return a - b; };
-    if(auto res = constFoldBinaryOp<FloatAttr>(getType(), operands, floatOp))
+    if(auto res = constFoldBinaryOp<FloatAttr>(getLoc(), getType(), operands, floatOp))
         return res;
-    if(auto res = constFoldBinaryOp<IntegerAttr>(getType(), operands, intOp))
+    if(auto res = constFoldBinaryOp<IntegerAttr>(getLoc(), getType(), operands, intOp))
         return res;
     return {};
 }
@@ -677,9 +699,9 @@ mlir::OpFoldResult mlir::daphne::EwMulOp::fold(FoldAdaptor adaptor) {
     ArrayRef<Attribute> operands = adaptor.getOperands();
     auto floatOp = [](const llvm::APFloat &a, const llvm::APFloat &b) { return a * b; };
     auto intOp = [](const llvm::APInt &a, const llvm::APInt &b) { return a * b; };
-    if(auto res = constFoldBinaryOp<FloatAttr>(getType(), operands, floatOp))
+    if(auto res = constFoldBinaryOp<FloatAttr>(getLoc(), getType(), operands, floatOp))
         return res;
-    if(auto res = constFoldBinaryOp<IntegerAttr>(getType(), operands, intOp))
+    if(auto res = constFoldBinaryOp<IntegerAttr>(getLoc(), getType(), operands, intOp))
         return res;
     return {};
 }
@@ -704,14 +726,14 @@ mlir::OpFoldResult mlir::daphne::EwDivOp::fold(FoldAdaptor adaptor) {
         return a.udiv(b);
     };
 
-    if(auto res = constFoldBinaryOp<FloatAttr>(getType(), operands, floatOp))
+    if(auto res = constFoldBinaryOp<FloatAttr>(getLoc(), getType(), operands, floatOp))
         return res;
     if(getType().isSignedInteger()) {
-        if(auto res = constFoldBinaryOp<IntegerAttr>(getType(), operands, sintOp))
+        if(auto res = constFoldBinaryOp<IntegerAttr>(getLoc(), getType(), operands, sintOp))
             return res;
     }
     else if(getType().isUnsignedInteger()) {
-        if(auto res = constFoldBinaryOp<IntegerAttr>(getType(), operands, uintOp))
+        if(auto res = constFoldBinaryOp<IntegerAttr>(getLoc(), getType(), operands, uintOp))
             return res;
     }
     return {};
@@ -723,7 +745,7 @@ mlir::OpFoldResult mlir::daphne::EwPowOp::fold(FoldAdaptor adaptor) {
     auto floatOp = [](const llvm::APFloat &a, const llvm::APFloat &b) {
         return std::pow(a.convertToDouble(), b.convertToDouble());
     };
-    if(auto res = constFoldBinaryOp<FloatAttr>(getType(), operands, floatOp))
+    if(auto res = constFoldBinaryOp<FloatAttr>(getLoc(), getType(), operands, floatOp))
         return res;
     return {};
 }
@@ -747,11 +769,11 @@ mlir::OpFoldResult mlir::daphne::EwModOp::fold(FoldAdaptor adaptor) {
         return a.urem(b);
     };
     if(getType().isSignedInteger()) {
-        if(auto res = constFoldBinaryOp<IntegerAttr>(getType(), operands, sintOp))
+        if(auto res = constFoldBinaryOp<IntegerAttr>(getLoc(), getType(), operands, sintOp))
             return res;
     }
     else if(getType().isUnsignedInteger()) {
-        if(auto res = constFoldBinaryOp<IntegerAttr>(getType(), operands, uintOp))
+        if(auto res = constFoldBinaryOp<IntegerAttr>(getLoc(), getType(), operands, uintOp))
             return res;
     }
     return {};
@@ -764,7 +786,7 @@ mlir::OpFoldResult mlir::daphne::EwLogOp::fold(FoldAdaptor adaptor) {
         // Equivalent to log_b(a)
         return log(a.convertToDouble()) / log(b.convertToDouble());
     };
-    if (auto res = constFoldBinaryOp<FloatAttr>(getType(), operands, floatOp))
+    if (auto res = constFoldBinaryOp<FloatAttr>(getLoc(), getType(), operands, floatOp))
         return res;
     return {};
 }
@@ -784,14 +806,14 @@ mlir::OpFoldResult mlir::daphne::EwMinOp::fold(FoldAdaptor adaptor) {
         else
             return b;
     };
-    if(auto res = constFoldBinaryOp<FloatAttr>(getType(), operands, floatOp))
+    if(auto res = constFoldBinaryOp<FloatAttr>(getLoc(), getType(), operands, floatOp))
         return res;
     if(getType().isSignedInteger()) {
-        if(auto res = constFoldBinaryOp<IntegerAttr>(getType(), operands, sintOp))
+        if(auto res = constFoldBinaryOp<IntegerAttr>(getLoc(), getType(), operands, sintOp))
             return res;
     }
     else if(getType().isUnsignedInteger()) {
-        if(auto res = constFoldBinaryOp<IntegerAttr>(getType(), operands, uintOp))
+        if(auto res = constFoldBinaryOp<IntegerAttr>(getLoc(), getType(), operands, uintOp))
             return res;
     }
     return {};
@@ -812,14 +834,14 @@ mlir::OpFoldResult mlir::daphne::EwMaxOp::fold(FoldAdaptor adaptor) {
         else
             return b;
     };
-    if(auto res = constFoldBinaryOp<FloatAttr>(getType(), operands, floatOp))
+    if(auto res = constFoldBinaryOp<FloatAttr>(getLoc(), getType(), operands, floatOp))
         return res;
     if(getType().isSignedInteger()) {
-        if(auto res = constFoldBinaryOp<IntegerAttr>(getType(), operands, sintOp))
+        if(auto res = constFoldBinaryOp<IntegerAttr>(getLoc(), getType(), operands, sintOp))
             return res;
     }
     else if(getType().isUnsignedInteger()) {
-        if(auto res = constFoldBinaryOp<IntegerAttr>(getType(), operands, uintOp))
+        if(auto res = constFoldBinaryOp<IntegerAttr>(getLoc(), getType(), operands, uintOp))
             return res;
     }
     return {};
@@ -829,10 +851,10 @@ mlir::OpFoldResult mlir::daphne::EwAndOp::fold(FoldAdaptor adaptor) {
     ArrayRef<Attribute> operands = adaptor.getOperands();
     auto boolOp = [](const bool &a, const bool &b) { return a && b; };
     auto intOp = [](const llvm::APInt &a, const llvm::APInt &b) { return (a != 0) && (b != 0); };
-    if(auto res = constFoldBinaryCmpOp<BoolAttr>(operands, boolOp))
+    if(auto res = constFoldBinaryCmpOp<BoolAttr>(getLoc(), operands, boolOp))
         return res;
     // TODO: should output bool?
-    if(auto res = constFoldBinaryOp<IntegerAttr>(getType(), operands, intOp))
+    if(auto res = constFoldBinaryOp<IntegerAttr>(getLoc(), getType(), operands, intOp))
         return res;
     return {};
 }
@@ -845,10 +867,10 @@ mlir::OpFoldResult mlir::daphne::EwOrOp::fold(FoldAdaptor adaptor) {
     ArrayRef<Attribute> operands = adaptor.getOperands();
     auto boolOp = [](const bool &a, const bool &b) { return a || b; };
     auto intOp = [](const llvm::APInt &a, const llvm::APInt &b) { return (a != 0) || (b != 0); };
-    if(auto res = constFoldBinaryCmpOp<BoolAttr>(operands, boolOp))
+    if(auto res = constFoldBinaryCmpOp<BoolAttr>(getLoc(), operands, boolOp))
         return res;
     // TODO: should output bool
-    if(auto res = constFoldBinaryOp<IntegerAttr>(getType(), operands, intOp))
+    if(auto res = constFoldBinaryOp<IntegerAttr>(getLoc(), getType(), operands, intOp))
         return res;
     return {};
 }
@@ -857,17 +879,22 @@ mlir::OpFoldResult mlir::daphne::EwXorOp::fold(FoldAdaptor adaptor) {
     ArrayRef<Attribute> operands = adaptor.getOperands();
     auto boolOp = [](const bool &a, const bool &b) { return a ^ b; };
     auto intOp = [](const llvm::APInt &a, const llvm::APInt &b) { return (a != 0) ^ (b != 0); };
-    if(auto res = constFoldBinaryCmpOp<BoolAttr>(operands, boolOp))
+    if(auto res = constFoldBinaryCmpOp<BoolAttr>(getLoc(), operands, boolOp))
         return res;
     // TODO: should output bool
-    if(auto res = constFoldBinaryOp<IntegerAttr>(getType(), operands, intOp))
+    if(auto res = constFoldBinaryOp<IntegerAttr>(getLoc(), getType(), operands, intOp))
         return res;
     return {};
 }
 
 mlir::OpFoldResult mlir::daphne::EwConcatOp::fold(FoldAdaptor adaptor) {
     ArrayRef<Attribute> operands = adaptor.getOperands();
-    assert(operands.size() == 2 && "binary op takes two operands");
+
+    if (operands.size() != 2)
+        throw ErrorHandler::compilerError(
+                this->getLoc(), "CanonicalizerPass (mlir::daphne::EwConcatOp::fold)",
+                "binary op takes two operands but " + std::to_string(operands.size()) + " were given");
+
     if(!operands[0] || !operands[1])
         return {};
 
@@ -885,7 +912,12 @@ mlir::OpFoldResult mlir::daphne::EwConcatOp::fold(FoldAdaptor adaptor) {
 // a temporary workaround, so it should be removed altogether later.
 mlir::OpFoldResult mlir::daphne::ConcatOp::fold(FoldAdaptor adaptor) {
     ArrayRef<Attribute> operands = adaptor.getOperands();
-    assert(operands.size() == 2 && "binary op takes two operands");
+
+    if (operands.size() != 2)
+        throw ErrorHandler::compilerError(
+                this->getLoc(), "CanonicalizerPass (mlir::daphne::ConcatOp::fold)",
+                "binary op takes two operands but " + std::to_string(operands.size()) + " were given");
+
     if(!operands[0] || !operands[1])
         return {};
 
@@ -901,7 +933,12 @@ mlir::OpFoldResult mlir::daphne::ConcatOp::fold(FoldAdaptor adaptor) {
 
 mlir::OpFoldResult mlir::daphne::StringEqOp::fold(FoldAdaptor adaptor) {
     ArrayRef<Attribute> operands = adaptor.getOperands();
-    assert(operands.size() == 2 && "binary op takes two operands");
+
+    if (operands.size() != 2)
+        throw ErrorHandler::compilerError(
+                this->getLoc(), "CanonicalizerPass (mlir::daphne::StringEqOp::fold)",
+                "binary op takes two operands but " + std::to_string(operands.size()) + " were given");
+
     if (!operands[0] || !operands[1] || !llvm::isa<StringAttr>(operands[0]) ||
         !isa<StringAttr>(operands[1])) {
         return {};
@@ -918,9 +955,9 @@ mlir::OpFoldResult mlir::daphne::EwEqOp::fold(FoldAdaptor adaptor) {
     auto floatOp = [](const llvm::APFloat &a, const llvm::APFloat &b) { return a == b; };
     auto intOp = [](const llvm::APInt &a, const llvm::APInt &b) { return a == b; };
     // TODO: fix bool return
-    if(auto res = constFoldBinaryOp<FloatAttr>(getType(), operands, floatOp))
+    if(auto res = constFoldBinaryOp<FloatAttr>(getLoc(), getType(), operands, floatOp))
         return res;
-    if(auto res = constFoldBinaryOp<IntegerAttr>(getType(), operands, intOp))
+    if(auto res = constFoldBinaryOp<IntegerAttr>(getLoc(), getType(), operands, intOp))
         return res;
     return {};
 }
@@ -930,9 +967,9 @@ mlir::OpFoldResult mlir::daphne::EwNeqOp::fold(FoldAdaptor adaptor) {
     auto floatOp = [](const llvm::APFloat &a, const llvm::APFloat &b) { return a != b; };
     auto intOp = [](const llvm::APInt &a, const llvm::APInt &b) { return a != b; };
     // TODO: fix bool return
-    if(auto res = constFoldBinaryOp<FloatAttr>(getType(), operands, floatOp))
+    if(auto res = constFoldBinaryOp<FloatAttr>(getLoc(), getType(), operands, floatOp))
         return res;
-    if(auto res = constFoldBinaryOp<IntegerAttr>(getType(), operands, intOp))
+    if(auto res = constFoldBinaryOp<IntegerAttr>(getLoc(), getType(), operands, intOp))
         return res;
     return {};
 }
@@ -943,14 +980,14 @@ mlir::OpFoldResult mlir::daphne::EwLtOp::fold(FoldAdaptor adaptor) {
     auto sintOp = [](const llvm::APInt &a, const llvm::APInt &b) { return a.slt(b); };
     auto uintOp = [](const llvm::APInt &a, const llvm::APInt &b) { return a.ult(b); };
     // TODO: fix bool return
-    if(auto res = constFoldBinaryOp<FloatAttr>(getType(), operands, floatOp))
+    if(auto res = constFoldBinaryOp<FloatAttr>(getLoc(), getType(), operands, floatOp))
         return res;
     if(getType().isSignedInteger()) {
-        if(auto res = constFoldBinaryOp<IntegerAttr>(getType(), operands, sintOp))
+        if(auto res = constFoldBinaryOp<IntegerAttr>(getLoc(), getType(), operands, sintOp))
             return res;
     }
     else if(getType().isUnsignedInteger()) {
-        if(auto res = constFoldBinaryOp<IntegerAttr>(getType(), operands, uintOp))
+        if(auto res = constFoldBinaryOp<IntegerAttr>(getLoc(), getType(), operands, uintOp))
             return res;
     }
     return {};
@@ -962,14 +999,14 @@ mlir::OpFoldResult mlir::daphne::EwLeOp::fold(FoldAdaptor adaptor) {
     auto sintOp = [](const llvm::APInt &a, const llvm::APInt &b) { return a.sle(b); };
     auto uintOp = [](const llvm::APInt &a, const llvm::APInt &b) { return a.ule(b); };
     // TODO: fix bool return
-    if(auto res = constFoldBinaryOp<FloatAttr>(getType(), operands, floatOp))
+    if(auto res = constFoldBinaryOp<FloatAttr>(getLoc(), getType(), operands, floatOp))
         return res;
     if(getType().isSignedInteger()) {
-        if(auto res = constFoldBinaryOp<IntegerAttr>(getType(), operands, sintOp))
+        if(auto res = constFoldBinaryOp<IntegerAttr>(getLoc(), getType(), operands, sintOp))
             return res;
     }
     else if(getType().isUnsignedInteger()) {
-        if(auto res = constFoldBinaryOp<IntegerAttr>(getType(), operands, uintOp))
+        if(auto res = constFoldBinaryOp<IntegerAttr>(getLoc(), getType(), operands, uintOp))
             return res;
     }
     return {};
@@ -981,14 +1018,14 @@ mlir::OpFoldResult mlir::daphne::EwGtOp::fold(FoldAdaptor adaptor) {
     auto sintOp = [](const llvm::APInt &a, const llvm::APInt &b) { return a.sgt(b); };
     auto uintOp = [](const llvm::APInt &a, const llvm::APInt &b) { return a.ugt(b); };
     // TODO: fix bool return
-    if(auto res = constFoldBinaryOp<FloatAttr>(getType(), operands, floatOp))
+    if(auto res = constFoldBinaryOp<FloatAttr>(getLoc(), getType(), operands, floatOp))
         return res;
     if(getType().isSignedInteger()) {
-        if(auto res = constFoldBinaryOp<IntegerAttr>(getType(), operands, sintOp))
+        if(auto res = constFoldBinaryOp<IntegerAttr>(getLoc(), getType(), operands, sintOp))
             return res;
     }
     else if(getType().isUnsignedInteger()) {
-        if(auto res = constFoldBinaryOp<IntegerAttr>(getType(), operands, uintOp))
+        if(auto res = constFoldBinaryOp<IntegerAttr>(getLoc(), getType(), operands, uintOp))
             return res;
     }
     return {};
@@ -1000,14 +1037,14 @@ mlir::OpFoldResult mlir::daphne::EwGeOp::fold(FoldAdaptor adaptor) {
     auto sintOp = [](const llvm::APInt &a, const llvm::APInt &b) { return a.sge(b); };
     auto uintOp = [](const llvm::APInt &a, const llvm::APInt &b) { return a.uge(b); };
     // TODO: fix bool return
-    if(auto res = constFoldBinaryOp<FloatAttr>(getType(), operands, floatOp))
+    if(auto res = constFoldBinaryOp<FloatAttr>(getLoc(), getType(), operands, floatOp))
         return res;
     if(getType().isSignedInteger()) {
-        if(auto res = constFoldBinaryOp<IntegerAttr>(getType(), operands, sintOp))
+        if(auto res = constFoldBinaryOp<IntegerAttr>(getLoc(), getType(), operands, sintOp))
             return res;
     }
     else if(getType().isUnsignedInteger()) {
-        if(auto res = constFoldBinaryOp<IntegerAttr>(getType(), operands, uintOp))
+        if(auto res = constFoldBinaryOp<IntegerAttr>(getLoc(), getType(), operands, uintOp))
             return res;
     }
     return {};

--- a/src/ir/daphneir/DaphneInferTypesOpInterface.cpp
+++ b/src/ir/daphneir/DaphneInferTypesOpInterface.cpp
@@ -202,8 +202,10 @@ std::vector<Type> daphne::RandMatrixOp::inferTypes() {
         elTy = getMax().getType();
     }
     else {
-        assert((getMax().getType() == UnknownType::get(getContext()) || elTy == getMax().getType())
-            && "Min and max need to have the same type");
+        if (getMax().getType() != UnknownType::get(getContext()) && elTy != getMax().getType())
+            throw ErrorHandler::compilerError(
+                getLoc(), "InferTypesOpInterface (daphne::RandMatrixOp::inferTypes)",
+                "min and max need to have the same type");
     }
     return {daphne::MatrixType::get(getContext(), elTy)};
 }

--- a/src/parser/daphnedsl/DaphneDSLVisitor.cpp
+++ b/src/parser/daphnedsl/DaphneDSLVisitor.cpp
@@ -943,8 +943,14 @@ antlrcpp::Any DaphneDSLVisitor::handleMapOpCall(DaphneDSLGrammarParser::CallExpr
     const auto& identifierVec = ctx->IDENTIFIER();
     for(size_t s = 0; s < identifierVec.size(); s++)
         func += (s < identifierVec.size() - 1) ? identifierVec[s]->getText() + '.' : identifierVec[s]->getText();
-    assert(func == "map" && "Called 'handleMapOpCall' for another function");
+
     mlir::Location loc = utils.getLoc(ctx->start);
+    
+    if (func != "map")
+        throw ErrorHandler::compilerError(loc, "DSLVisitor",
+                "called 'handleMapOpCall' for function "
+                 + func + " instead of 'map'"
+        );
     
     if (ctx->expr().size() != 2) {
         throw ErrorHandler::compilerError(loc, "DSLVisitor",

--- a/src/runtime/distributed/coordinator/kernels/Broadcast.h
+++ b/src/runtime/distributed/coordinator/kernels/Broadcast.h
@@ -34,7 +34,6 @@
 #include <runtime/distributed/worker/MPIWorker.h>
 #endif
 
-#include <cassert>
 #include <cstddef>
 
 // ****************************************************************************

--- a/src/runtime/distributed/coordinator/kernels/Distribute.h
+++ b/src/runtime/distributed/coordinator/kernels/Distribute.h
@@ -29,8 +29,8 @@
     #include <runtime/distributed/worker/MPIHelper.h>
 #endif 
 
-#include <cassert>
 #include <cstddef>
+#include <stdexcept>
 
 // ****************************************************************************
 // Struct for partial template specialization
@@ -124,7 +124,8 @@ struct Distribute<ALLOCATION_TYPE::DIST_GRPC_ASYNC, DT>
         }; 
         DistributedGRPCCaller<StoredInfo, distributed::Data, distributed::StoredData> caller(dctx);
             
-        assert(mat != nullptr);
+        if (mat == nullptr)
+            throw std::runtime_error("Distribute gRPC: mat must not be a nullptr");
         
         LoadPartitioningDistributed<DT, AllocationDescriptorGRPC> partioner(DistributionSchema::DISTRIBUTE, mat, dctx);
         
@@ -193,7 +194,8 @@ struct Distribute<ALLOCATION_TYPE::DIST_GRPC_SYNC, DT>
         auto ctx = DistributedContext::get(dctx);
         auto workers = ctx->getWorkers();
         
-        assert(mat != nullptr);
+        if (mat == nullptr)
+            throw std::runtime_error("Distribute gRPC: mat must not be a nullptr");
         
         std::vector<std::thread> threads_vector;
         LoadPartitioningDistributed<DT, AllocationDescriptorGRPC> partioner(DistributionSchema::DISTRIBUTE, mat, dctx);

--- a/src/runtime/distributed/coordinator/kernels/DistributedCollect.h
+++ b/src/runtime/distributed/coordinator/kernels/DistributedCollect.h
@@ -31,8 +31,8 @@
     #include <runtime/distributed/worker/MPIHelper.h>
 #endif
 
-#include <cassert>
 #include <cstddef>
+#include <stdexcept>
 
 
 // ****************************************************************************
@@ -70,7 +70,8 @@ struct DistributedCollect<ALLOCATION_TYPE::DIST_MPI, DT>
 {
     static void apply(DT *&mat, const VectorCombine& combine, DCTX(dctx)) 
     {
-        assert (mat != nullptr && "result matrix must be already allocated by wrapper since only there exists information regarding size");        
+        if (mat == nullptr)
+            throw std::runtime_error("DistributedCollect gRPC: result matrix must be already allocated by wrapper since information regarding size only exists there");        
         size_t worldSize = MPIHelper::getCommSize();
         for(size_t rank=0; rank<worldSize ; rank++) 
         {
@@ -138,7 +139,8 @@ struct DistributedCollect<ALLOCATION_TYPE::DIST_GRPC_ASYNC, DT>
 {
     static void apply(DT *&mat, const VectorCombine& combine, DCTX(dctx)) 
     {
-        assert (mat != nullptr && "result matrix must be already allocated by wrapper since only there exists information regarding size");        
+        if (mat == nullptr)
+            throw std::runtime_error("DistributedCollect gRPC: result matrix must be already allocated by wrapper since information regarding size only exists there");        
 
         struct StoredInfo{
             size_t dp_id;
@@ -207,7 +209,8 @@ struct DistributedCollect<ALLOCATION_TYPE::DIST_GRPC_SYNC, DT>
 {
     static void apply(DT *&mat, const VectorCombine& combine, DCTX(dctx)) 
     {
-        assert (mat != nullptr && "result matrix must be already allocated by wrapper since only there exists information regarding size");        
+        if (mat == nullptr)
+            throw std::runtime_error("DistributedCollect gRPC: result matrix must be already allocated by wrapper since information regarding size only exists there");        
 
         auto ctx = DistributedContext::get(dctx);
         std::vector<std::thread> threads_vector;

--- a/src/runtime/distributed/coordinator/kernels/DistributedCompute.h
+++ b/src/runtime/distributed/coordinator/kernels/DistributedCompute.h
@@ -29,7 +29,6 @@
     #include <runtime/distributed/worker/MPIHelper.h>
 #endif
 
-#include <cassert>
 #include <cstddef>
 
 using mlir::daphne::VectorCombine;

--- a/src/runtime/distributed/coordinator/kernels/DistributedRead.h
+++ b/src/runtime/distributed/coordinator/kernels/DistributedRead.h
@@ -22,7 +22,6 @@
 #include <runtime/local/io/ReadCsv.h>
 #include <runtime/local/io/File.h>
 #include <parser/metadata/MetaDataParser.h>
-#include <cassert>
 #include <cstddef>
 
 

--- a/src/runtime/distributed/coordinator/kernels/DistributedWrapper.h
+++ b/src/runtime/distributed/coordinator/kernels/DistributedWrapper.h
@@ -35,6 +35,7 @@
 #include <llvm/Support/SourceMgr.h>
 #include <mlir/IR/BuiltinTypes.h>
 #include <vector>
+#include <stdexcept>
 
 using mlir::daphne::VectorSplit;
 using mlir::daphne::VectorCombine;
@@ -146,7 +147,8 @@ public:
                 }
             }
             else {
-                assert(splits[i] == VectorSplit::ROWS && "only row split supported for now");
+                if (splits[i] != VectorSplit::ROWS)
+                    throw std::runtime_error("DistributedWrapper: only row split is currently supported");
                 // std::cout << i << " distr: " << inputs[i]->getNumRows() << " x " << inputs[i]->getNumCols() << std::endl;
                 if(allocation_type==ALLOCATION_TYPE::DIST_MPI){
 #ifdef USE_MPI 

--- a/src/runtime/distributed/coordinator/scheduling/LoadPartitioningDistributed.h
+++ b/src/runtime/distributed/coordinator/scheduling/LoadPartitioningDistributed.h
@@ -22,8 +22,8 @@
 #include <runtime/local/datastructures/Range.h>
 
 #include <vector>
+#include <stdexcept>
 #include <string>
-#include <cassert>
 #include <cstddef>
 #include <type_traits>
 
@@ -182,7 +182,7 @@ public:
                     m = (*outputs[i])->getNumCols() % workersSize;
                 }
                 else
-                    assert(!"Only Rows/Cols combineType supported atm");
+                    throw std::runtime_error("LoadPartitioningDistributed: Only Rows/Cols combineType supported atm");
 
                 DistributedData data;
                 data.ix = ix[i];

--- a/src/runtime/local/context/CUDAContext.h
+++ b/src/runtime/local/context/CUDAContext.h
@@ -19,7 +19,6 @@
 #include "runtime/local/context/DaphneContext.h"
 #include "runtime/local/kernels/CUDA/HostUtils.h"
 
-#include <cassert>
 #include <iostream>
 #include <memory>
 #include <map>

--- a/src/runtime/local/context/FPGAContext.h
+++ b/src/runtime/local/context/FPGAContext.h
@@ -20,7 +20,6 @@
 #include "IContext.h"
 #include <AOCLUtils/aocl_utils.h>
 #include <CL/opencl.h>
-#include <cassert>
 #include <iostream>
 #include <memory>
 

--- a/src/runtime/local/datagen/GenGivenVals.h
+++ b/src/runtime/local/datagen/GenGivenVals.h
@@ -22,9 +22,9 @@
 #include <runtime/local/datastructures/DenseMatrix.h>
 
 #include <algorithm>
+#include <stdexcept>
 #include <vector>
 
-#include <cassert>
 #include <cstddef>
 #include <cstring>
 
@@ -108,7 +108,8 @@ template<>
 struct GenGivenVals<DenseMatrix<const char*>> {
     static DenseMatrix<const char*> * generate(size_t numRows, const std::vector<const char*> & elements, size_t minNumNonZeros = 0) {
         const size_t numCells = elements.size();
-        assert((numCells % numRows == 0) && "number of given data elements must be divisible by given number of rows");
+        if (numCells % numRows != 0)
+            throw std::runtime_error("genGivenVals: number of given data elements must be divisible by given number of rows");
         const size_t numCols = numCells / numRows;
         auto res = DataObjectFactory::create<DenseMatrix<const char*>>(numRows, numCols, false);
         res->prepareAppend();
@@ -128,7 +129,8 @@ template<typename VT>
 struct GenGivenVals<CSRMatrix<VT>> {
     static CSRMatrix<VT> * generate(size_t numRows, const std::vector<VT> & elements, size_t minNumNonZeros = 0) {
         const size_t numCells = elements.size();
-        assert((numCells % numRows == 0) && "number of given data elements must be divisible by given number of rows");
+        if (numCells % numRows != 0)
+            throw std::runtime_error("genGivenVals: number of given data elements must be divisible by given number of rows");
         const size_t numCols = numCells / numRows;
         size_t numNonZeros = 0;
         for(VT v : elements)

--- a/src/runtime/local/datastructures/CSRMatrix.h
+++ b/src/runtime/local/datastructures/CSRMatrix.h
@@ -23,8 +23,8 @@
 #include <algorithm>
 #include <iostream>
 #include <memory>
+#include <stdexcept>
 
-#include <cassert>
 #include <cstddef>
 #include <cstring>
 
@@ -122,10 +122,14 @@ class CSRMatrix : public Matrix<ValueType> {
             isRowAllocatedBefore(rowLowerIncl > 0),
             lastAppendedRowIdx(0)
     {
-        assert(src && "src must not be null");
-        assert((rowLowerIncl < src->numRows) && "rowLowerIncl is out of bounds");
-        assert((rowUpperExcl <= src->numRows) && "rowUpperExcl is out of bounds");
-        assert((rowLowerIncl < rowUpperExcl) && "rowLowerIncl must be lower than rowUpperExcl");
+        if (!src)
+            throw std::runtime_error("CSRMatrix: src must not be null");
+        if (rowLowerIncl >= src->numRows)
+            throw std::runtime_error("CSRMatrix: rowLowerIncl is out of bounds");
+        if (rowUpperExcl > src->numRows)
+            throw std::runtime_error("CSRMatrix: rowUpperExcl is out of bounds");
+        if (rowLowerIncl >= rowUpperExcl)
+            throw std::runtime_error("CSRMatrix: rowLowerIncl must be lower than rowUpperExcl");
         
         maxNumNonZeros = src->maxNumNonZeros;
         values = src->values;
@@ -151,7 +155,8 @@ public:
     using WithValueType = CSRMatrix<NewValueType>;
     
     void shrinkNumRows(size_t numRows) {
-        assert((numRows <= this->numRows) && "numRows can only the shrinked");
+        if (numRows > this->numRows)
+            throw std::runtime_error("CSRMatrix (shrinkNumRows): numRows can only be shrunk");
         // TODO Here we could reduce the allocated size of the rowOffsets array.
         this->numRows = numRows;
     }
@@ -164,12 +169,14 @@ public:
     }
     
     size_t getNumNonZeros(size_t rowIdx) const {
-        assert((rowIdx < numRows) && "rowIdx is out of bounds");
+        if (rowIdx >= numRows)
+            throw std::runtime_error("CSRMatrix (getNumNonZeros): rowIdx is out of bounds");
         return rowOffsets.get()[rowIdx + 1] - rowOffsets.get()[rowIdx];
     }
     
     void shrinkNumNonZeros(size_t numNonZeros) {
-        assert((numNonZeros <= getNumNonZeros()) && "numNonZeros can only be shrinked");
+        if (numNonZeros > getNumNonZeros())
+            throw std::runtime_error("CSRMatrix (shrinkNumNonZeros): numNonZeros can only be shrunk");
         // TODO Here we could reduce the allocated size of the values and
         // colIdxs arrays.
     }
@@ -184,7 +191,8 @@ public:
     
     ValueType * getValues(size_t rowIdx) {
         // We allow equality here to enable retrieving a pointer to the end.
-        assert((rowIdx <= numRows) && "rowIdx is out of bounds");
+        if (rowIdx > numRows)
+            throw std::runtime_error("CSRMatrix (getValues): rowIdx is out of bounds");
         return values.get() + rowOffsets.get()[rowIdx];
     }
     
@@ -202,7 +210,8 @@ public:
     
     size_t * getColIdxs(size_t rowIdx) {
         // We allow equality here to enable retrieving a pointer to the end.
-        assert((rowIdx <= numRows) && "rowIdx is out of bounds");
+        if (rowIdx > numRows)
+            throw std::runtime_error("CSRMatrix (getColIdxs): rowIdx is out of bounds");
         return colIdxs.get() + rowOffsets.get()[rowIdx];
     }
 
@@ -219,8 +228,10 @@ public:
     }
 
     ValueType get(size_t rowIdx, size_t colIdx) const override {
-        assert((rowIdx < numRows) && "rowIdx is out of bounds");
-        assert((colIdx < numCols) && "colIdx is out of bounds");
+        if (rowIdx >= numRows)
+            throw std::runtime_error("CSRMatrix (get): rowIdx is out of bounds");
+        if (colIdx >= numCols)
+            throw std::runtime_error("CSRMatrix (get): colIdx is out of bounds");
         
         const size_t * rowColIdxsBeg = getColIdxs(rowIdx);
         const size_t * rowColIdxsEnd = getColIdxs(rowIdx + 1);
@@ -235,8 +246,10 @@ public:
     }
     
     void set(size_t rowIdx, size_t colIdx, ValueType value) override {
-        assert((rowIdx < numRows) && "rowIdx is out of bounds");
-        assert((colIdx < numCols) && "colIdx is out of bounds");
+        if (rowIdx >= numRows)
+            throw std::runtime_error("CSRMatrix (set): rowIdx is out of bounds");
+        if (colIdx >= numCols)
+            throw std::runtime_error("CSRMatrix (set): colIdx is out of bounds");
         
         size_t * rowColIdxsBeg = getColIdxs(rowIdx);
         size_t * rowColIdxsEnd = getColIdxs(rowIdx + 1);
@@ -300,8 +313,10 @@ public:
     // `prepareAppend`/`append`/`finishAppend` assume that the larger matrix
     // has been populated up to just before the row range of this view.
     void append(size_t rowIdx, size_t colIdx, ValueType value) override {
-        assert((rowIdx < numRows) && "rowIdx is out of bounds");
-        assert((colIdx < numCols) && "colIdx is out of bounds");
+        if (rowIdx >= numRows)
+            throw std::runtime_error("CSRMatrix (append): rowIdx is out of bounds");
+        if (colIdx >= numCols)
+            throw std::runtime_error("CSRMatrix (append): colIdx is out of bounds");
         
         if(value == ValueType(0))
             return;

--- a/src/runtime/local/datastructures/DenseMatrix.h
+++ b/src/runtime/local/datastructures/DenseMatrix.h
@@ -22,8 +22,8 @@
 
 #include <iostream>
 #include <memory>
+#include <stdexcept>
 
-#include <cassert>
 #include <cstddef>
 #include <cstring>
 
@@ -178,7 +178,8 @@ public:
     [[nodiscard]] bool isPartialBuffer() const { return bufferSize != this->getNumRows() * this->getRowSkip() * sizeof(ValueType); }
 
     void shrinkNumRows(size_t numRows) {
-        assert((numRows <= this->numRows) && "number of rows can only the shrunk");
+        if (numRows > this->numRows)
+            throw std::runtime_error("DenseMatrix (shrinkNumRows): number of rows can only be shrunk");
         // TODO Here we could reduce the allocated size of the values array.
         this->numRows = numRows;
     }
@@ -484,7 +485,8 @@ class DenseMatrix<const char*> : public Matrix<const char*>
 public:
 
     void shrinkNumRows(size_t numRows) {
-        assert((numRows <= this->numRows) && "number of rows can only the shrunk");
+        if (numRows > this->numRows)
+            throw std::runtime_error("DenseMatrix (shrinkNumRows): number of rows can only be shrunk");
         // TODO Here we could reduce the allocated size of the values array.
         this->numRows = numRows;
     }
@@ -622,7 +624,8 @@ public:
     float printBufferSize() const { return static_cast<float>(numRows*numCols) / (1048576); }
 
     bool operator==(const DenseMatrix<const char*> &M) const {
-        assert(getNumRows() != 0 && getNumCols() != 0 && strBuf && values && "Invalid matrix");
+        if (getNumRows() == 0 || getNumCols() == 0 || !strBuf || !values)
+            throw std::runtime_error("DenseMatrix (operator==): invalid matrix. DenseMatrix must not be empty");
         for(size_t r = 0; r < getNumRows(); r++)
             for(size_t c = 0; c < getNumCols(); c++)
                 if(strcmp(M.getValues()[M.pos(r,c)], values.get()[pos(r,c)]))

--- a/src/runtime/local/io/DaphneSerializer.h
+++ b/src/runtime/local/io/DaphneSerializer.h
@@ -24,7 +24,6 @@
 #include <runtime/local/datastructures/CSRMatrix.h>
 #include <runtime/local/datastructures/Frame.h>
 
-#include <cassert>
 #include <cstdint>
 #include <stdlib.h>
 #include <stdexcept>
@@ -263,8 +262,10 @@ struct DaphneSerializer<DenseMatrix<VT>, false> {
      */
     static DenseMatrix<VT> *deserializeHeader(const char *buf, DenseMatrix<VT> *matrix = nullptr) {
         size_t bufIdx = 0;
-        assert((DF_Dtype(buf) == DF_data_t::DenseMatrix_t) && "DenseMatrix deserialize(): DT mismatch");
-        assert((DF_Vtype(buf) == ValueTypeUtils::codeFor<VT>) && "DenseMatrix deserialize(): VT mismatch");
+        if (DF_Dtype(buf) != DF_data_t::DenseMatrix_t)
+            throw std::runtime_error("DenseMatrix deserialize(): DT mismatch");
+        if (DF_Vtype(buf) != ValueTypeUtils::codeFor<VT>)
+            throw std::runtime_error("DenseMatrix deserialize(): VT mismatch");
         // FF to the body
         bufIdx += sizeof(DF_header);
         bufIdx += sizeof(ValueTypeCode);
@@ -642,8 +643,10 @@ struct DaphneSerializer<CSRMatrix<VT>, false> {
      * @return CSRMatrix<VT>* The result matrix.
      */
     static CSRMatrix<VT> *deserializeHeader(const char *buffer, CSRMatrix<VT> *matrix = nullptr) {
-        assert((DF_Dtype(buffer) == DF_data_t::CSRMatrix_t) && "CSRMatrix deserialize(): DT mismatch");
-        assert((DF_Vtype(buffer) == ValueTypeUtils::codeFor<VT>) && "CSRMatrix deserialize(): VT mismatch");
+        if (DF_Dtype(buffer) != DF_data_t::CSRMatrix_t)
+            throw std::runtime_error("CSRMatrix deserialize(): DT mismatch");
+        if (DF_Vtype(buffer) != ValueTypeUtils::codeFor<VT>)
+            throw std::runtime_error("CSRMatrix deserialize(): VT mismatch");
 
         size_t bufferIdx = 0;
         // FF to the body

--- a/src/runtime/local/io/ReadCsv.h
+++ b/src/runtime/local/io/ReadCsv.h
@@ -29,7 +29,6 @@
 
 #include <type_traits>
 
-#include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <queue>

--- a/src/runtime/local/io/ReadCsvFile.h
+++ b/src/runtime/local/io/ReadCsvFile.h
@@ -28,13 +28,13 @@
 
 #include <type_traits>
 
-#include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <queue>
 #include <fstream>
 #include <limits>
 #include <sstream>
+#include <stdexcept>
 
 // ****************************************************************************
 // Struct for partial template specialization
@@ -84,9 +84,12 @@ void readCsvFile(DTRes *&res, File *file, size_t numRows, size_t numCols,
 template <typename VT> struct ReadCsvFile<DenseMatrix<VT>> {
   static void apply(DenseMatrix<VT> *&res, struct File *file, size_t numRows,
                     size_t numCols, char delim) {
-    assert(file != nullptr && "File required");
-    assert(numRows > 0 && "numRows must be > 0");
-    assert(numCols > 0 && "numCols must be > 0");
+    if (file == nullptr)
+      throw std::runtime_error("ReadCsvFile: requires a file to be specified (must not be nullptr)");
+    if (numRows <= 0)
+      throw std::runtime_error("ReadCsvFile: numRows must be > 0");
+    if (numCols <= 0)
+      throw std::runtime_error("ReadCsvFile: numCols must be > 0");
 
     if (res == nullptr) {
       res = DataObjectFactory::create<DenseMatrix<VT>>(numRows, numCols, false);
@@ -131,8 +134,8 @@ template <typename VT> struct ReadCsvFile<DenseMatrix<VT>> {
 template <typename VT> struct ReadCsvFile<CSRMatrix<VT>> {
     static void apply(CSRMatrix<VT> *&res, struct File *file, size_t numRows,
                       size_t numCols, char delim, ssize_t numNonZeros, bool sorted = true) {
-        assert(numNonZeros != -1
-            && "Currently reading of sparse matrices requires a number of non zeros to be defined");
+        if (numNonZeros == -1)
+          throw std::runtime_error("ReadCsvFile: Currently, reading of sparse matrices requires a number of non zeros to be defined");
 
         if(res == nullptr)
             res = DataObjectFactory::create<CSRMatrix<VT>>(
@@ -239,8 +242,10 @@ private:
 template <> struct ReadCsvFile<Frame> {
   static void apply(Frame *&res, struct File *file, size_t numRows,
                     size_t numCols, char delim, ValueTypeCode *schema) {
-    assert(numRows > 0 && "numRows must be > 0");
-    assert(numCols > 0 && "numCols must be > 0");
+    if (numRows <= 0)
+      throw std::runtime_error("ReadCsvFile: numRows must be > 0");
+    if (numCols <= 0)
+      throw std::runtime_error("ReadCsvFile: numCols must be > 0");
 
     if (res == nullptr) {
       res = DataObjectFactory::create<Frame>(numRows, numCols, schema, nullptr, false);

--- a/src/runtime/local/io/ReadDaphne.h
+++ b/src/runtime/local/io/ReadDaphne.h
@@ -29,7 +29,6 @@
 #include <util/preprocessor_defs.h>
 
 #include <type_traits>
-#include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <fstream>

--- a/src/runtime/local/io/ReadParquet.h
+++ b/src/runtime/local/io/ReadParquet.h
@@ -27,7 +27,6 @@
 
 #include <type_traits>
 
-#include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <queue>

--- a/src/runtime/local/io/WriteCsv.h
+++ b/src/runtime/local/io/WriteCsv.h
@@ -27,12 +27,12 @@
 #include <stdexcept>
 #include <type_traits>
 
-#include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <fstream>
 #include <limits>
 #include <sstream>
+#include <stdexcept>
 
 // ****************************************************************************
 // Struct for partial template specialization
@@ -63,7 +63,8 @@ void writeCsv(const DTArg *arg, File *file) {
 template <typename VT>
 struct WriteCsv<DenseMatrix<VT>> {
     static void apply(const DenseMatrix<VT> *arg, File* file) {
-        assert(file != nullptr && "File required");
+        if (file == nullptr)
+            throw std::runtime_error("WriteCsv: requires a file to be specified (must not be nullptr)");
         const VT * valuesArg = arg->getValues();
         const size_t rowSkip = arg->getRowSkip();
         const size_t argNumCols = arg->getNumCols();
@@ -93,7 +94,8 @@ struct WriteCsv<DenseMatrix<VT>> {
 template <> struct WriteCsv<Frame> {
     static void apply(const Frame * arg, File * file) {
 
-    assert(file != nullptr && "File required");
+    if (file == nullptr)
+        throw std::runtime_error("WriteCsv: requires a file to be specified (must not be nullptr)");
 
     for(size_t i = 0; i < arg->getNumRows(); ++i) {
         for(size_t j = 0; j < arg->getNumCols(); ++j) {

--- a/src/runtime/local/io/WriteDaphne.h
+++ b/src/runtime/local/io/WriteDaphne.h
@@ -29,7 +29,6 @@
 
 #include <type_traits>
 
-#include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <fstream>

--- a/src/runtime/local/kernels/CUDA/Affine.cpp
+++ b/src/runtime/local/kernels/CUDA/Affine.cpp
@@ -52,8 +52,10 @@ namespace CUDA::NN::Affine {
         const VT* d_weights = weights->getValues(&alloc_desc);
 
         if (nc1 != weights->getNumRows()) {
-            throw std::runtime_error(fmt::format("NN::Affine: #cols of lhs and #rows of rhs must be the same ({} != {})",
-                    nc1, weights->getNumRows()));
+            throw std::runtime_error(
+                fmt::format("CUDA::NN::Affine: #cols of lhs and #rows of rhs must be "
+                            "the same ({} != {})",
+                            nc1, weights->getNumRows()));
         }
 
         if(res == nullptr)
@@ -64,7 +66,8 @@ namespace CUDA::NN::Affine {
         launch_cublas_gemm<VT>(*ctx, nr1, nc1, nc2, &blend_alpha, &blend_beta, d_input, d_weights, d_res);
 
         if(bias) {
-            assert((bias->getNumRows() == 1) && "bias dimensions not matching up with weights matrix (W[MxN] -> b[1xN]");
+            if (bias->getNumRows() != 1)
+                throw std::runtime_error("Affine (CUDA): bias dimensions not matching up with weights matrix (W[MxN] -> b[1xN]");
             const VT* d_bias = bias->getValues(&alloc_desc);
             CHECK_CUDNN(cudnnSetTensor4dDescriptor(ctx->src_tensor_desc, ctx->tensor_format, ctx->getCUDNNDataType<VT>(),
                     1, bias->getNumCols(), 1, 1));

--- a/src/runtime/local/kernels/CUDA/ColBind.h
+++ b/src/runtime/local/kernels/CUDA/ColBind.h
@@ -20,7 +20,6 @@
 #include <runtime/local/datastructures/DataObjectFactory.h>
 #include <runtime/local/datastructures/DenseMatrix.h>
 
-#include <cassert>
 #include <cstddef>
 #include <string>
 

--- a/src/runtime/local/kernels/CUDA/Convolution.h
+++ b/src/runtime/local/kernels/CUDA/Convolution.h
@@ -25,7 +25,6 @@
 #include <random>
 #include <type_traits>
 
-#include <cassert>
 #include <cstddef>
 #include <cstdint>
 

--- a/src/runtime/local/kernels/CUDA/EwBinaryMat.cu
+++ b/src/runtime/local/kernels/CUDA/EwBinaryMat.cu
@@ -251,10 +251,11 @@ namespace CUDA {
             throw std::runtime_error(fmt::format("Unknown opCode {} for EwBinaryMat", static_cast<uint32_t>(opCode)));
         }
         if(err) {
-            assert(
-                    false && "lhs and rhs must either have the same dimensions, "
-                             "or one if them must be a row/column vector with the "
-                             "width/height of the other"
+            throw std::runtime_error(
+                            "EwBinaryMat (CUDA): "
+                            "lhs and rhs must either have the same dimensions, "
+                            "or one of them must be a row/column vector with the "
+                            "width/height of the other"
             );
         }
         ctx->logger->debug("EwBinMat[{}]: {} blocks x {} threads = {} total threads for {} items",

--- a/src/runtime/local/kernels/CUDA/EwBinaryMat.h
+++ b/src/runtime/local/kernels/CUDA/EwBinaryMat.h
@@ -24,7 +24,6 @@
 #include <runtime/local/kernels/BinaryOpCode.h>
 #include <runtime/local/kernels/EwBinarySca.h>
 
-#include <cassert>
 #include <cstddef>
 #include <string>
 

--- a/src/runtime/local/kernels/CUDA/EwBinaryObjSca.h
+++ b/src/runtime/local/kernels/CUDA/EwBinaryObjSca.h
@@ -24,7 +24,6 @@
 #include <runtime/local/kernels/BinaryOpCode.h>
 #include <runtime/local/kernels/EwBinarySca.h>
 
-#include <cassert>
 #include <cstddef>
 #include <string>
 

--- a/src/runtime/local/kernels/CUDA/ExtractCol.h
+++ b/src/runtime/local/kernels/CUDA/ExtractCol.h
@@ -20,7 +20,6 @@
 #include <runtime/local/datastructures/DataObjectFactory.h>
 #include <runtime/local/datastructures/DenseMatrix.h>
 
-#include <cassert>
 #include <cstddef>
 #include <string>
 

--- a/src/runtime/local/kernels/CUDA/Fill.h
+++ b/src/runtime/local/kernels/CUDA/Fill.h
@@ -20,7 +20,6 @@
 #include <runtime/local/datastructures/DataObjectFactory.h>
 #include <runtime/local/datastructures/DenseMatrix.h>
 
-#include <cassert>
 #include <cstddef>
 #include <cstdint>
 

--- a/src/runtime/local/kernels/CUDA/MatMul.cpp
+++ b/src/runtime/local/kernels/CUDA/MatMul.cpp
@@ -101,7 +101,8 @@ namespace CUDA {
         const size_t nc2 = rhs->getNumCols();
         const size_t A_nnz = lhs->getNumNonZeros();
         const size_t B_nnz = rhs->getNumNonZeros();
-        assert((nc1 == nr2) && "#cols of lhs and #rows of rhs must be the same");
+        if (nc1 != nr2)
+            throw std::runtime_error("MatMul (CUDA): #cols of lhs and #rows of rhs must be the same");
         const VT blend_alpha = 1.0f;
         const VT blend_beta = 0.0f;
         cusparseOperation_t opA = transa ? CUSPARSE_OPERATION_TRANSPOSE : CUSPARSE_OPERATION_NON_TRANSPOSE;

--- a/src/runtime/local/kernels/CUDA/Softmax.h
+++ b/src/runtime/local/kernels/CUDA/Softmax.h
@@ -25,7 +25,6 @@
 #include <random>
 #include <type_traits>
 
-#include <cassert>
 #include <cstddef>
 #include <cstdint>
 

--- a/src/runtime/local/kernels/CUDA/Solve.cpp
+++ b/src/runtime/local/kernels/CUDA/Solve.cpp
@@ -87,10 +87,14 @@ namespace CUDA {
         const size_t nr1 = lhs->getNumRows();
         const size_t nc1 = lhs->getNumCols();
         const size_t nc2 = rhs->getNumCols();
-        assert((nr1 == rhs->getNumRows()) && "#rows of lhs and #rows of rhs must be the same");
-        assert((nr1 == nc1) && "#rows and #cols of lhs must be the same");
-        assert((lhs->getRowSkip() == nc1) && "#cols of lhs must match row skip");
-        assert((nc2 == 1) && "#cols of rhs must be 1");
+        if (nr1 != rhs->getNumRows())
+            throw std::runtime_error("Solve (CUDA): #rows of lhs and #rows of rhs must be the same");
+        if (nr1 != nc1)
+            throw std::runtime_error("Solve (CUDA): #rows and #cols of lhs must be the same");
+        if (lhs->getRowSkip() != nc1)
+            throw std::runtime_error("Solve (CUDA): #cols of lhs must match row skip");
+        if (nc2 != 1)
+            throw std::runtime_error("Solve (CUDA): #cols of rhs must be 1");
 
         if(res == nullptr)
             res = DataObjectFactory::create<DenseMatrix<VT>>(nr1, nc2, false, &alloc_desc);

--- a/src/runtime/local/kernels/CUDA/Solve.h
+++ b/src/runtime/local/kernels/CUDA/Solve.h
@@ -20,7 +20,6 @@
 #include <runtime/local/datastructures/DataObjectFactory.h>
 #include <runtime/local/datastructures/DenseMatrix.h>
 
-#include <cassert>
 #include <cstddef>
 
 namespace CUDA {

--- a/src/runtime/local/kernels/FPGAOPENCL/MatMul.h
+++ b/src/runtime/local/kernels/FPGAOPENCL/MatMul.h
@@ -24,7 +24,6 @@
 #include <cblas.h>
 #include <math.h>
 
-#include <cassert>
 #include <cstddef>
 #include "gemm_interface.h"
 #include "sgemv_interface.h"
@@ -64,7 +63,8 @@ struct MatMul<DenseMatrix<float>, DenseMatrix<float>, DenseMatrix<float>> {
         const size_t nc1 = lhs->getNumCols();
         const size_t nc2 = rhs->getNumCols();
         const size_t nr2 = rhs->getNumRows();
-        assert((nc1 == nr2) && "#cols of lhs and #rows of rhs must be the same");        
+        if (nc1 != nr2)
+            perror("#cols of lhs and #rows of rhs must be the same");
 
 // Parameters of the systolic array in the bitstream. Do not change.
 
@@ -83,9 +83,12 @@ struct MatMul<DenseMatrix<float>, DenseMatrix<float>, DenseMatrix<float>> {
 
 
 //#ifndef NDEBUG
-//	assert((nr1%(II*III)==0) && "lhs #rows number must be a multiple of 448");        
-//	assert((nc1%(JJ*JJJ)==0 && nc1>512 && nr2%(JJ*JJJ)==0 && nc1>512) && "#cols of lhs and #rows of rhs must be a multiple of 512 (and minimum 1024)");        
-//	assert((nc2%(KK*KKK)==0) && "#cols of rhs must be a multiple of 512");        
+    // if (nr1%(II*III) != 0)
+    //     perror("lhs #rows number must be a multiple of 448");
+    // if (nc1%(JJ*JJJ) != 0 || nc1 <= 512 || nr2%(JJ*JJJ) != 0 || nc1 <= 512)
+    //     perror("#cols of lhs and #rows of rhs must be a multiple of 512 (and minimum 1024)");
+	// if (nc2%(KK*KKK) != 0)
+    //     perror("#cols of rhs must be a multiple of 512");
 //#endif       
 
 //	printf("\ntest MatMul f32 \n");
@@ -209,7 +212,8 @@ struct MatMul<DenseMatrix<double>, DenseMatrix<double>, DenseMatrix<double>> {
         const size_t nc2 = rhs->getNumCols();
 #ifndef NDEBUG
         const size_t nr2 = rhs->getNumRows();
-        assert((nc1 == nr2) && "#cols of lhs and #rows of rhs must be the same");
+        if (nc1 != nr2)
+            perror("#cols of lhs and #rows of rhs must be the same");
 #endif 
         if(res == nullptr)
             res = DataObjectFactory::create<DenseMatrix<double>>(nr1, nc2, false);

--- a/src/runtime/local/kernels/FPGAOPENCL/Syrk.h
+++ b/src/runtime/local/kernels/FPGAOPENCL/Syrk.h
@@ -24,7 +24,6 @@
 #include <cblas.h>
 #include <math.h>
 
-#include <cassert>
 #include <cstddef>
 #include "syrk_interface.h"
 

--- a/src/runtime/local/kernels/FPGAOPENCL/gemm_interface.cpp
+++ b/src/runtime/local/kernels/FPGAOPENCL/gemm_interface.cpp
@@ -24,7 +24,6 @@
 
 #include "AOCLUtils/aocl_utils.h"
 #include "CL/opencl.h"
-#include <cassert>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -229,7 +228,9 @@ int sgemm(const float *A, const float *B, float *C, const int OUTERMOST_I, const
     fseek(fp, 0, SEEK_END);
     binary_length = ftell(fp);
     binary = (unsigned char *)malloc(sizeof(unsigned char) * binary_length);
-    assert(binary && "Malloc failed");
+    if (!binary) {
+        perror("Failed malloc for binaries");
+    }
     rewind(fp);
 
     if (fread((void *)binary, binary_length, 1, fp) == 0) {

--- a/src/runtime/local/kernels/FPGAOPENCL/kernel_utils.cpp
+++ b/src/runtime/local/kernels/FPGAOPENCL/kernel_utils.cpp
@@ -4,7 +4,6 @@
 
 #include "AOCLUtils/aocl_utils.h"
 #include "CL/opencl.h"
-#include <cassert>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>

--- a/src/runtime/local/kernels/FPGAOPENCL/sgemv_interface.cpp
+++ b/src/runtime/local/kernels/FPGAOPENCL/sgemv_interface.cpp
@@ -25,7 +25,6 @@
 #include "AOCLUtils/aocl_utils.h"
 #include "CL/opencl.h"
 #include "CL/cl_ext_intelfpga.h"
-#include <cassert>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -306,7 +305,9 @@ int sgemv(const float *A, const float *B, float *C, const int I, const int K, DC
     fseek(fp, 0, SEEK_END);
     binary_length = ftell(fp);
     binary = (unsigned char *)malloc(sizeof(unsigned char) * binary_length);
-    assert(binary && "Malloc failed");
+    if (!binary) {
+        perror("Failed malloc for binaries");
+    }
     rewind(fp);
 
     if (fread((void *)binary, binary_length, 1, fp) == 0) {

--- a/src/runtime/local/kernels/FPGAOPENCL/syrk_interface.cpp
+++ b/src/runtime/local/kernels/FPGAOPENCL/syrk_interface.cpp
@@ -24,7 +24,6 @@
 
 #include "AOCLUtils/aocl_utils.h"
 #include "CL/opencl.h"
-#include <cassert>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -249,7 +248,9 @@ int syrk(const float *A, float *C, const int OUTERMOST_I, const int OUTERMOST_K,
     fseek(fp, 0, SEEK_END);
     binary_length = ftell(fp);
     binary = (unsigned char *)malloc(sizeof(unsigned char) * binary_length);
-    assert(binary && "Malloc failed");
+    if (!binary) {
+        perror("Failed malloc for binaries");
+    }
     rewind(fp);
 
     if (fread((void *)binary, binary_length, 1, fp) == 0) {

--- a/src/runtime/local/vectorized/Tasks.cpp
+++ b/src/runtime/local/vectorized/Tasks.cpp
@@ -128,13 +128,15 @@ void CompiledPipelineTask<CSRMatrix<VT>>::execute(uint32_t fid, uint32_t batchSi
     for(size_t i = 0; i < _data._numOutputs; i++) {
         switch(_data._combines[i]) {
             case VectorCombine::ROWS: {
-                assert(_data._wholeResultCols[i] != -1 && "TODO");
+                if (_data._wholeResultCols[i] == -1)
+                    throw std::runtime_error("TODO: CompiledPipeLineTask (CSRMatrix) Rows _data._wholeResultCols[i] == -1");
                 localResNumRows[i] = _data._ru - _data._rl;
                 localResNumCols[i] = _data._wholeResultCols[i];
                 break;
             }
             case VectorCombine::COLS: {
-                assert(_data._wholeResultRows[i] != -1 && "TODO");
+                if (_data._wholeResultRows[i] == -1)
+                    throw std::runtime_error("TODO: CompiledPipeLineTask (CSRMatrix) Cols _data._wholeResultRows[i] == -1");
                 localResNumRows[i] = _data._wholeResultRows[i];
                 localResNumCols[i] = _data._ru - _data._rl;
                 break;

--- a/test/api/cli/distributed/DistributedTest.cpp
+++ b/test/api/cli/distributed/DistributedTest.cpp
@@ -38,7 +38,7 @@ TEST_CASE("Distributed runtime tests using gRPC", TAG_DISTRIBUTED)
     int nullFd = open("/dev/null", O_WRONLY);
     auto pid1 = runProgramInBackground(nullFd, nullFd, "bin/DistributedWorker", "DistributedWorker", addr1);
     auto pid2 = runProgramInBackground(nullFd, nullFd, "bin/DistributedWorker", "DistributedWorker", addr2);
-    assert(std::getenv("DISTRIBUTED_WORKERS") == nullptr);
+    CHECK(std::getenv("DISTRIBUTED_WORKERS") == nullptr);
     auto distWorkerStr = std::string(addr1) + ',' + addr2;
 
     SECTION("Execution of scripts using distributed runtime (gRPC)"){

--- a/test/runtime/local/kernels/DNNAffineTest.cpp
+++ b/test/runtime/local/kernels/DNNAffineTest.cpp
@@ -24,7 +24,6 @@
 #include <runtime/local/kernels/CheckEq.h>
 
 #include <catch.hpp>
-#include <cassert>
 #include <tags.h>
 
 template<class DT>

--- a/test/runtime/local/kernels/DNNBatchNormTest.cpp
+++ b/test/runtime/local/kernels/DNNBatchNormTest.cpp
@@ -23,7 +23,6 @@
 #include <runtime/local/datastructures/DenseMatrix.h>
 #include "runtime/local/kernels/CUDA/BatchNorm.h"
 
-#include <cassert>
 #include <catch.hpp>
 #include <tags.h>
 

--- a/test/runtime/local/kernels/DNNConvolutionTest.cpp
+++ b/test/runtime/local/kernels/DNNConvolutionTest.cpp
@@ -22,7 +22,6 @@
 #include <runtime/local/datastructures/DenseMatrix.h>
 #include <runtime/local/kernels/CheckEq.h>
 
-#include <cassert>
 #include <tags.h>
 #include <catch.hpp>
 

--- a/test/runtime/local/kernels/DNNSoftmaxTest.cpp
+++ b/test/runtime/local/kernels/DNNSoftmaxTest.cpp
@@ -19,8 +19,6 @@
 #include <runtime/local/datagen/GenGivenVals.h>
 #include <runtime/local/datastructures/DenseMatrix.h>
 
-
-#include <cassert>
 #include <catch.hpp>
 #include <tags.h>
 


### PR DESCRIPTION
This PR closes #720 by removing `assert` statements in the codebase and replacing them with the new `ErrorHandler` or normal `runtime_error` exceptions. For `FPGA OpenCL` kernels, `perror` statements are used instead.

Any unnecessary `cassert` headers have been removed as well.

There are a few assertions in `MatMulOpLowering.cpp` with a mismatching error message, i.e.
```
assert(twiceTiledNest[5].getStep() == NR * vec_size && "tTN: 5 should have step size NR.");
assert(twiceTiledNest[2].getStep() == KC            && "tTN: 2 should have step size 1.");
assert(blisTiledLoops[1].getStep() == KC            && "blisTiled: 1 should have step size 1.");
```
Since you are very familiar with the PR that introduced them (653), could you please help me verify the checked conditions @philipportner?