### PR TITLE
[DAPHNE-#747] Use test.sh in CI again.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
       shell: bash
 
     - name: Testing
-      run: LD_LIBRARY_PATH=$PWD/lib:$LD_LIBRARY_PATH PATH=$PWD/bin:/usr/lib/llvm-10/bin:$PATH DAPHNELIB_DIR_PATH=$PWD/lib PYTHONPATH="$PYTHONPATH:$PWD/src/api/python/:/usr/lib/llvm-10/build/utils/lit/" bin/run_tests
+      run: ./test.sh --no-build
 
     - name: "List generated files"
       run: |


### PR DESCRIPTION
- As a part of our CI workflows, we run the entire DAPHNE test suite.
  - The tests reside in the catch2-based executable run_tests.
  - Normally (e.g., in a local dev environment), we don't run run_tests directly, but invoke it indirectly through test.sh.
  - test.sh offers a few arguments and sets a few environment variables such that the tests can run as expected.
- In the CI workflow, we initially executed test.sh to run the test cases.
- However, in ebfcc3bfe9457fc8106ba87c62c89ba7b2b4f48f, this was changed to invoking run_tests directly (plus adding a few essential environment variables on the command line).
  - The motivation back then was that test.sh re-builds run_tests, but potentially with unwanted parameters (in the worst case, this can result in pulling the LLVM repo).
- In the meantime, test.sh has become more complex, e.g., by setting more environment variables.
  - These changes have not been reflected in the CI workflow (.github/workflows/main.yml).
  - So far, this inconsistency did not lead to any problems.
    - Except, maybe, the one described in 00eec3cb714df336c818f400beb72c990691e9f5.
  - However, recently TensorFlow was added to the CI container image. - That caused the DaphneLib test cases to import TensorFlow (so far, it was not imported, since it is an optional dependency that is only imported if installed). - TensorFlow has the habit of printing various warnings to stderr. - As these warnings confuse the checks in our test cases (for empty stderr), test.sh suppresses these warnings by setting the environment variable "export TF_CPP_MIN_LOG_LEVEL=3"). - As the CI workflow bypasses test.sh, it did not silence the TensorFlow warnings. - As a consequence, all DaphneLib test cases started failing in the CI workload after the recent container image update.
- To solve this problem, we could
  - either: add those additional environment variables before the invocation of run_tests in main.yml - Error-prone code duplication, difficult in case of conditional environment variables (which we do have meanwhile).
  - or: simply use test.sh in the CI workflow again
    - Consistent solution, since environment variables are contained in a single place.
    - The original motivation for swtiching to run_tests in ebfcc3bfe9457fc8106ba87c62c89ba7b2b4f48f is meanwhile gone, since test.sh has an argument --no-build.
- Thus, this commit makes the CI workflow use test.sh instead of run_tests again.
  - Following the comment in the commit message of ebfcc3bfe9457fc8106ba87c62c89ba7b2b4f48f, we don't pipe the output of test.sh to ts now.
- Fixes #747.