### PR TITLE
Refactoring MetaDataObject out of DenseMatrix

### DIFF
--- a/src/api/internal/daphne_internal.cpp
+++ b/src/api/internal/daphne_internal.cpp
@@ -92,7 +92,7 @@ void handleSignals(int signal) {
     auto callstacksReturned = backtrace(callstack, callstackMaxSize);
     backtrace_symbols_fd(callstack, callstacksReturned, STDOUT_FILENO);
     gSignalStatus = signal;
-    longjmp(return_from_handler, gSignalStatus);
+    longjmp(return_from_handler, gSignalStatus); // NOLINT(*-err52-cpp)
 }
 
 int startDAPHNE(int argc, const char** argv, DaphneLibResult* daphneLibRes, int *id, DaphneUserConfig& user_config){
@@ -526,7 +526,7 @@ int startDAPHNE(int argc, const char** argv, DaphneLibResult* daphneLibRes, int 
 #ifndef USE_MPI
     throw std::runtime_error("you are trying to use the MPI backend. But, Daphne was not build with --mpi option\n");    
 #else
-        MPI_Init(NULL,NULL);
+        MPI_Init(nullptr,nullptr);
         MPI_Comm_rank(MPI_COMM_WORLD, id);
         int size=0;
         MPI_Comm_size(MPI_COMM_WORLD, &size);
@@ -648,7 +648,7 @@ int startDAPHNE(int argc, const char** argv, DaphneLibResult* daphneLibRes, int 
         tpBegExec = clock::now();
 
         // set jump address for catching exceptions in kernel libraries via signal handling
-        if(setjmp(return_from_handler) == 0) {
+        if(setjmp(return_from_handler) == 0) { // NOLINT(*-err52-cpp)
             auto error = engine->invoke("main");
             if (error) {
                 llvm::errs() << "JIT-Engine invocation failed: " << error;

--- a/src/runtime/distributed/coordinator/kernels/Distribute.h
+++ b/src/runtime/distributed/coordinator/kernels/Distribute.h
@@ -16,14 +16,14 @@
 
 #pragma once
 
-#include <runtime/local/context/DistributedContext.h>
-#include <runtime/local/datastructures/DataObjectFactory.h>
-#include <runtime/local/datastructures/DenseMatrix.h>
 #include <runtime/distributed/coordinator/scheduling/LoadPartitioningDistributed.h>
-
-#include <runtime/local/datastructures/AllocationDescriptorGRPC.h>
 #include <runtime/distributed/proto/DistributedGRPCCaller.h>
 #include <runtime/distributed/worker/WorkerImpl.h>
+#include <runtime/local/context/DistributedContext.h>
+#include <runtime/local/datastructures/AllocationDescriptorGRPC.h>
+#include <runtime/local/datastructures/DataObjectFactory.h>
+#include <runtime/local/datastructures/DenseMatrix.h>
+#include <runtime/local/io/DaphneSerializer.h>
 
 #ifdef USE_MPI
     #include <runtime/distributed/worker/MPIHelper.h>
@@ -71,12 +71,12 @@ struct Distribute<ALLOCATION_TYPE::DIST_MPI, DT>
         
         while (partioner.HasNextChunk()){
             DataPlacement *dp = partioner.GetNextChunk();
-            auto rank = dynamic_cast<AllocationDescriptorMPI&>(*(dp->allocation)).getRank();
+            auto rank = dynamic_cast<AllocationDescriptorMPI*>(dp->getAllocation(0))->getRank();
             
-            if (dynamic_cast<AllocationDescriptorMPI&>(*(dp->allocation)).getDistributedData().isPlacedAtWorker)
+            if (dynamic_cast<AllocationDescriptorMPI*>(dp->getAllocation(0))->getDistributedData().isPlacedAtWorker)
                 continue;
             
-            auto slicedMat = mat->sliceRow(dp->range->r_start, dp->range->r_start + dp->range->r_len);
+            auto slicedMat = mat->sliceRow(dp->getRange()->r_start, dp->getRange()->r_start + dp->getRange()->r_len);
             
             // Minimum chunk size
             auto min_chunk_size = dctx->config.max_distributed_serialization_chunk_size < DaphneSerializer<DT>::length(slicedMat) ? 
@@ -99,12 +99,12 @@ struct Distribute<ALLOCATION_TYPE::DIST_MPI, DT>
             WorkerImpl::StoredInfo dataAcknowledgement = MPIHelper::getDataAcknowledgement(&rank);
             std::string address = std::to_string(rank);
             DataPlacement *dp = mat->getMetaDataObject()->getDataPlacementByLocation(address);
-            auto data = dynamic_cast<AllocationDescriptorMPI&>(*(dp->allocation)).getDistributedData();
+            auto data = dynamic_cast<AllocationDescriptorMPI*>(dp->getAllocation(0))->getDistributedData();
             data.identifier = dataAcknowledgement.identifier ;
             data.numRows = dataAcknowledgement.numRows;
             data.numCols = dataAcknowledgement.numCols;
             data.isPlacedAtWorker = true;
-            dynamic_cast<AllocationDescriptorMPI&>(*(dp->allocation)).updateDistributedData(data);
+            dynamic_cast<AllocationDescriptorMPI*>(dp->getAllocation(0))->updateDistributedData(data);
         }
 
     }
@@ -131,17 +131,17 @@ struct Distribute<ALLOCATION_TYPE::DIST_GRPC_ASYNC, DT>
         while (partioner.HasNextChunk()){ 
             auto dp = partioner.GetNextChunk();
             // Skip if already placed at workers
-            if (dynamic_cast<AllocationDescriptorGRPC&>(*(dp->allocation)).getDistributedData().isPlacedAtWorker)
+            if (dynamic_cast<AllocationDescriptorGRPC*>(dp->getAllocation(0))->getDistributedData().isPlacedAtWorker)
                 continue;
             distributed::Data protoMsg;
 
             std::vector<char> buffer;
             
-            auto slicedMat = mat->sliceRow(dp->range->r_start, dp->range->r_start + dp->range->r_len);
+            auto slicedMat = mat->sliceRow(dp->getRange()->r_start, dp->getRange()->r_start + dp->getRange()->r_len);
 
-            StoredInfo storedInfo({dp->dp_id}); 
+            StoredInfo storedInfo({dp->getID()}); 
 
-            auto address = dynamic_cast<AllocationDescriptorGRPC&>(*(dp->allocation)).getLocation();
+            auto address = dynamic_cast<AllocationDescriptorGRPC*>(dp->getAllocation(0))->getLocation();
 
             caller.asyncStoreCall(address, storedInfo);
             // Minimum chunk size
@@ -171,12 +171,12 @@ struct Distribute<ALLOCATION_TYPE::DIST_GRPC_ASYNC, DT>
 
             auto dp = mat->getMetaDataObject()->getDataPlacementByID(dp_id);
             
-            auto data = dynamic_cast<AllocationDescriptorGRPC&>(*(dp->allocation)).getDistributedData();
+            auto data = dynamic_cast<AllocationDescriptorGRPC*>(dp->getAllocation(0))->getDistributedData();
             data.identifier = storedData.identifier();
             data.numRows = storedData.num_rows();
             data.numCols = storedData.num_cols();
             data.isPlacedAtWorker = true;
-            dynamic_cast<AllocationDescriptorGRPC&>(*(dp->allocation)).updateDistributedData(data);            
+            dynamic_cast<AllocationDescriptorGRPC*>(dp->getAllocation(0))->updateDistributedData(data);            
         }
 
     }
@@ -200,14 +200,14 @@ struct Distribute<ALLOCATION_TYPE::DIST_GRPC_SYNC, DT>
         while (partioner.HasNextChunk()){ 
             auto dp = partioner.GetNextChunk();
             // Skip if already placed at workers
-            if (dynamic_cast<AllocationDescriptorGRPC&>(*(dp->allocation)).getDistributedData().isPlacedAtWorker)
+            if (dynamic_cast<AllocationDescriptorGRPC*>(dp->getAllocation(0))->getDistributedData().isPlacedAtWorker)
                 continue;
 
 
             std::vector<char> buffer;
             
             
-            auto workerAddr = dynamic_cast<AllocationDescriptorGRPC&>(*(dp->allocation)).getLocation();
+            auto workerAddr = dynamic_cast<AllocationDescriptorGRPC*>(dp->getAllocation(0))->getLocation();
             std::thread t([=, &mat]()
             {
                 auto stub = ctx->stubs[workerAddr].get();
@@ -215,7 +215,7 @@ struct Distribute<ALLOCATION_TYPE::DIST_GRPC_SYNC, DT>
                 distributed::StoredData storedData;
                 grpc::ClientContext grpc_ctx;
 
-                auto slicedMat = mat->sliceRow(dp->range->r_start, dp->range->r_start + dp->range->r_len);            
+                auto slicedMat = mat->sliceRow(dp->getRange()->r_start, dp->getRange()->r_start + dp->getRange()->r_len);            
                 auto serializer = DaphneSerializerChunks<DT>(slicedMat, dctx->config.max_distributed_serialization_chunk_size);
                 
                 distributed::Data protoMsg;
@@ -236,10 +236,10 @@ struct Distribute<ALLOCATION_TYPE::DIST_GRPC_SYNC, DT>
                 newData.numRows = storedData.num_rows();
                 newData.numCols = storedData.num_cols();
                 newData.isPlacedAtWorker = true;
-                dynamic_cast<AllocationDescriptorGRPC&>(*(dp->allocation)).updateDistributedData(newData);
+                dynamic_cast<AllocationDescriptorGRPC*>(dp->getAllocation(0))->updateDistributedData(newData);
                 DataObjectFactory::destroy(slicedMat);
             });
-            threads_vector.push_back(move(t));            
+            threads_vector.push_back(std::move(t));
         }
         for (auto &thread : threads_vector)
             thread.join();

--- a/src/runtime/distributed/coordinator/kernels/Distribute.h
+++ b/src/runtime/distributed/coordinator/kernels/Distribute.h
@@ -199,10 +199,16 @@ struct Distribute<ALLOCATION_TYPE::DIST_GRPC_SYNC, DT>
         LoadPartitioningDistributed<DT, AllocationDescriptorGRPC> partioner(DistributionSchema::DISTRIBUTE, mat, dctx);
         while (partioner.HasNextChunk()){ 
             auto dp = partioner.GetNextChunk();
-            // Skip if already placed at workers
-            if (dynamic_cast<AllocationDescriptorGRPC*>(dp->getAllocation(0))->getDistributedData().isPlacedAtWorker)
-                continue;
-
+            auto alloc = dp->getAllocation(0);
+            auto grpc_alloc = dynamic_cast<AllocationDescriptorGRPC*>(alloc);
+            if(grpc_alloc) {
+                auto dist_data = grpc_alloc->getDistributedData();
+                // Skip if already placed at workers
+                if (dist_data.isPlacedAtWorker)
+                    continue;
+            }
+            else
+                throw std::runtime_error("dynamic_cast<AllocationDescriptorGRPC*>(alloc) failed (returned nullptr)");
 
             std::vector<char> buffer;
             

--- a/src/runtime/distributed/coordinator/kernels/DistributedCollect.h
+++ b/src/runtime/distributed/coordinator/kernels/DistributedCollect.h
@@ -68,7 +68,7 @@ void distributedCollect(DT *&mat, const VectorCombine &combine, DCTX(dctx))
 template<class DT>
 struct DistributedCollect<ALLOCATION_TYPE::DIST_MPI, DT>
 {
-    static void apply(DT *&mat, const VectorCombine& combine, DCTX(dctx)) 
+    static void apply(DT *&mat, const VectorCombine& combine, DCTX(dctx))
     {
         assert (mat != nullptr && "result matrix must be already allocated by wrapper since only there exists information regarding size");        
         size_t worldSize = MPIHelper::getCommSize();
@@ -79,7 +79,7 @@ struct DistributedCollect<ALLOCATION_TYPE::DIST_MPI, DT>
             
             std::string address = std::to_string(rank);  
             auto dp=mat->getMetaDataObject()->getDataPlacementByLocation(address);   
-            auto distributedData = dynamic_cast<AllocationDescriptorMPI&>(*(dp->allocation)).getDistributedData();            
+            auto distributedData = dynamic_cast<AllocationDescriptorMPI*>(dp->getAllocation(0))->getDistributedData();
             WorkerImpl::StoredInfo info = {
                 distributedData.identifier,
                 distributedData.numRows,
@@ -105,22 +105,22 @@ struct DistributedCollect<ALLOCATION_TYPE::DIST_MPI, DT>
             auto slicedMat = dynamic_cast<DenseMatrix<double>*>(DF_deserialize(buffer));
             if (combine == VectorCombine::ADD) {
                 ewBinaryMat(BinaryOpCode::ADD, denseMat, slicedMat, denseMat, nullptr);
-            } else {                    
-                auto resValues = denseMat->getValues() + (dp->range->r_start * denseMat->getRowSkip());
+            } else {
+                auto resValues = denseMat->getValues() + (dp->getRange()->r_start * denseMat->getRowSkip());
                 auto slicedMatValues = slicedMat->getValues();
-                for (size_t r = 0; r < dp->range->r_len; r++){
-                    memcpy(resValues + dp->range->c_start, slicedMatValues, dp->range->c_len * sizeof(double));
+                for (size_t r = 0; r < dp->getRange()->r_len; r++){
+                    memcpy(resValues + dp->getRange()->c_start, slicedMatValues, dp->getRange()->c_len * sizeof(double));
                     resValues += denseMat->getRowSkip();
                     slicedMatValues += slicedMat->getRowSkip();
                 }
             }
             DataObjectFactory::destroy(slicedMat);
             
-            collectedDataItems+=  dp->range->r_len *  dp->range->c_len;
+            collectedDataItems+=  dp->getRange()->r_len *  dp->getRange()->c_len;
 
-            auto distributedData = dynamic_cast<AllocationDescriptorMPI&>(*(dp->allocation)).getDistributedData();            
+            auto distributedData = dynamic_cast<AllocationDescriptorMPI*>(dp->getAllocation(0))->getDistributedData();
             distributedData.isPlacedAtWorker = false;
-            dynamic_cast<AllocationDescriptorMPI&>(*(dp->allocation)).updateDistributedData(distributedData);
+            dynamic_cast<AllocationDescriptorMPI*>(dp->getAllocation(0))->updateDistributedData(distributedData);
             // this is to handle the case when not all workers participate in the computation, i.e., number of workers is larger than of the work items
             if(collectedDataItems == denseMat->getNumRows() * denseMat->getNumCols())
                 break;
@@ -136,7 +136,7 @@ struct DistributedCollect<ALLOCATION_TYPE::DIST_MPI, DT>
 template<class DT>
 struct DistributedCollect<ALLOCATION_TYPE::DIST_GRPC_ASYNC, DT>
 {
-    static void apply(DT *&mat, const VectorCombine& combine, DCTX(dctx)) 
+    static void apply(DT *&mat, const VectorCombine& combine, DCTX(dctx))
     {
         assert (mat != nullptr && "result matrix must be already allocated by wrapper since only there exists information regarding size");        
 
@@ -146,12 +146,12 @@ struct DistributedCollect<ALLOCATION_TYPE::DIST_GRPC_ASYNC, DT>
         DistributedGRPCCaller<StoredInfo, distributed::StoredData, distributed::Data> caller(dctx);
 
 
-        auto dpVector = mat->getMetaDataObject()->getDataPlacementByType(ALLOCATION_TYPE::DIST_GRPC);
+        auto dpVector = mat->getMetaDataObject()->getRangeDataPlacementByType(ALLOCATION_TYPE::DIST_GRPC);
         for (auto &dp : *dpVector) {
-            auto address = dp->allocation->getLocation();
+            auto address = dp->getAllocation(0)->getLocation();
             
-            auto distributedData = dynamic_cast<AllocationDescriptorGRPC&>(*(dp->allocation)).getDistributedData();
-            StoredInfo storedInfo({dp->dp_id});
+            auto distributedData = dynamic_cast<AllocationDescriptorGRPC*>(dp->getAllocation(0))->getDistributedData();
+            StoredInfo storedInfo({dp->getID()});
             distributed::StoredData protoData;
             protoData.set_identifier(distributedData.identifier);
             protoData.set_num_rows(distributedData.numRows);
@@ -166,7 +166,7 @@ struct DistributedCollect<ALLOCATION_TYPE::DIST_GRPC_ASYNC, DT>
             auto response = caller.getNextResult();
             auto dp_id = response.storedInfo.dp_id;
             auto dp = mat->getMetaDataObject()->getDataPlacementByID(dp_id);
-            auto data = dynamic_cast<AllocationDescriptorGRPC&>(*(dp->allocation)).getDistributedData();            
+            auto data = dynamic_cast<AllocationDescriptorGRPC*>(dp->getAllocation(0))->getDistributedData();
 
             auto matProto = response.result;
             
@@ -181,18 +181,18 @@ struct DistributedCollect<ALLOCATION_TYPE::DIST_GRPC_ASYNC, DT>
             if (combine == VectorCombine::ADD) {
                 ewBinaryMat(BinaryOpCode::ADD, denseMat, slicedMat, denseMat, nullptr);
             } else {
-                auto resValues = denseMat->getValues() + (dp->range->r_start * denseMat->getRowSkip());
+                auto resValues = denseMat->getValues() + (dp->getRange()->r_start * denseMat->getRowSkip());
                 auto slicedMatValues = slicedMat->getValues();
-                for (size_t r = 0; r < dp->range->r_len; r++){
-                    memcpy(resValues + dp->range->c_start, slicedMatValues, dp->range->c_len * sizeof(double));
-                    resValues += denseMat->getRowSkip();                    
+                for (size_t r = 0; r < dp->getRange()->r_len; r++){
+                    memcpy(resValues + dp->getRange()->c_start, slicedMatValues, dp->getRange()->c_len * sizeof(double));
+                    resValues += denseMat->getRowSkip();
                     slicedMatValues += slicedMat->getRowSkip();
                 }
             }
             DataObjectFactory::destroy(slicedMat);
 
             data.isPlacedAtWorker = false;
-            dynamic_cast<AllocationDescriptorGRPC&>(*(dp->allocation)).updateDistributedData(data);
+            dynamic_cast<AllocationDescriptorGRPC*>(dp->getAllocation(0))->updateDistributedData(data);
         } 
     };
 };
@@ -205,7 +205,7 @@ struct DistributedCollect<ALLOCATION_TYPE::DIST_GRPC_ASYNC, DT>
 template<class DT>
 struct DistributedCollect<ALLOCATION_TYPE::DIST_GRPC_SYNC, DT>
 {
-    static void apply(DT *&mat, const VectorCombine& combine, DCTX(dctx)) 
+    static void apply(DT *&mat, const VectorCombine& combine, DCTX(dctx))
     {
         assert (mat != nullptr && "result matrix must be already allocated by wrapper since only there exists information regarding size");        
 
@@ -213,11 +213,11 @@ struct DistributedCollect<ALLOCATION_TYPE::DIST_GRPC_SYNC, DT>
         std::vector<std::thread> threads_vector;
         std::mutex lock;
 
-        auto dpVector = mat->getMetaDataObject()->getDataPlacementByType(ALLOCATION_TYPE::DIST_GRPC);
+        auto dpVector = mat->getMetaDataObject()->getRangeDataPlacementByType(ALLOCATION_TYPE::DIST_GRPC);
         for (auto &dp : *dpVector) {
-            auto address = dp->allocation->getLocation();
+            auto address = dp->getAllocation(0)->getLocation();
             
-            auto distributedData = dynamic_cast<AllocationDescriptorGRPC&>(*(dp->allocation)).getDistributedData();            
+            auto distributedData = dynamic_cast<AllocationDescriptorGRPC*>(dp->getAllocation(0))->getDistributedData();
             distributed::StoredData protoData;
             protoData.set_identifier(distributedData.identifier);
             protoData.set_num_rows(distributedData.numRows);
@@ -243,19 +243,19 @@ struct DistributedCollect<ALLOCATION_TYPE::DIST_GRPC_SYNC, DT>
                     std::lock_guard g(lock);
                     ewBinaryMat(BinaryOpCode::ADD, denseMat, slicedMat, denseMat, nullptr);
                 } else {
-                    auto resValues = denseMat->getValues() + (dp->range->r_start * denseMat->getRowSkip());
+                    auto resValues = denseMat->getValues() + (dp->getRange()->r_start * denseMat->getRowSkip());
                     auto slicedMatValues = slicedMat->getValues();
-                    for (size_t r = 0; r < dp->range->r_len; r++){
-                        memcpy(resValues + dp->range->c_start, slicedMatValues, dp->range->c_len * sizeof(double));
-                        resValues += denseMat->getRowSkip();                    
+                    for (size_t r = 0; r < dp->getRange()->r_len; r++){
+                        memcpy(resValues + dp->getRange()->c_start, slicedMatValues, dp->getRange()->c_len * sizeof(double));
+                        resValues += denseMat->getRowSkip();
                         slicedMatValues += slicedMat->getRowSkip();
                     }
                 }
                 DataObjectFactory::destroy(slicedMat);
                 distributedData.isPlacedAtWorker = false;
-                dynamic_cast<AllocationDescriptorGRPC&>(*(dp->allocation)).updateDistributedData(distributedData);
+                dynamic_cast<AllocationDescriptorGRPC*>(dp->getAllocation(0))->updateDistributedData(distributedData);
             });
-            threads_vector.push_back(move(t));        
+            threads_vector.push_back(std::move(t));
         }
         for (auto &thread : threads_vector)
             thread.join();

--- a/src/runtime/distributed/coordinator/kernels/DistributedCompute.h
+++ b/src/runtime/distributed/coordinator/kernels/DistributedCompute.h
@@ -87,7 +87,7 @@ struct DistributedCompute<ALLOCATION_TYPE::DIST_MPI, DTRes, const Structure>
             for (size_t i = 0; i < numInputs; i++)
             {
                 auto dp = args[i]->getMetaDataObject()->getDataPlacementByLocation(addr);
-                auto distrData = dynamic_cast<AllocationDescriptorMPI&>(*(dp->allocation)).getDistributedData();
+                auto distrData = dynamic_cast<AllocationDescriptorMPI*>(dp->getAllocation(0))->getDistributedData();
                 
                 MPIHelper::StoredInfo storedData({distrData.identifier, distrData.numRows, distrData.numCols});                
                 task.inputs.push_back(storedData);
@@ -106,12 +106,12 @@ struct DistributedCompute<ALLOCATION_TYPE::DIST_MPI, DTRes, const Structure>
                 auto resMat = *res[idx++];
                 auto dp = resMat->getMetaDataObject()->getDataPlacementByLocation(std::to_string(rank));
 
-                auto data = dynamic_cast<AllocationDescriptorMPI&>(*(dp->allocation)).getDistributedData();
+                auto data = dynamic_cast<AllocationDescriptorMPI*>(dp->getAllocation(0))->getDistributedData();
                 data.identifier = info.identifier;
                 data.numRows = info.numRows;
                 data.numCols = info.numCols;
                 data.isPlacedAtWorker = true;
-                dynamic_cast<AllocationDescriptorMPI&>(*(dp->allocation)).updateDistributedData(data);                                                
+                dynamic_cast<AllocationDescriptorMPI*>(dp->getAllocation(0))->updateDistributedData(data);
             }
         }
     }
@@ -152,7 +152,7 @@ struct DistributedCompute<ALLOCATION_TYPE::DIST_GRPC_ASYNC, DTRes, const Structu
             distributed::Task task;
             for (size_t i = 0; i < numInputs; i++){
                 auto dp = args[i]->getMetaDataObject()->getDataPlacementByLocation(addr);
-                auto distrData = dynamic_cast<AllocationDescriptorGRPC&>(*(dp->allocation)).getDistributedData();
+                auto distrData = dynamic_cast<AllocationDescriptorMPI*>(dp->getAllocation(0))->getDistributedData();
 
                 distributed::StoredData protoData;
                 protoData.set_identifier(distrData.identifier);
@@ -180,12 +180,12 @@ struct DistributedCompute<ALLOCATION_TYPE::DIST_GRPC_ASYNC, DTRes, const Structu
                 auto resMat = *res[o];
                 auto dp = resMat->getMetaDataObject()->getDataPlacementByLocation(addr);
 
-                auto data = dynamic_cast<AllocationDescriptorGRPC&>(*(dp->allocation)).getDistributedData();
+                auto data = dynamic_cast<AllocationDescriptorGRPC*>(dp->getAllocation(0))->getDistributedData();
                 data.identifier = computeResult.outputs()[o].stored().identifier();
                 data.numRows = computeResult.outputs()[o].stored().num_rows();
                 data.numCols = computeResult.outputs()[o].stored().num_cols();
                 data.isPlacedAtWorker = true;
-                dynamic_cast<AllocationDescriptorGRPC&>(*(dp->allocation)).updateDistributedData(data);                                                
+                dynamic_cast<AllocationDescriptorGRPC*>(dp->getAllocation(0))->updateDistributedData(data);                                                
             }            
         }                
     }
@@ -226,7 +226,7 @@ struct DistributedCompute<ALLOCATION_TYPE::DIST_GRPC_SYNC, DTRes, const Structur
             distributed::Task task;
             for (size_t i = 0; i < numInputs; i++){
                 auto dp = args[i]->getMetaDataObject()->getDataPlacementByLocation(addr);
-                auto distrData = dynamic_cast<AllocationDescriptorGRPC&>(*(dp->allocation)).getDistributedData();
+                auto distrData = dynamic_cast<AllocationDescriptorMPI*>(dp->getAllocation(0))->getDistributedData();
 
                 distributed::StoredData protoData;
                 protoData.set_identifier(distrData.identifier);
@@ -251,15 +251,15 @@ struct DistributedCompute<ALLOCATION_TYPE::DIST_GRPC_SYNC, DTRes, const Structur
                     auto resMat = *res[o];
                     auto dp = resMat->getMetaDataObject()->getDataPlacementByLocation(addr);
 
-                    auto data = dynamic_cast<AllocationDescriptorGRPC&>(*(dp->allocation)).getDistributedData();
+                    auto data = dynamic_cast<AllocationDescriptorGRPC*>(dp->getAllocation(0))->getDistributedData();
                     data.identifier = computeResult.outputs()[o].stored().identifier();
                     data.numRows = computeResult.outputs()[o].stored().num_rows();
                     data.numCols = computeResult.outputs()[o].stored().num_cols();
                     data.isPlacedAtWorker = true;
-                    dynamic_cast<AllocationDescriptorGRPC&>(*(dp->allocation)).updateDistributedData(data);                                                
+                    dynamic_cast<AllocationDescriptorGRPC*>(dp->getAllocation(0))->updateDistributedData(data);                                                
                 }
             });
-            threads_vector.push_back(move(t));           
+            threads_vector.push_back(std::move(t));
         }
         for (auto &thread : threads_vector)
             thread.join();

--- a/src/runtime/distributed/coordinator/scheduling/LoadPartitioningDistributed.h
+++ b/src/runtime/distributed/coordinator/scheduling/LoadPartitioningDistributed.h
@@ -16,7 +16,8 @@
 
 #pragma once
 
-#include <runtime/local/context/DaphneContext.h>
+#include <runtime/local/context/DistributedContext.h>
+
 #include <runtime/local/datastructures/AllocationDescriptorGRPC.h>
 #include <runtime/local/datastructures/AllocationDescriptorMPI.h>
 #include <runtime/local/datastructures/Range.h>
@@ -64,7 +65,7 @@ public:
     // Each allocation descriptor might use a different constructor.
     // Here we provide the different implementations.
     // Another solution would be to make sure that every constructor is similar so this would not be needed.
-    static ALLOCATOR CreateAllocatorDescriptor(DaphneContext* ctx, const std::string &addr, const DistributedData &data) {
+    static ALLOCATOR CreateAllocatorDescriptor(DaphneContext* ctx, const std::string &addr, DistributedData& data) {
         if constexpr (std::is_same_v<ALLOCATOR, AllocationDescriptorMPI>)
             return AllocationDescriptorMPI(std::stoi(addr), ctx, data);
         else if constexpr (std::is_same_v<ALLOCATOR, AllocationDescriptorGRPC>)
@@ -86,7 +87,6 @@ public:
                     ((taskIndex + 1) * k + std::min(taskIndex + 1, m)) - ((taskIndex * k) + std::min(taskIndex, m)),
                     mat->getNumCols()
                 );
-                break;
             }
             case DistributionSchema::BROADCAST:
                 return Range(
@@ -95,7 +95,6 @@ public:
                     mat->getNumRows(),
                     mat->getNumCols()
                 );
-                break;
             default:
                 throw std::runtime_error("Unknown distribution scheme");
         }
@@ -122,24 +121,24 @@ public:
 
         DataPlacement *dp;
         if ((dp = mat->getMetaDataObject()->getDataPlacementByLocation(workerAddr))) {
-            auto data = dynamic_cast<ALLOCATOR&>(*(dp->allocation)).getDistributedData();
+            auto data = dynamic_cast<ALLOCATOR*>(dp->getAllocation(0))->getDistributedData();
 
             // Check if existing placement matches the same ranges we currently need
             if (data.isPlacedAtWorker) {
-                auto existingRange = dp->range.get();
+                auto existingRange = dp->getRange();
                 if (*existingRange == range)
                     data.isPlacedAtWorker = true;
                 else {
-                    mat->getMetaDataObject()->updateRangeDataPlacementByID(dp->dp_id, &range);
+                    mat->getMetaDataObject()->updateRangeDataPlacementByID(dp->getID(), &range);
                     data.isPlacedAtWorker = false;
                 }
             } else
-                mat->getMetaDataObject()->updateRangeDataPlacementByID(dp->dp_id, &range);
+                mat->getMetaDataObject()->updateRangeDataPlacementByID(dp->getID(), &range);
             // TODO Currently we do not support distributing/splitting
             // by columns. When we do, this should be changed (e.g. Index(0, taskIndex))
             // This can be decided based on DistributionSchema
             data.ix = GetDistributedIndex();
-            dynamic_cast<ALLOCATOR&>(*(dp->allocation)).updateDistributedData(data);
+            dynamic_cast<ALLOCATOR*>(dp->getAllocation(0))->updateDistributedData(data);
         }
         else { // Else, create new object metadata entry
             DistributedData data;
@@ -147,7 +146,9 @@ public:
             // by columns. When we do, this should be changed (e.g. Index(0, taskIndex))
             data.ix = GetDistributedIndex();
             auto allocationDescriptor = CreateAllocatorDescriptor(dctx, workerAddr, data);
-            dp = mat->getMetaDataObject()->addDataPlacement(&allocationDescriptor, &range);
+            std::vector<std::unique_ptr<IAllocationDescriptor>> allocations;
+            allocations.emplace_back(&allocationDescriptor);
+            dp = mat->getMetaDataObject()->addDataPlacement(allocations, &range);
         }
         taskIndex++;
         return dp;
@@ -214,13 +215,15 @@ public:
                 // If dp already exists for this worker, update the range and data
                 if (auto dp = (*outputs[i])->getMetaDataObject()->getDataPlacementByLocation(workerAddr))
                 {
-                    (*outputs[i])->getMetaDataObject()->updateRangeDataPlacementByID(dp->dp_id, &range);
-                    dynamic_cast<ALLOCATOR&>(*(dp->allocation)).updateDistributedData(data);
+                    (*outputs[i])->getMetaDataObject()->updateRangeDataPlacementByID(dp->getID(), &range);
+                    dynamic_cast<ALLOCATOR*>(dp->getAllocation(0))->updateDistributedData(data);
                 }
                 else
                 { // else create new dp entry
                     auto allocationDescriptor = CreateAllocatorDescriptor(dctx, workerAddr, data);
-                    ((*outputs[i]))->getMetaDataObject()->addDataPlacement(&allocationDescriptor, &range);
+                    std::vector<std::unique_ptr<IAllocationDescriptor>> allocations;
+                    allocations.emplace_back(&allocationDescriptor);
+                    ((*outputs[i]))->getMetaDataObject()->addDataPlacement(allocations, &range);
                 }
             }
         }

--- a/src/runtime/distributed/coordinator/scheduling/LoadPartitioningDistributed.h
+++ b/src/runtime/distributed/coordinator/scheduling/LoadPartitioningDistributed.h
@@ -18,10 +18,6 @@
 
 #include <runtime/local/context/DistributedContext.h>
 
-#include <runtime/local/datastructures/AllocationDescriptorGRPC.h>
-#include <runtime/local/datastructures/AllocationDescriptorMPI.h>
-#include <runtime/local/datastructures/Range.h>
-
 #include <vector>
 #include <string>
 #include <cassert>
@@ -65,11 +61,13 @@ public:
     // Each allocation descriptor might use a different constructor.
     // Here we provide the different implementations.
     // Another solution would be to make sure that every constructor is similar so this would not be needed.
-    static ALLOCATOR CreateAllocatorDescriptor(DaphneContext* ctx, const std::string &addr, DistributedData& data) {
+    static std::unique_ptr<ALLOCATOR> CreateAllocatorDescriptor(DaphneContext* ctx, const std::string &addr, DistributedData& data) {
         if constexpr (std::is_same_v<ALLOCATOR, AllocationDescriptorMPI>)
-            return AllocationDescriptorMPI(std::stoi(addr), ctx, data);
+//            return AllocationDescriptorMPI(std::stoi(addr), ctx, data);
+            return std::make_unique<AllocationDescriptorMPI>(std::stoi(addr), ctx, data);
         else if constexpr (std::is_same_v<ALLOCATOR, AllocationDescriptorGRPC>)
-            return AllocationDescriptorGRPC(ctx, addr, data);
+//            return AllocationDescriptorGRPC(ctx, addr, data);
+            return std::make_unique<AllocationDescriptorGRPC>(ctx, addr, data);
         else
             throw std::runtime_error("Unknown allocation type");
     }
@@ -147,7 +145,7 @@ public:
             data.ix = GetDistributedIndex();
             auto allocationDescriptor = CreateAllocatorDescriptor(dctx, workerAddr, data);
             std::vector<std::unique_ptr<IAllocationDescriptor>> allocations;
-            allocations.emplace_back(&allocationDescriptor);
+            allocations.emplace_back(std::move(allocationDescriptor));
             dp = mat->getMetaDataObject()->addDataPlacement(allocations, &range);
         }
         taskIndex++;
@@ -222,7 +220,7 @@ public:
                 { // else create new dp entry
                     auto allocationDescriptor = CreateAllocatorDescriptor(dctx, workerAddr, data);
                     std::vector<std::unique_ptr<IAllocationDescriptor>> allocations;
-                    allocations.emplace_back(&allocationDescriptor);
+                    allocations.emplace_back(std::move(allocationDescriptor));
                     ((*outputs[i]))->getMetaDataObject()->addDataPlacement(allocations, &range);
                 }
             }

--- a/src/runtime/distributed/worker/MPICoordinator.h
+++ b/src/runtime/distributed/worker/MPICoordinator.h
@@ -3,7 +3,6 @@
 
 #include <mpi.h>
 #include <runtime/local/datastructures/DenseMatrix.h>
-#include <runtime/distributed/worker/MPISerializer.h>
 #include <unistd.h>
 #include <iostream>
 #include <sstream>
@@ -15,7 +14,6 @@
 #include <ir/daphneir/Daphne.h>
 #include <mlir/InitAllDialects.h>
 #include <mlir/IR/AsmState.h>
-##include <mlir/Parser.h>
 #include <llvm/Support/SourceMgr.h>
 #include <mlir/IR/BuiltinTypes.h>
 
@@ -100,15 +98,14 @@ class MPICoordinator{
                 std::string addr= std::to_string(COORDINATOR);
                 // If dp already exists for this worker, update the range and data
                 if (auto dp = (*res[i])->getMetaDataObject()->getDataPlacementByLocation(addr)) { 
-                    (*res[i])->getMetaDataObject()->updateRangeDataPlacementByID(dp->dp_id, &range);
-                    dynamic_cast<AllocationDescriptorMPI&>(*(dp->allocation)).updateDistributedData(data);                    
+                    (*res[i])->getMetaDataObject()->updateRangeDataPlacementByID(dp->getID(), &range);
+                    dynamic_cast<AllocationDescriptorMPI*>(dp->getAllocation(0))->updateDistributedData(data);
                 }
                 else { // else create new dp entry   
-                    AllocationDescriptorMPI allocationDescriptor(
-                                            dctx,
-                                            COORDINATOR,
-                                            data);                                    
-                    ((*res[i]))->getMetaDataObject()->addDataPlacement(&allocationDescriptor, &range);                    
+                    AllocationDescriptorMPI allocationDescriptor(COORDINATOR, dctx, data);
+                    std::vector<std::unique_ptr<IAllocationDescriptor>> allocations;
+                    allocations.emplace_back(&allocationDescriptor);
+                    ((*res[i]))->getMetaDataObject()->addDataPlacement(allocations, &range);
                 } 
             }
             //solver.Compute(&outputsStoredInfo, inputsStoredInfo, mlirCode);

--- a/src/runtime/local/context/CUDAContext.cpp
+++ b/src/runtime/local/context/CUDAContext.cpp
@@ -50,7 +50,6 @@ void CUDAContext::init() {
 
     logger->info("Using CUDA device {}: {}\n\tAvailable mem: {} Total mem: {} using {}% -> {}", device_id,
             device_properties.name, available, total, mem_usage * 100, mem_budget);
-
     CHECK_CUBLAS(cublasCreate(&cublas_handle));
     CHECK_CUSPARSE(cusparseCreate(&cusparse_handle));
     CHECK_CUDNN(cudnnCreate(&cudnn_handle));
@@ -67,7 +66,6 @@ void CUDAContext::init() {
     CHECK_CUSOLVER(cusolverDnSetStream(cusolver_handle, cusolver_stream));
 
     getCUDNNWorkspace(64 * 1024 * 1024);
-
 //    CHECK_CUBLAS(cublasLtCreate(&cublaslt_Handle));
 //    CHECK_CUDART(cudaMalloc(&cublas_workspace, cublas_workspace_size));
 }
@@ -145,6 +143,6 @@ void CUDAContext::free(size_t id) {
     allocations.erase(id);
 }
 
-int CUDAContext::getMaxNumThreads() {
+int CUDAContext::getMaxNumThreads() const {
     return device_properties.maxThreadsPerBlock;
 }

--- a/src/runtime/local/context/CUDAContext.h
+++ b/src/runtime/local/context/CUDAContext.h
@@ -79,7 +79,7 @@ public:
     void* getCUDNNWorkspace(size_t size);
 
     [[nodiscard]] size_t getMemBudget() const { return mem_budget; }
-    int getMaxNumThreads();
+    int getMaxNumThreads() const;
     static CUDAContext* get(DaphneContext* ctx, size_t id) { return dynamic_cast<CUDAContext*>(ctx->getCUDAContext(id)); }
 
     std::shared_ptr<std::byte> malloc(size_t size, bool zero, size_t& id);

--- a/src/runtime/local/context/DistributedContext.h
+++ b/src/runtime/local/context/DistributedContext.h
@@ -17,6 +17,8 @@
 #pragma once
 
 #include <runtime/local/context/DaphneContext.h>
+#include <runtime/local/datastructures/AllocationDescriptorGRPC.h>
+#include <runtime/local/datastructures/AllocationDescriptorMPI.h>
 #ifdef USE_MPI
     #include <runtime/distributed/worker/MPIHelper.h>
 #endif 

--- a/src/runtime/local/datastructures/AllocationDescriptorCUDA.h
+++ b/src/runtime/local/datastructures/AllocationDescriptorCUDA.h
@@ -28,8 +28,6 @@ class AllocationDescriptorCUDA : public IAllocationDescriptor {
     size_t alloc_id{};
 
 public:
-    AllocationDescriptorCUDA() = delete;
-
     AllocationDescriptorCUDA(DaphneContext* ctx, uint32_t device_id) : device_id(device_id), dctx(ctx) { }
 
     ~AllocationDescriptorCUDA() override {
@@ -44,9 +42,12 @@ public:
     // [[nodiscard]] uint32_t getLocation() const { return device_id; }
     [[nodiscard]] std::string getLocation() const override { return std::to_string(device_id); }
 
-    void createAllocation(size_t size, bool zero) override {
+    [[nodiscard]] std::unique_ptr<IAllocationDescriptor>  createAllocation(size_t size, bool zero) const override {
+        auto new_alloc = std::make_unique<AllocationDescriptorCUDA>(dctx, device_id);
         auto ctx = CUDAContext::get(dctx, device_id);
-        data = ctx->malloc(size, zero, alloc_id);
+        new_alloc->data = ctx->malloc(size, zero, new_alloc->alloc_id);
+        new_alloc->size = size;
+        return new_alloc;
     }
 
     std::shared_ptr<std::byte> getData() override { return data; }

--- a/src/runtime/local/datastructures/AllocationDescriptorGRPC.h
+++ b/src/runtime/local/datastructures/AllocationDescriptorGRPC.h
@@ -41,7 +41,7 @@ public:
     
     std::string getLocation() const override 
     {return workerAddress; };
-    void createAllocation(size_t size, bool zero) override {}
+    [[nodiscard]] std::unique_ptr<IAllocationDescriptor>  createAllocation(size_t size, bool zero) const override {}
     // TODO: Implement transferTo and transferFrom functions
     std::shared_ptr<std::byte> getData() override { 
         throw std::runtime_error("TransferTo/From functions are not implemented yet.");

--- a/src/runtime/local/datastructures/AllocationDescriptorGRPC.h
+++ b/src/runtime/local/datastructures/AllocationDescriptorGRPC.h
@@ -24,7 +24,7 @@
 
 class AllocationDescriptorGRPC : public IAllocationDescriptor {
 private:
-    DaphneContext *ctx;
+    [[maybe_unused]] DaphneContext *ctx;
     ALLOCATION_TYPE type = ALLOCATION_TYPE::DIST_GRPC;
     const std::string workerAddress;
     DistributedData distributedData;
@@ -41,7 +41,10 @@ public:
     
     std::string getLocation() const override 
     {return workerAddress; };
-    [[nodiscard]] std::unique_ptr<IAllocationDescriptor>  createAllocation(size_t size, bool zero) const override {}
+    [[nodiscard]] std::unique_ptr<IAllocationDescriptor>  createAllocation(size_t size, bool zero) const override {
+        /* TODO */
+        throw std::runtime_error("AllocationDescriptorGRPC::createAllocation not implemented");
+    }
     // TODO: Implement transferTo and transferFrom functions
     std::shared_ptr<std::byte> getData() override { 
         throw std::runtime_error("TransferTo/From functions are not implemented yet.");

--- a/src/runtime/local/datastructures/AllocationDescriptorGRPC.h
+++ b/src/runtime/local/datastructures/AllocationDescriptorGRPC.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include "DataPlacement.h"
+
 #include <runtime/local/context/DaphneContext.h>
 #include <runtime/local/datastructures/Structure.h>
 #include <ir/daphneir/Daphne.h>
@@ -23,8 +25,7 @@
 #include <runtime/local/datastructures/DistributedAllocationHelpers.h>
 
 class AllocationDescriptorGRPC : public IAllocationDescriptor {
-private:
-    [[maybe_unused]] DaphneContext *ctx;
+    DaphneContext *ctx;
     ALLOCATION_TYPE type = ALLOCATION_TYPE::DIST_GRPC;
     const std::string workerAddress;
     DistributedData distributedData;

--- a/src/runtime/local/datastructures/AllocationDescriptorHost.h
+++ b/src/runtime/local/datastructures/AllocationDescriptorHost.h
@@ -18,6 +18,7 @@
 
 #include "DataPlacement.h"
 #include <memory>
+#include <utility>
 
 class AllocationDescriptorHost : public IAllocationDescriptor {
     ALLOCATION_TYPE type = ALLOCATION_TYPE::HOST;
@@ -25,15 +26,41 @@ class AllocationDescriptorHost : public IAllocationDescriptor {
 
 public:
     ~AllocationDescriptorHost() override = default;
+
     [[nodiscard]] ALLOCATION_TYPE getType() const override { return type; }
-    void createAllocation(size_t size, bool zero) override { }
-    std::string getLocation() const override 
-    { return "Host"; }
+
+    static std::unique_ptr<AllocationDescriptorHost> createHostAllocation(std::shared_ptr<std::byte> data, size_t size,
+            bool zero) {
+        auto new_alloc = std::make_unique<AllocationDescriptorHost>();
+        new_alloc->data = std::move(data);
+        new_alloc->size = size;
+        if(zero)
+            memset(new_alloc->data.get(), 0, size);
+        return new_alloc;
+    }
+
+    [[nodiscard]] std::unique_ptr<IAllocationDescriptor> createAllocation(size_t size, bool zero) const override {
+        auto new_alloc = std::make_unique<AllocationDescriptorHost>();
+        new_alloc->size = size;
+        new_alloc->data = std::shared_ptr<std::byte>(new std::byte[size], std::default_delete<std::byte[]>());
+
+        if(zero)
+            memset(new_alloc->data.get(), 0, size);
+
+        return new_alloc;
+    }
+
+    [[nodiscard]] std::string getLocation() const override { return "Host"; }
+
     std::shared_ptr<std::byte> getData() override { return data; }
+
+    void setData(std::shared_ptr<std::byte>& _data) { data = _data; }
+
     void transferTo(std::byte* src, size_t size) override { }
     void transferFrom(std::byte* dst, size_t size) override {}
     [[nodiscard]] std::unique_ptr<IAllocationDescriptor> clone() const override {
         return std::make_unique<AllocationDescriptorHost>(*this);
     }
+
     bool operator==(const IAllocationDescriptor* other) const override { return (getType() == other->getType()); }
 };

--- a/src/runtime/local/datastructures/AllocationDescriptorMPI.h
+++ b/src/runtime/local/datastructures/AllocationDescriptorMPI.h
@@ -26,27 +26,24 @@
 
 class AllocationDescriptorMPI : public IAllocationDescriptor {
     ALLOCATION_TYPE type = ALLOCATION_TYPE::DIST_MPI;
-    int processRankID;
-    DaphneContext* ctx;
+    int processRankID{};
+    DaphneContext* ctx{};
     DistributedData distributedData;
     std::shared_ptr<std::byte> data;
 
 public:
-    AllocationDescriptorMPI() {} ;
-    AllocationDescriptorMPI(int id,
-                            DaphneContext* ctx, 
-                            DistributedData data) :  processRankID(id), ctx(ctx), distributedData(data) {} ;
+    AllocationDescriptorMPI() = default;
+    AllocationDescriptorMPI(int id, DaphneContext* ctx, DistributedData& data) :  processRankID(id), ctx(ctx),
+            distributedData(data) {}
 
-    ~AllocationDescriptorMPI() override {};
+    ~AllocationDescriptorMPI() override = default;
 
-    [[nodiscard]] ALLOCATION_TYPE getType() const override 
-    { return type; };
+    [[nodiscard]] ALLOCATION_TYPE getType() const override { return type; };
     
-    std::string getLocation() const override {
-        return std::to_string(processRankID); 
-    };
-    
-    void createAllocation(size_t size, bool zero) override {} ;
+    [[nodiscard]] std::string getLocation() const override { return std::to_string(processRankID); };
+
+    [[nodiscard]] std::unique_ptr<IAllocationDescriptor>  createAllocation(size_t size, bool zero) const override {}
+
     std::shared_ptr<std::byte> getData() override {return nullptr;} ;
 
     bool operator==(const IAllocationDescriptor* other) const override {
@@ -62,14 +59,13 @@ public:
     void transferTo(std::byte *src, size_t size) override { /* TODO */ };
     void transferFrom(std::byte *src, size_t size) override { /* TODO */ };
 
-    const DistributedIndex getDistributedIndex()
-    { return distributedData.ix; }    
-    const DistributedData getDistributedData()
-    { return distributedData; }
-    void updateDistributedData(DistributedData data_)
-    { distributedData = data_; }
-    int getRank()
-    { return processRankID; }
+    DistributedIndex getDistributedIndex() const { return distributedData.ix; }
+
+    DistributedData getDistributedData() { return distributedData; }
+
+    void updateDistributedData(DistributedData& data_) { distributedData = data_; }
+
+    int getRank() const { return processRankID; }
 };
 
 #endif //SRC_RUNTIME_LOCAL_DATASTRUCTURE_ALLOCATION_DESCRIPTORMPH_H

--- a/src/runtime/local/datastructures/AllocationDescriptorMPI.h
+++ b/src/runtime/local/datastructures/AllocationDescriptorMPI.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef SRC_RUNTIME_LOCAL_DATASTRUCTURE_ALLOCATION_DESCRIPTORMPH_H
-#define SRC_RUNTIME_LOCAL_DATASTRUCTURE_ALLOCATION_DESCRIPTORMPH_H
+#pragma once
 
 #include <runtime/local/context/DaphneContext.h>
 #include <runtime/local/datastructures/Structure.h>
@@ -27,7 +26,7 @@
 class AllocationDescriptorMPI : public IAllocationDescriptor {
     ALLOCATION_TYPE type = ALLOCATION_TYPE::DIST_MPI;
     int processRankID{};
-    DaphneContext* ctx{};
+    [[maybe_unused]] DaphneContext* ctx{};
     DistributedData distributedData;
     std::shared_ptr<std::byte> data;
 
@@ -42,7 +41,10 @@ public:
     
     [[nodiscard]] std::string getLocation() const override { return std::to_string(processRankID); };
 
-    [[nodiscard]] std::unique_ptr<IAllocationDescriptor>  createAllocation(size_t size, bool zero) const override {}
+    [[nodiscard]] std::unique_ptr<IAllocationDescriptor>  createAllocation(size_t size, bool zero) const override {
+        /* TODO */
+        throw std::runtime_error("AllocationDescriptorGRPC::createAllocation not implemented");
+    }
 
     std::shared_ptr<std::byte> getData() override {return nullptr;} ;
 
@@ -59,13 +61,11 @@ public:
     void transferTo(std::byte *src, size_t size) override { /* TODO */ };
     void transferFrom(std::byte *src, size_t size) override { /* TODO */ };
 
-    DistributedIndex getDistributedIndex() const { return distributedData.ix; }
+    [[maybe_unused]] [[nodiscard]] DistributedIndex getDistributedIndex() const { return distributedData.ix; }
 
     DistributedData getDistributedData() { return distributedData; }
 
     void updateDistributedData(DistributedData& data_) { distributedData = data_; }
 
-    int getRank() const { return processRankID; }
+    [[nodiscard]] int getRank() const { return processRankID; }
 };
-
-#endif //SRC_RUNTIME_LOCAL_DATASTRUCTURE_ALLOCATION_DESCRIPTORMPH_H

--- a/src/runtime/local/datastructures/CSRMatrix.cpp
+++ b/src/runtime/local/datastructures/CSRMatrix.cpp
@@ -19,6 +19,54 @@
 #include "CSRMatrix.h"
 
 template<typename ValueType>
+CSRMatrix<ValueType>::CSRMatrix(size_t maxNumRows, size_t numCols, size_t maxNumNonZeros, bool zero, IAllocationDescriptor* allocInfo) :
+        Matrix<ValueType>(maxNumRows, numCols), numRowsAllocated(maxNumRows), isRowAllocatedBefore(false),
+        is_view(false), maxNumNonZeros(maxNumNonZeros), lastAppendedRowIdx(0) {
+    auto val_buf_size = maxNumNonZeros * sizeof(ValueType);
+    auto cidx_buf_size = maxNumNonZeros * sizeof(size_t);
+    auto rptr_buf_size = (numRows + 1) * sizeof(size_t);
+
+    std::unique_ptr<IAllocationDescriptor> val_alloc;
+    std::unique_ptr<IAllocationDescriptor> cidx_alloc;
+    std::unique_ptr<IAllocationDescriptor> rptr_alloc;
+
+    if(!allocInfo) {
+        values = std::shared_ptr<ValueType>(new ValueType[maxNumNonZeros], std::default_delete<ValueType[]>());
+        auto bytes = std::reinterpret_pointer_cast<std::byte>(values);
+        val_alloc = AllocationDescriptorHost::createHostAllocation(bytes, val_buf_size, zero);
+        colIdxs = std::shared_ptr<size_t>(new size_t[maxNumNonZeros], std::default_delete<size_t[]>());
+        bytes = std::reinterpret_pointer_cast<std::byte>(colIdxs);
+        cidx_alloc = AllocationDescriptorHost::createHostAllocation(bytes, cidx_buf_size, zero);
+        rowOffsets = std::shared_ptr<size_t>(new size_t[numRows + 1], std::default_delete<size_t[]>());
+        bytes = std::reinterpret_pointer_cast<std::byte>(rowOffsets);
+        rptr_alloc = AllocationDescriptorHost::createHostAllocation(bytes, rptr_buf_size, zero);
+    }
+    else {
+        val_alloc = allocInfo->createAllocation(val_buf_size, zero);
+        cidx_alloc = allocInfo->createAllocation(cidx_buf_size, zero);
+        rptr_alloc = allocInfo->createAllocation(rptr_buf_size, zero);
+
+        // ToDo: refactor data storage into memory management
+        if(allocInfo->getType() == ALLOCATION_TYPE::HOST) {
+            values = std::reinterpret_pointer_cast<ValueType>(val_alloc->getData());
+            colIdxs = std::reinterpret_pointer_cast<size_t>(cidx_alloc->getData());
+            rowOffsets = std::reinterpret_pointer_cast<size_t>(rptr_alloc->getData());
+        }
+    }
+
+    spdlog::debug("Creating {} x {} sparse matrix of type: {}. Required memory: vals={}, cidxs={}, rptrs={}, total={} Mb", numRows, numCols,
+                  val_alloc->getTypeName(), static_cast<float>(val_buf_size) / (1048576), static_cast<float>(cidx_buf_size) / (1048576),
+                  static_cast<float>(rptr_buf_size) / (1048576), static_cast<float>(val_buf_size + cidx_buf_size + rptr_buf_size) / (1048576));
+
+    std::vector<std::unique_ptr<IAllocationDescriptor>> allocations;
+    allocations.emplace_back(std::move(val_alloc));
+    allocations.emplace_back(std::move(cidx_alloc));
+    allocations.emplace_back(std::move(rptr_alloc));
+    auto p = this->mdo->addDataPlacement(allocations);
+    this->mdo->addLatest(p->getID());
+}
+
+template<typename ValueType>
 size_t CSRMatrix<ValueType>::serialize(std::vector<char> &buf) const {
     return DaphneSerializer<CSRMatrix<ValueType>>::serialize(this, buf);
 }

--- a/src/runtime/local/datastructures/CSRMatrix.h
+++ b/src/runtime/local/datastructures/CSRMatrix.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <runtime/local/datastructures/AllocationDescriptorHost.h>
 #include <runtime/local/datastructures/DataObjectFactory.h>
 #include <runtime/local/datastructures/Matrix.h>
 #include <runtime/local/datastructures/ValueTypeUtils.h>
@@ -60,7 +61,9 @@ class CSRMatrix : public Matrix<ValueType> {
     size_t numRowsAllocated;
     
     bool isRowAllocatedBefore;
-    
+
+    const bool is_view;
+
     /**
      * @brief The maximum number of non-zero values this matrix was allocated
      * to accommodate.
@@ -91,23 +94,8 @@ class CSRMatrix : public Matrix<ValueType> {
      * @param zero Whether the allocated memory of the internal arrays shall be
      * initialized to zeros (`true`), or be left uninitialized (`false`).
      */
-    CSRMatrix(size_t maxNumRows, size_t numCols, size_t maxNumNonZeros, bool zero) : 
-            Matrix<ValueType>(maxNumRows, numCols),
-            numRowsAllocated(maxNumRows),
-            isRowAllocatedBefore(false),
-            maxNumNonZeros(maxNumNonZeros),
-            values(new ValueType[maxNumNonZeros], std::default_delete<ValueType[]>()),
-            colIdxs(new size_t[maxNumNonZeros], std::default_delete<size_t[]>()),
-            rowOffsets(new size_t[numRows + 1], std::default_delete<size_t[]>()),
-            lastAppendedRowIdx(0)
-    {
-        if(zero) {
-            memset(values.get(), 0, maxNumNonZeros * sizeof(ValueType));
-            memset(colIdxs.get(), 0, maxNumNonZeros * sizeof(size_t));
-            memset(rowOffsets.get(), 0, (numRows + 1) * sizeof(size_t));
-        }
-    }
-    
+    CSRMatrix(size_t maxNumRows, size_t numCols, size_t maxNumNonZeros, bool zero, IAllocationDescriptor* allocInfo = nullptr);
+
     /**
      * @brief Creates a `CSRMatrix` around a sub-matrix of another `CSRMatrix`
      * without copying the data.
@@ -120,22 +108,25 @@ class CSRMatrix : public Matrix<ValueType> {
             Matrix<ValueType>(rowUpperExcl - rowLowerIncl, src->numCols),
             numRowsAllocated(src->numRowsAllocated - rowLowerIncl),
             isRowAllocatedBefore(rowLowerIncl > 0),
-            lastAppendedRowIdx(0)
+            is_view(true), lastAppendedRowIdx(0)
     {
         assert(src && "src must not be null");
         assert((rowLowerIncl < src->numRows) && "rowLowerIncl is out of bounds");
         assert((rowUpperExcl <= src->numRows) && "rowUpperExcl is out of bounds");
         assert((rowLowerIncl < rowUpperExcl) && "rowLowerIncl must be lower than rowUpperExcl");
-        
+
+        this->row_offset = rowLowerIncl;
         maxNumNonZeros = src->maxNumNonZeros;
         values = src->values;
         colIdxs = src->colIdxs;
         rowOffsets = std::shared_ptr<size_t>(src->rowOffsets, src->rowOffsets.get() + rowLowerIncl);
+        //ToDo: temporary fix to directly assign mdo
+        this->mdo = src->mdo;
     }
-    
-    virtual ~CSRMatrix() {
-        // nothing to do
-    }
+
+    [[nodiscard]] size_t offset() const { return this->row_offset; }
+
+    virtual ~CSRMatrix() = default;
     
     void fillNextPosUntil(size_t nextPos, size_t rowIdx) {
         if(rowIdx > lastAppendedRowIdx) {
@@ -156,74 +147,81 @@ public:
         this->numRows = numRows;
     }
     
-    size_t getMaxNumNonZeros() const {
+    [[nodiscard]] size_t getMaxNumNonZeros() const {
         return maxNumNonZeros;
     }
-    size_t getNumNonZeros() const {
-        return rowOffsets.get()[numRows] - rowOffsets.get()[0];
+    [[nodiscard]] size_t getNumNonZeros() const {
+        return getRowOffsets()[numRows] - getRowOffsets()[0];
     }
     
-    size_t getNumNonZeros(size_t rowIdx) const {
+    [[nodiscard]] size_t getNumNonZeros(size_t rowIdx) const {
         assert((rowIdx < numRows) && "rowIdx is out of bounds");
-        return rowOffsets.get()[rowIdx + 1] - rowOffsets.get()[rowIdx];
+        auto roff = getRowOffsets();
+        auto rownext = roff[rowIdx+1];
+        auto row = roff[rowIdx];
+        return  rownext - row;
     }
-    
+
     void shrinkNumNonZeros(size_t numNonZeros) {
         assert((numNonZeros <= getNumNonZeros()) && "numNonZeros can only be shrinked");
         // TODO Here we could reduce the allocated size of the values and
         // colIdxs arrays.
     }
 
-    ValueType * getValues() {
-        return values.get();
+    ValueType* getValues(const IAllocationDescriptor* alloc_desc = nullptr, const Range* range = nullptr) {
+        return  reinterpret_cast<ValueType*>(this->mdo->getData(0, alloc_desc, range));
     }
-    
-    const ValueType * getValues() const {
-        return values.get();
+
+    const ValueType* getValues(const IAllocationDescriptor* alloc_desc = nullptr, const Range* range = nullptr) const {
+        return  reinterpret_cast<const ValueType*>(this->mdo->getData(0, alloc_desc, range));
     }
-    
-    ValueType * getValues(size_t rowIdx) {
+
+    ValueType* getRowValues(size_t rowIdx, const IAllocationDescriptor* alloc_desc = nullptr, const Range* range = nullptr) {
         // We allow equality here to enable retrieving a pointer to the end.
         assert((rowIdx <= numRows) && "rowIdx is out of bounds");
-        return values.get() + rowOffsets.get()[rowIdx];
+        return &(reinterpret_cast<ValueType*>(getValues(alloc_desc, range))[getRowOffsets()[rowIdx]]);
+    }
+
+    const ValueType* getRowValues(size_t rowIdx, const IAllocationDescriptor* alloc_desc = nullptr, const Range* range = nullptr) const {
+        return &(reinterpret_cast<const ValueType*>(getValues(alloc_desc, range))[getRowOffsets()[rowIdx]]);
     }
     
-    const ValueType * getValues(size_t rowIdx) const {
-        return const_cast<CSRMatrix<ValueType> *>(this)->getValues(rowIdx);
+    size_t* getColIdxs(const IAllocationDescriptor* alloc_desc = nullptr, const Range* range = nullptr) {
+        return reinterpret_cast<size_t*>(this->mdo->getData(1, alloc_desc, range));
     }
     
-    size_t * getColIdxs() {
-        return colIdxs.get();
+    const size_t* getColIdxs(const IAllocationDescriptor* alloc_desc = nullptr, const Range* range = nullptr) const {
+        return reinterpret_cast<const size_t*>(this->mdo->getData(1, alloc_desc, range));
     }
     
-    const size_t * getColIdxs() const {
-        return colIdxs.get();
-    }
-    
-    size_t * getColIdxs(size_t rowIdx) {
+    size_t* getColIdxsOfRow(size_t rowIdx, const IAllocationDescriptor* alloc_desc = nullptr, const Range* range = nullptr) {
         // We allow equality here to enable retrieving a pointer to the end.
         assert((rowIdx <= numRows) && "rowIdx is out of bounds");
-        return colIdxs.get() + rowOffsets.get()[rowIdx];
+        auto data = this->mdo->getData(1, alloc_desc, range);
+        return &(reinterpret_cast<size_t*>(data)[getRowOffsets()[rowIdx]]);
     }
 
-    const size_t * getColIdxs(size_t rowIdx) const {
-        return const_cast<CSRMatrix<ValueType> *>(this)->getColIdxs(rowIdx);
+    const size_t* getColIdxsOfRow(size_t rowIdx, const IAllocationDescriptor* alloc_desc = nullptr, const Range* range = nullptr) const {
+        auto data = this->mdo->getData(1, alloc_desc, range);
+        return &(reinterpret_cast<const size_t*>(data)[getRowOffsets()[rowIdx]]);
     }
 
-    size_t * getRowOffsets() {
-        return rowOffsets.get();
+    size_t* getRowOffsets(const IAllocationDescriptor* alloc_desc = nullptr, const Range* range = nullptr) {
+        auto ptr = reinterpret_cast<size_t*>(this->mdo->getData(2, alloc_desc, range));
+        return ptr + offset();
     }
 
-    const size_t * getRowOffsets() const {
-        return rowOffsets.get();
+    const size_t* getRowOffsets(const IAllocationDescriptor* alloc_desc = nullptr, const Range* range = nullptr) const {
+        auto ptr = reinterpret_cast<const size_t*>(this->mdo->getData(2, alloc_desc, range));
+        return ptr + offset();
     }
 
     ValueType get(size_t rowIdx, size_t colIdx) const override {
         assert((rowIdx < numRows) && "rowIdx is out of bounds");
         assert((colIdx < numCols) && "colIdx is out of bounds");
         
-        const size_t * rowColIdxsBeg = getColIdxs(rowIdx);
-        const size_t * rowColIdxsEnd = getColIdxs(rowIdx + 1);
+        const size_t * rowColIdxsBeg = getColIdxsOfRow(rowIdx);
+        const size_t * rowColIdxsEnd = getColIdxsOfRow(rowIdx + 1);
         const size_t * ptrExpected = std::lower_bound(rowColIdxsBeg, rowColIdxsEnd, colIdx);
 
         if(ptrExpected == rowColIdxsEnd || *ptrExpected != colIdx)
@@ -231,20 +229,20 @@ public:
             return ValueType(0);
         else
             // Entry for the given coordinates present.
-            return getValues(rowIdx)[ptrExpected - rowColIdxsBeg];
+            return getRowValues(rowIdx)[ptrExpected - rowColIdxsBeg];
     }
     
     void set(size_t rowIdx, size_t colIdx, ValueType value) override {
         assert((rowIdx < numRows) && "rowIdx is out of bounds");
         assert((colIdx < numCols) && "colIdx is out of bounds");
         
-        size_t * rowColIdxsBeg = getColIdxs(rowIdx);
-        size_t * rowColIdxsEnd = getColIdxs(rowIdx + 1);
+        size_t * rowColIdxsBeg = getColIdxsOfRow(rowIdx);
+        size_t * rowColIdxsEnd = getColIdxsOfRow(rowIdx + 1);
         const size_t * ptrExpected = std::lower_bound(rowColIdxsBeg, rowColIdxsEnd, colIdx);
         const size_t posExpected = ptrExpected - rowColIdxsBeg;
         
         const size_t posEnd = colIdxs.get() + rowOffsets.get()[numRowsAllocated] - rowColIdxsBeg;
-        ValueType * rowValuesBeg = getValues(rowIdx);
+        ValueType * rowValuesBeg = getRowValues(rowIdx);
         
         if(ptrExpected == rowColIdxsEnd || *ptrExpected != colIdx) {
             // No entry for the given coordinates present.
@@ -318,8 +316,9 @@ public:
         fillNextPosUntil(rowOffsets.get()[lastAppendedRowIdx + 1], numRows - 1);
     }
 
-    bool isView() const {
-        return (numRowsAllocated > numRows || isRowAllocatedBefore);
+    [[nodiscard]] bool isView() const {
+//        return (numRowsAllocated > numRows || isRowAllocatedBefore);
+        return is_view;
     }
     
     void printValue(std::ostream & os, ValueType val) const {
@@ -335,12 +334,12 @@ public:
                 << ValueTypeUtils::cppNameFor<ValueType> << ')' << std::endl;
         // Note that, in general, the values within one row might not be sorted
         // by column index. Thus, the following is a little complicated.
-        ValueType * oneRow = new ValueType[numCols];
+        auto oneRow = new ValueType[numCols];
         for (size_t r = 0; r < numRows; r++) {
             memset(oneRow, 0, numCols * sizeof(ValueType));
             const size_t rowNumNonZeros = getNumNonZeros(r);
-            const size_t * rowColIdxs = getColIdxs(r);
-            const ValueType * rowValues = getValues(r);
+            const size_t* rowColIdxs = getColIdxsOfRow(r);
+            const ValueType* rowValues = getRowValues(r);
             for(size_t i = 0; i < rowNumNonZeros; i++)
                 oneRow[rowColIdxs[i]] = rowValues[i];
             for(size_t c = 0; c < numCols; c++) {
@@ -412,10 +411,10 @@ public:
         if(numRows != rhs.getNumRows() || numCols != rhs.getNumCols())
             return false;
         
-        const ValueType * valuesBegLhs = this->getValues(0);
-        const ValueType * valuesEndLhs = this->getValues(numRows);
-        const ValueType * valuesBegRhs = rhs.getValues(0);
-        const ValueType * valuesEndRhs = rhs.getValues(numRows);
+        const ValueType * valuesBegLhs = this->getRowValues(0);
+        const ValueType * valuesEndLhs = this->getRowValues(numRows);
+        const ValueType * valuesBegRhs = rhs.getRowValues(0);
+        const ValueType * valuesEndRhs = rhs.getRowValues(numRows);
         
         const size_t nnzLhs = valuesEndLhs - valuesBegLhs;
         const size_t nnzRhs = valuesEndRhs - valuesBegRhs;
@@ -431,7 +430,7 @@ public:
         const size_t * colIdxsBegRhs = rhs.getColIdxs(0);
         
         if(colIdxsBegLhs != colIdxsBegRhs)
-            if(memcmp(colIdxsBegLhs, colIdxsBegRhs, nnzLhs * sizeof(size_t)))
+            if(memcmp(colIdxsBegLhs, colIdxsBegRhs, nnzLhs * sizeof(size_t)) != 0)
                 return false;
         
         return true;

--- a/src/runtime/local/datastructures/DataPlacement.h
+++ b/src/runtime/local/datastructures/DataPlacement.h
@@ -23,20 +23,33 @@
 #include <atomic>
 
 /**
- * The DataPlacement struct binds an allocation descriptor to a range description and stores an ID of
+ * The DataPlacement struct binds allocation descriptors to a range description and stores an ID of
  * an instantiated object.
+ *
+ * The number of allocations varys depending on the data type (1 allocation of values of a dense matrix
+ * three allocations for values/col_idxs/row_ptrs of a CSR matrix)
  */
-struct DataPlacement {
+class DataPlacement {
     size_t dp_id;
 
     // used to generate object IDs
     static std::atomic_size_t instance_count;
     
-    std::unique_ptr<IAllocationDescriptor> allocation{};
+    std::vector<std::unique_ptr<IAllocationDescriptor>> allocations{};
 
     std::unique_ptr<Range> range{};
 
+public:
     DataPlacement() = delete;
-    DataPlacement(std::unique_ptr<IAllocationDescriptor> _a, std::unique_ptr<Range> _r) : dp_id(instance_count++),
-            allocation(std::move(_a)), range(std::move(_r)) { }
+    DataPlacement(std::vector<std::unique_ptr<IAllocationDescriptor>> _a, std::unique_ptr<Range> _r) :
+            dp_id(instance_count++), allocations(std::move(_a)), range(std::move(_r)) { }
+
+    [[nodiscard]] size_t getID() const {return dp_id;}
+    std::string getLocation() { return allocations.front()->getLocation(); }
+    Range* getRange() { return range.get(); }
+    void setRange(Range* r) { range.reset(r); }
+    void setRange(std::unique_ptr<Range> r) { range = std::move(r); }
+    uint32_t getNumAllocations() { return allocations.size(); }
+    IAllocationDescriptor* getAllocation(uint32_t num) { return allocations[num].get(); }
+
 };

--- a/src/runtime/local/datastructures/DenseMatrix.cpp
+++ b/src/runtime/local/datastructures/DenseMatrix.cpp
@@ -60,165 +60,75 @@ DenseMatrix<ValueType>::DenseMatrix(size_t maxNumRows, size_t numCols, bool zero
         Matrix<ValueType>(maxNumRows, numCols), is_view(false), rowSkip(numCols),
         bufferSize(numRows*numCols*sizeof(ValueType)), lastAppendedRowIdx(0), lastAppendedColIdx(0)
 {
-    DataPlacement* new_data_placement;
-    if(allocInfo != nullptr) {
-        spdlog::debug("Creating {} x {} dense matrix of type: {}. Required memory: {} Mb",
-                numRows, numCols, static_cast<int>(allocInfo->getType()),
-                static_cast<float>(getBufferSize()) / (1048576));
-
-        new_data_placement = this->mdo->addDataPlacement(allocInfo);
-        new_data_placement->allocation->createAllocation(getBufferSize(), zero);
+    std::unique_ptr<IAllocationDescriptor> val_alloc;
+    if(!allocInfo) {
+        alloc_shared_values(zero);
+        auto bytes = std::reinterpret_pointer_cast<std::byte>(values);
+        val_alloc = AllocationDescriptorHost::createHostAllocation(bytes, getBufferSize(), zero);
     }
     else {
-        AllocationDescriptorHost myHostAllocInfo;
-        alloc_shared_values();
-        if(zero)
-            memset(values.get(), 0, maxNumRows * numCols * sizeof(ValueType));
-        new_data_placement = this->mdo->addDataPlacement(&myHostAllocInfo);
+        val_alloc = allocInfo->createAllocation(getBufferSize(), zero);
+
+        // ToDo: refactor data storage into memory management
+        if(allocInfo->getType() == ALLOCATION_TYPE::HOST) {
+            alloc_shared_values(zero);
+
+            auto bytes = std::reinterpret_pointer_cast<std::byte>(values);
+            dynamic_cast<AllocationDescriptorHost *>(val_alloc.get())->setData(bytes);
+        }
     }
-    this->mdo->addLatest(new_data_placement->dp_id);
+    spdlog::debug("Creating {} x {} dense matrix of type: {}. Required memory: {} Mb", numRows, numCols,
+            val_alloc->getTypeName(), static_cast<float>(getBufferSize()) / (1048576));
+
+    std::vector<std::unique_ptr<IAllocationDescriptor>> allocations;
+    allocations.emplace_back(std::move(val_alloc));
+    auto p = this->mdo->addDataPlacement(allocations);
+    this->mdo->addLatest(p->getID());
 }
 
 template<typename ValueType>
 DenseMatrix<ValueType>::DenseMatrix(size_t numRows, size_t numCols, std::shared_ptr<ValueType[]>& values) :
         Matrix<ValueType>(numRows, numCols), is_view(false), rowSkip(numCols), values(values),
         bufferSize(numRows*numCols*sizeof(ValueType)), lastAppendedRowIdx(0), lastAppendedColIdx(0)  {
-    AllocationDescriptorHost myHostAllocInfo;
-    DataPlacement* new_data_placement = this->mdo->addDataPlacement(&myHostAllocInfo);
-    this->mdo->addLatest(new_data_placement->dp_id);
+    auto bytes = std::reinterpret_pointer_cast<std::byte>(values);
+
+    std::vector<std::unique_ptr<IAllocationDescriptor>> allocations;
+    auto vec_alloc = AllocationDescriptorHost::createHostAllocation(bytes, getBufferSize(), false);
+    allocations.emplace_back(std::move(vec_alloc));
+
+    auto p = this->mdo->addDataPlacement(allocations);
+    this->mdo->addLatest(p->getID());
 }
 
 template<typename ValueType>
 DenseMatrix<ValueType>::DenseMatrix(const DenseMatrix<ValueType> * src, int64_t rowLowerIncl, int64_t rowUpperExcl,
         int64_t colLowerIncl, int64_t colUpperExcl) : Matrix<ValueType>(rowUpperExcl - rowLowerIncl,
-        colUpperExcl - colLowerIncl),  is_view(true), bufferSize(numRows*numCols*sizeof(ValueType)),
-        lastAppendedRowIdx(0), lastAppendedColIdx(0)
-{
+        colUpperExcl - colLowerIncl),  is_view(true), rowSkip(src->rowSkip), bufferSize(numRows*numCols*sizeof(ValueType)),
+        lastAppendedRowIdx(0), lastAppendedColIdx(0) {
     validateArgs(src, rowLowerIncl, rowUpperExcl, colLowerIncl, colUpperExcl);
     
-    this->row_offset = rowLowerIncl;
-    this->col_offset = colLowerIncl;
-    rowSkip = src->rowSkip;
+    this->row_offset = isView() ? src->row_offset + rowLowerIncl : rowLowerIncl;
+    this->col_offset = isView() ? src->col_offset + colLowerIncl : colLowerIncl;
 
     // ToDo: manage host mem (values) in a data placement
     if(src->values) {
-        alloc_shared_values(src->values, offset());
         bufferSize = numRows*rowSkip*sizeof(ValueType);
+        this->values = src->values;
     }
-    this->clone_mdo(src);
+    this->mdo = src->mdo;
 }
 
 template<typename ValueType>
 DenseMatrix<ValueType>::DenseMatrix(size_t numRows, size_t numCols, const DenseMatrix<ValueType> *src) :
-        Matrix<ValueType>(numRows, numCols), is_view(false), rowSkip(numCols),
+        Matrix<ValueType>(numRows, numCols), is_view(src->is_view), rowSkip(src->getRowSkip()),
         bufferSize(numRows*numCols*sizeof(ValueType)), lastAppendedRowIdx(0), lastAppendedColIdx(0) {
-    if(src->values)
-        values = src->values;
-    this->clone_mdo(src);
-}
+    if(!is_view)
+        rowSkip = numCols;
 
-template<typename ValueType>
-auto DenseMatrix<ValueType>::getValuesInternal(const IAllocationDescriptor* alloc_desc, const Range* range)
-        -> std::tuple<bool, size_t, ValueType*> {
-    // If no range information is provided we assume the full range that this matrix covers
-    if(range == nullptr || *range == Range(*this)) {
-        if(alloc_desc) {
-            auto ret = this->mdo->findDataPlacementByType(alloc_desc, range);
-            if(!ret) {
-                // find other allocation type X (preferably host allocation) to transfer from in latest_version
-
-                // tuple content: <is latest, latest-id, ptr-to-data-placement>
-                std::tuple<bool, size_t, ValueType *> result = std::make_tuple(false, 0, nullptr);
-                auto latest = this->mdo->getLatest();
-                DataPlacement *placement;
-                for (auto &placement_id: latest) {
-                    placement = this->mdo->getDataPlacementByID(placement_id);
-                    if(placement->range == nullptr || *(placement->range) == Range{0, 0, this->getNumRows(),
-                            this->getNumCols()}) {
-                        std::get<0>(result) = true;
-                        std::get<1>(result) = placement->dp_id;
-                        // prefer host allocation
-                        if(placement->allocation->getType() == ALLOCATION_TYPE::HOST) {
-                            std::get<2>(result) = reinterpret_cast<ValueType *>(values.get());
-                            break;
-                        }
-                    }
-                }
-
-                // if we found a data placement that is not in host memory, transfer it there before returning
-                if(std::get<0>(result) == true && std::get<2>(result) == nullptr) {
-                    AllocationDescriptorHost myHostAllocInfo;
-                    if(!values)
-                        this->alloc_shared_values();
-                    this->mdo->addDataPlacement(&myHostAllocInfo);
-                    placement->allocation->transferFrom(reinterpret_cast<std::byte *>(startAddress()), getBufferSize());
-                    std::get<2>(result) = startAddress();
-                }
-
-                // create new data placement
-                auto new_data_placement = const_cast<DenseMatrix<ValueType> *>(this)->mdo->addDataPlacement(alloc_desc);
-                new_data_placement->allocation->createAllocation(getBufferSize(), false);
-
-                // transfer to requested data placement
-                new_data_placement->allocation->transferTo(reinterpret_cast<std::byte *>(startAddress()), getBufferSize());
-                return std::make_tuple(false, new_data_placement->dp_id, reinterpret_cast<ValueType *>(
-                        new_data_placement->allocation->getData().get()));
-            }
-            else {
-                bool latest = this->mdo->isLatestVersion(ret->dp_id);
-                if(!latest) {
-                    ret->allocation->transferTo(reinterpret_cast<std::byte *>(startAddress()), getBufferSize());
-                }
-                return std::make_tuple(latest, ret->dp_id, reinterpret_cast<ValueType *>(ret->allocation->getData()
-                        .get()));
-            }
-        }
-        else {
-            // if no alloc info was provided we try to get/create a full host allocation and return that
-            std::tuple<bool, size_t, ValueType *> result = std::make_tuple(false, 0, nullptr);
-            auto latest = this->mdo->getLatest();
-            DataPlacement *placement;
-            for (auto &placement_id: latest) {
-                placement = this->mdo->getDataPlacementByID(placement_id);
-                
-                // only consider allocations covering full range of matrix
-                if(placement->range == nullptr || *(placement->range) == Range{this->row_offset, this->col_offset,
-                        this->getNumRows(), this->getNumCols()}) {
-                    std::get<0>(result) = true;
-                    std::get<1>(result) = placement->dp_id;
-                    // prefer host allocation
-                    if(placement->allocation->getType() == ALLOCATION_TYPE::HOST) {
-                        std::get<2>(result) = reinterpret_cast<ValueType *>(startAddress());
-                        break;
-                    }
-                }
-            }
-
-            // if we found a data placement that is not in host memory, transfer it there before returning
-            if(std::get<0>(result) == true && std::get<2>(result) == nullptr) {
-                AllocationDescriptorHost myHostAllocInfo;
-
-                // ToDo: this needs fixing in the context of matrix views
-                if(!values)
-                    const_cast<DenseMatrix<ValueType>*>(this)->alloc_shared_values();
-
-                this->mdo->addDataPlacement(&myHostAllocInfo);
-//                std::cout << "bufferSize: " << getBufferSize() << " RxRS: " << this->getNumRows() * this->getRowSkip() * sizeof(ValueType) << std::endl;
-//                if(getBufferSize() != this->getNumRows() * this->getRowSkip()) {
-//                    placement->allocation->transferFrom(reinterpret_cast<std::byte *>(startAddress()), this->getNumRows() * this->getRowSkip() * sizeof(ValueType));
-//                }
-//                else
-                    placement->allocation->transferFrom(reinterpret_cast<std::byte *>(startAddress()), getBufferSize());
-                std::get<2>(result) = startAddress();
-            }
-            if(std::get<2>(result) == nullptr)
-                throw std::runtime_error("No object meta data in matrix");
-            else
-                return result;
-        }
-    }
-    else
-        throw std::runtime_error("Range support under construction");
+    this->row_offset = src->row_offset;
+    this->col_offset = src->col_offset;
+    this->values = src->values;
+    this->mdo = src->mdo;
 }
 
 template <typename ValueType> void DenseMatrix<ValueType>::printValue(std::ostream & os, ValueType val) const {
@@ -238,14 +148,53 @@ template <>
 }
 
 template<typename ValueType>
-void DenseMatrix<ValueType>::alloc_shared_values(std::shared_ptr<ValueType[]> src, size_t offset) {
+void DenseMatrix<ValueType>::alloc_shared_values(bool zero, std::shared_ptr<ValueType[]> src, size_t offset) {
     // correct since C++17: Calls delete[] instead of simple delete
     if(src) {
         values = std::shared_ptr<ValueType[]>(src, src.get() + offset);
     }
-    else
-//        values = std::shared_ptr<ValueType[]>(new ValueType[numRows*numCols]);
-        values = std::shared_ptr<ValueType[]>(new ValueType[numRows * getRowSkip()]);
+    else {
+        values = std::shared_ptr<ValueType[]>(new ValueType[getBufferSize()]);
+        if(zero)
+            memset(values.get(), 0, getBufferSize());
+    }
+}
+
+template<typename ValueType>
+bool DenseMatrix<ValueType>::operator==(const DenseMatrix<ValueType> & rhs) const {
+    // Note that we do not use the generic `get` interface to matrices here since
+    // this operator is meant to be used for writing tests for, besides others,
+    // those generic interfaces.
+
+    if(this == &rhs)
+        return true;
+
+    const size_t numRows = this->getNumRows();
+    const size_t numCols = this->getNumCols();
+
+    if(numRows != rhs.getNumRows() || numCols != rhs.getNumCols())
+        return false;
+
+    const ValueType* valuesLhs = this->getValues();
+    const ValueType* valuesRhs = rhs.getValues();
+
+    size_t rowSkipLhs = this->getRowSkip();
+    size_t rowSkipRhs = rhs.getRowSkip();
+
+    if(valuesLhs == valuesRhs && rowSkipLhs == rowSkipRhs)
+        return true;
+
+    if(rowSkipLhs == numCols && rowSkipRhs == numCols)
+        return !memcmp(valuesLhs, valuesRhs, numRows * numCols * sizeof(ValueType));
+    else {
+        for(size_t r = 0; r < numRows; r++) {
+            if(memcmp(valuesLhs, valuesRhs, numCols * sizeof(ValueType)) != 0)
+                return false;
+            valuesLhs += rowSkipLhs;
+            valuesRhs += rowSkipRhs;
+        }
+        return true;
+    }
 }
 
 template<typename ValueType>
@@ -257,6 +206,43 @@ template<>
 size_t DenseMatrix<bool>::serialize(std::vector<char> &buf) const{
     throw std::runtime_error("DenseMatrix<bool> serialization not implemented");
 }
+
+template<typename ValueType>
+const ValueType* DenseMatrix<ValueType>::getValues(const IAllocationDescriptor* alloc_desc, const Range* range) const {
+    const ValueType* ptr;
+    if(this->isPinned(alloc_desc)) {
+        ptr = reinterpret_cast<const ValueType*>(this->pinned_mem);
+    }
+    else {
+        this->pinned_mem = this->mdo->getData(0, alloc_desc, range);
+        ptr = reinterpret_cast<const ValueType*>(this->pinned_mem);
+        const_cast<DenseMatrix<ValueType>*>(this)->pin(alloc_desc);
+    }
+
+    if(isView())
+        return ptr + offset();
+    else
+        return ptr;
+}
+
+template<typename ValueType>
+ValueType* DenseMatrix<ValueType>::getValues(const IAllocationDescriptor* alloc_desc, const Range* range) {
+    ValueType* ptr;
+    if(this->isPinned(alloc_desc)) {
+        ptr = reinterpret_cast<ValueType*>(this->pinned_mem);
+    }
+    else {
+        this->pinned_mem = this->mdo->getData(0, alloc_desc, range);
+        ptr = reinterpret_cast<ValueType*>(this->pinned_mem);
+        this->pin(alloc_desc);
+    }
+
+    if(isView())
+        return ptr + offset();
+    else
+        return ptr;
+}
+
 
 // ----------------------------------------------------------------------------
 // const char* specialization

--- a/src/runtime/local/datastructures/DenseMatrix.h
+++ b/src/runtime/local/datastructures/DenseMatrix.h
@@ -96,11 +96,12 @@ class DenseMatrix : public Matrix<ValueType>
             int64_t colUpperExcl);
 
     /**
-     * @brief Creates a `DenseMatrix` around an existing array of values without copying the data.
+     * @brief Creates a `DenseMatrix` around an existing `DenseMatrix` without copying the data.
+     *        This is used in transpose and reshape operations for example;
      *
      * @param numRows The exact number of rows.
      * @param numCols The exact number of columns.
-     * @param values A `std::shared_ptr` to an existing array of values.
+     * @param src A source matrix
      */
     DenseMatrix(size_t numRows, size_t numCols, const DenseMatrix<ValueType>* src);
 
@@ -119,10 +120,10 @@ class DenseMatrix : public Matrix<ValueType>
             const size_t startPosIncl = pos(lastAppendedRowIdx, lastAppendedColIdx) + 1;
             const size_t endPosExcl = pos(rowIdx, colIdx);
             if(startPosIncl < endPosExcl)
-                memset(values.get() + startPosIncl, 0, (endPosExcl - startPosIncl) * sizeof(ValueType));
+                memset(getValues() + startPosIncl, 0, (endPosExcl - startPosIncl) * sizeof(ValueType));
         }
         else {
-            auto v = values.get() + lastAppendedRowIdx * rowSkip;
+            auto v = getValues() + lastAppendedRowIdx * rowSkip;
             memset(v + lastAppendedColIdx + 1, 0, (numCols - lastAppendedColIdx - 1) * sizeof(ValueType));
             v += rowSkip;
             for(size_t r = lastAppendedRowIdx + 1; r < rowIdx; r++) {
@@ -136,39 +137,9 @@ class DenseMatrix : public Matrix<ValueType>
 
     void printValue(std::ostream & os, ValueType val) const;
 
-    void alloc_shared_values(std::shared_ptr<ValueType[]> src = nullptr, size_t offset = 0);
+    void alloc_shared_values(bool zero = false, std::shared_ptr<ValueType[]> src = nullptr, size_t offset = 0);
 
-
-    /**
-     * @brief The getValuesInternal method fetches a pointer to an allocation of values. Optionally a sub range
-     * can be specified.
-     *
-     * This method is called by the public getValues() methods either in const or non-const fashion. The const version
-     * returns a data pointer that is meant to be read-only. Read only access updates the list of up-to-date
-     * allocations (the latest_versions "list"). This way several copies of the data in various allocations can be
-     * kept without invalidating their copy. If the read write version of getValues() is used, the latest_versions
-     * list is cleared because a write to an allocation is assumed, which renders the other allocations of the
-     * same data out of sync.
-     *
-     * @param alloc_desc An instance of an IAllocationDescriptor derived class that is used to specify what type of
-     * allocation is requested. If no allocation descriptor is provided, a host allocation (plain main memory) is
-     * assumed by default.
-     *
-     * @param range An optional range describing which rows and columns of a matrix-like structure are requested.
-     * By default this is null and means all rows and columns.
-     * @return A tuple of three values is returned:
-     *         1: bool - is the returend allocation in the latest_versions list
-     *         2: size_t - the ID of the data placement (a structure relating an allocation to a range)
-     *         3: ValueType* - the pointer to the actual data
-     */
-
-    auto getValuesInternal(const IAllocationDescriptor* alloc_desc = nullptr, const Range* range = nullptr)
-    -> std::tuple<bool, size_t, ValueType*>;
-    
     [[nodiscard]] size_t offset() const { return this->row_offset * rowSkip + this->col_offset; }
-    
-    
-    ValueType* startAddress() const { return isPartialBuffer() ?  values.get() + offset() : values.get(); }
 
 public:
 
@@ -199,13 +170,7 @@ public:
      * @param range A Range object describing optionally requesting a sub range of a data structure.
      * @return A pointer to the data in the requested memory space
      */
-    const ValueType* getValues(const IAllocationDescriptor* alloc_desc = nullptr, const Range* range = nullptr) const
-    {
-        auto[isLatest, id, ptr] = const_cast<DenseMatrix<ValueType> *>(this)->getValuesInternal(alloc_desc, range);
-        if(!isLatest)
-            this->mdo->addLatest(id);
-        return ptr;
-    }
+    const ValueType* getValues(const IAllocationDescriptor* alloc_desc = nullptr, const Range* range = nullptr) const;
 
     /**
      * @brief Fetch a pointer to the data held by this structure meant for read-write access.
@@ -216,22 +181,19 @@ public:
      * @param alloc_desc An allocation descriptor describing which type of memory is requested (e.g. main memory in
      * the current system, memory in an accelerator card or memory in another host)
      *
+     *
      * @param range A Range object describing optionally requesting a sub range of a data structure.
      * @return A pointer to the data in the requested memory space
      */
-    ValueType* getValues(IAllocationDescriptor* alloc_desc = nullptr, const Range* range = nullptr) {
-        auto [isLatest, id, ptr] = const_cast<DenseMatrix<ValueType>*>(this)->getValuesInternal(alloc_desc, range);
-        if(!isLatest)
-            this->mdo->setLatest(id);
-        return ptr;
-    }
+    ValueType* getValues(const IAllocationDescriptor* alloc_desc = nullptr, const Range* range = nullptr);
     
     std::shared_ptr<ValueType[]> getValuesSharedPtr() const {
         return values;
     }
     
     ValueType get(size_t rowIdx, size_t colIdx) const override {
-        return getValues()[pos(rowIdx, colIdx, isPartialBuffer())];
+        auto position = pos(rowIdx, colIdx, isPartialBuffer());
+        return getValues()[position];
     }
     
     void set(size_t rowIdx, size_t colIdx, ValueType value) override {
@@ -242,7 +204,7 @@ public:
     void prepareAppend() override {
         // The matrix might be empty.
         if (numRows != 0 && numCols != 0)
-            values.get()[0] = ValueType(0);
+            getValues()[0] = ValueType(0);
         lastAppendedRowIdx = 0;
         lastAppendedColIdx = 0;
     }
@@ -251,7 +213,7 @@ public:
         // Set all cells since the last one that was appended to zero.
         fillZeroUntil(rowIdx, colIdx);
         // Set the specified cell.
-        values.get()[pos(rowIdx, colIdx)] = value;
+        getValues()[pos(rowIdx, colIdx)] = value;
         // Update append state.
         lastAppendedRowIdx = rowIdx;
         lastAppendedColIdx = colIdx;
@@ -297,41 +259,7 @@ public:
 
     [[nodiscard]] size_t getBufferSize() const { return bufferSize; }
 
-    bool operator==(const DenseMatrix<ValueType> & rhs) const {
-        // Note that we do not use the generic `get` interface to matrices here since
-        // this operator is meant to be used for writing tests for, besides others,
-        // those generic interfaces.
-        
-        if(this == &rhs)
-            return true;
-        
-        const size_t numRows = this->getNumRows();
-        const size_t numCols = this->getNumCols();
-        
-        if(numRows != rhs.getNumRows() || numCols != rhs.getNumCols())
-            return false;
-        
-        const ValueType* valuesLhs = this->getValues();
-        const ValueType* valuesRhs = rhs.getValues();
-        
-        const size_t rowSkipLhs = this->getRowSkip();
-        const size_t rowSkipRhs = rhs.getRowSkip();
-        
-        if(valuesLhs == valuesRhs && rowSkipLhs == rowSkipRhs)
-            return true;
-        
-        if(rowSkipLhs == numCols && rowSkipRhs == numCols)
-            return !memcmp(valuesLhs, valuesRhs, numRows * numCols * sizeof(ValueType));
-        else {
-            for(size_t r = 0; r < numRows; r++) {
-                if(memcmp(valuesLhs, valuesRhs, numCols * sizeof(ValueType)))
-                    return false;
-                valuesLhs += rowSkipLhs;
-                valuesRhs += rowSkipRhs;
-            }
-            return true;
-        }
-    }
+    bool operator==(const DenseMatrix<ValueType> & rhs) const;
 
     size_t serialize(std::vector<char> &buf) const override;
 };

--- a/src/runtime/local/datastructures/IAllocationDescriptor.h
+++ b/src/runtime/local/datastructures/IAllocationDescriptor.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <memory>
+#include <string_view>
 
 // An alphabetically sorted wishlist of supported allocation types ;-)
 // Supporting all of that is probably unmaintainable :-/
@@ -36,6 +37,11 @@ enum class ALLOCATION_TYPE {
     NUM_ALLOC_TYPES
 };
 
+// string representation of enum
+static std::string_view allocation_types[] = { "DIST_GRPC", "DIST_GRPC_ASYNC", "DIST_GRPC_SYNC", "DIST_MPI", "DIST_SPARK",
+                                              "GPU_CUDA", "GPU_HIP", "HOST", "HOST_PINNED_CUDA", "FPGA_INT", "FPGA_XLX",
+                                              "ONEAPI", "NUM_ALLOC_TYPES" };
+
 /**
  * @brief The IAllocationDescriptor interface class describes an abstract interface to handle memory allocations
  *
@@ -47,14 +53,19 @@ enum class ALLOCATION_TYPE {
  * the allocator.
  */
 class IAllocationDescriptor {
+protected:
+    size_t size = 0;
 public:
     virtual ~IAllocationDescriptor() = default;
     [[nodiscard]] virtual ALLOCATION_TYPE getType() const = 0;
-    virtual void createAllocation(size_t size, bool zero) = 0;
-    virtual std::string getLocation() const = 0;
+    [[nodiscard]] virtual std::unique_ptr<IAllocationDescriptor> createAllocation(size_t size, bool zero)  const = 0;
+    [[nodiscard]] virtual std::string getLocation() const = 0;
     virtual std::shared_ptr<std::byte> getData() = 0;
     virtual void transferTo(std::byte* src, size_t size) = 0;
     virtual void transferFrom(std::byte* dst, size_t size) = 0;
     [[nodiscard]] virtual std::unique_ptr<IAllocationDescriptor> clone() const = 0;
     virtual bool operator==(const IAllocationDescriptor* other) const { return (getType() == other->getType()); }
+    [[nodiscard]] virtual size_t getSize() const { return size; };
+
+    virtual std::string_view getTypeName() const { return allocation_types[static_cast<int>(getType())]; }
 };

--- a/src/runtime/local/datastructures/MetaDataObject.h
+++ b/src/runtime/local/datastructures/MetaDataObject.h
@@ -35,21 +35,29 @@ class DataPlacement;
  */
 class MetaDataObject {
     std::array<std::vector<std::unique_ptr<DataPlacement>>,
-            static_cast<size_t>(ALLOCATION_TYPE::NUM_ALLOC_TYPES)> data_placements;
-    std::vector<size_t> latest_version;
+            static_cast<size_t>(ALLOCATION_TYPE::NUM_ALLOC_TYPES)> range_data_placements;
 
+    std::array<std::unique_ptr<DataPlacement>, static_cast<size_t>(ALLOCATION_TYPE::NUM_ALLOC_TYPES)> data_placements;
+    mutable std::mutex mtx{};
+    std::vector<size_t> latest_version;
+    std::pair<uint32_t, std::byte*> getDataInternal(uint32_t alloc_idx, const IAllocationDescriptor* alloc_desc, const Range* range);
 public:
-    DataPlacement *addDataPlacement(const IAllocationDescriptor *allocInfo, Range *r = nullptr);
-    const DataPlacement *findDataPlacementByType(const IAllocationDescriptor *alloc_desc, const Range *range) const;
+    DataPlacement *addDataPlacement(std::vector<std::unique_ptr<IAllocationDescriptor>>& allocInfos, Range *r = nullptr);
     [[nodiscard]] DataPlacement *getDataPlacementByID(size_t id) const;
     [[nodiscard]] DataPlacement *getDataPlacementByLocation(const std::string& location) const;
-    [[nodiscard]] auto getDataPlacementByType(ALLOCATION_TYPE type) const ->
+    [[nodiscard]] auto getRangeDataPlacementByType(ALLOCATION_TYPE type) const ->
             const std::vector<std::unique_ptr<DataPlacement>>*;
+    [[nodiscard]] auto getDataPlacementByType(ALLOCATION_TYPE type) const -> DataPlacement*;
+
     void updateRangeDataPlacementByID(size_t id, Range *r);
+
+    DataPlacement* getDataPlacement(const IAllocationDescriptor* alloc_desc);
 
     [[nodiscard]] bool isLatestVersion(size_t placement) const;
     void addLatest(size_t id);
     void setLatest(size_t id);
     [[nodiscard]] auto getLatest() const -> std::vector<size_t>;
 
+    const std::byte* getData(uint32_t alloc_idx, const IAllocationDescriptor* alloc_desc = nullptr, const Range* range = nullptr) const;
+    std::byte* getData(uint32_t alloc_idx, const IAllocationDescriptor* alloc_desc = nullptr, const Range* range = nullptr);
 };

--- a/src/runtime/local/datastructures/Structure.cpp
+++ b/src/runtime/local/datastructures/Structure.cpp
@@ -19,18 +19,12 @@
 
 Structure::Structure(size_t numRows, size_t numCols) : refCounter(1), numRows(numRows), numCols(numCols) {
     mdo = std::make_shared<MetaDataObject>();
-};
+}
 
-void Structure::clone_mdo(const Structure* src) {
-    // FIXME: This clones the meta data to avoid locking (thread synchronization for data copy)
-    for(int i = 0; i < static_cast<int>(ALLOCATION_TYPE::NUM_ALLOC_TYPES); i++) {
-        auto placements = src->mdo->getDataPlacementByType(static_cast<ALLOCATION_TYPE>(i));
-        for(auto it = placements->begin(); it != placements->end(); it++) {
-            auto src_alloc = it->get()->allocation.get();
-            auto src_range = it->get()->range.get();
-            auto new_data_placement = this->mdo->addDataPlacement(src_alloc, src_range);
-            if(src->mdo->isLatestVersion(it->get()->dp_id))
-                this->mdo->addLatest(new_data_placement->dp_id);
-        }
-    }
+bool Structure::isPinned(const IAllocationDescriptor* alloc_desc) const {
+    return alloc_desc ? pinned_allocation == alloc_desc->getType() : pinned_allocation == ALLOCATION_TYPE::HOST;
+}
+
+void Structure::pin(const IAllocationDescriptor *alloc_desc) {
+    alloc_desc ? pinned_allocation = alloc_desc->getType() : pinned_allocation = ALLOCATION_TYPE::HOST;
 }

--- a/src/runtime/local/datastructures/Structure.h
+++ b/src/runtime/local/datastructures/Structure.h
@@ -39,13 +39,17 @@ protected:
     size_t col_offset{};
     size_t numRows;
     size_t numCols;
+    mutable ALLOCATION_TYPE pinned_allocation{};
+    mutable std::byte* pinned_mem{};
 
     Structure(size_t numRows, size_t numCols);
 
     mutable std::shared_ptr<MetaDataObject> mdo;
 
-    void clone_mdo(const Structure* src);
-    
+    [[nodiscard]] bool isPinned(const IAllocationDescriptor* alloc_desc) const;
+
+    void pin(const IAllocationDescriptor* alloc_desc);
+
 public:
     virtual ~Structure() = default;
 

--- a/src/runtime/local/datastructures/Structure.h
+++ b/src/runtime/local/datastructures/Structure.h
@@ -35,6 +35,7 @@ private:
     friend void DataObjectFactory::destroy(const DataType * obj);
 
 protected:
+    // offset in number of rows/cols (used with views)
     size_t row_offset{};
     size_t col_offset{};
     size_t numRows;

--- a/src/runtime/local/io/DaphneSerializer.h
+++ b/src/runtime/local/io/DaphneSerializer.h
@@ -560,7 +560,7 @@ struct DaphneSerializer<CSRMatrix<VT>, false> {
             return bufferIdx;
 
 
-        const size_t * colIdxs = arg->getColIdxs(0);
+        const size_t * colIdxs = arg->getColIdxsOfRow(0);
         if (serializeFromByte < serializationIdx + nzb * sizeof(size_t)){
             size_t startOffset = serializeFromByte > serializationIdx ? serializeFromByte - serializationIdx : 0;
             size_t bytesToCopy = 0;
@@ -583,7 +583,7 @@ struct DaphneSerializer<CSRMatrix<VT>, false> {
         if (chunkSize <= bufferIdx)
             return bufferIdx;
 
-        const VT * vals = arg->getValues(0);
+        const VT * vals = arg->getRowValues(0);
         if (serializeFromByte < serializationIdx + nzb * sizeof(VT)){
             size_t startOffset = serializeFromByte > serializationIdx ? serializeFromByte - serializationIdx : 0;
             size_t bytesToCopy = 0;

--- a/src/runtime/local/kernels/AggAll.h
+++ b/src/runtime/local/kernels/AggAll.h
@@ -141,7 +141,7 @@ struct AggAll<VTRes, CSRMatrix<VTArg>> {
             EwBinaryScaFuncPtr<VTRes, VTRes, VTRes> func = getEwBinaryScaFuncPtr<VTRes, VTRes, VTRes>(AggOpCodeUtils::getBinaryOpCode(opCode));
             
             return aggArray(
-                    arg->getValues(0),
+                    arg->getRowValues(0),
                     arg->getNumNonZeros(),
                     arg->getNumRows() * arg->getNumCols(),
                     func,
@@ -153,7 +153,7 @@ struct AggAll<VTRes, CSRMatrix<VTArg>> {
         else { // The op-code is either MEAN or STDDEV or VAR.
             EwBinaryScaFuncPtr<VTRes, VTRes, VTRes> func = getEwBinaryScaFuncPtr<VTRes, VTRes, VTRes>(AggOpCodeUtils::getBinaryOpCode(AggOpCode::SUM));            
             auto agg = aggArray(
-                arg->getValues(0),
+                arg->getRowValues(0),
                 arg->getNumNonZeros(),
                 arg->getNumRows() * arg->getNumCols(),
                 func,

--- a/src/runtime/local/kernels/AggCol.h
+++ b/src/runtime/local/kernels/AggCol.h
@@ -207,8 +207,8 @@ struct AggCol<DenseMatrix<VTRes>, CSRMatrix<VTArg>> {
             // for MEAN and STDDDEV, we need to sum
             func = getEwBinaryScaFuncPtr<VTRes, VTRes, VTRes>(AggOpCodeUtils::getBinaryOpCode(AggOpCode::SUM));
 
-        const VTArg * valuesArg = arg->getValues(0);
-        const size_t * colIdxsArg = arg->getColIdxs(0);
+        const VTArg * valuesArg = arg->getRowValues(0);
+        const size_t * colIdxsArg = arg->getColIdxsOfRow(0);
         
         const size_t numNonZeros = arg->getNumNonZeros();
         

--- a/src/runtime/local/kernels/AggCum.h
+++ b/src/runtime/local/kernels/AggCum.h
@@ -69,18 +69,21 @@ struct AggCum<DenseMatrix<VTRes>, DenseMatrix<VTArg>> {
                 AggOpCodeUtils::getBinaryOpCode(opCode)
         );
 
+        auto arg_inc = arg->isView() ? arg->getNumCols() : arg->getRowSkip();
+        auto res_inc = res->isView() ? res->getNumCols() : res->getRowSkip();
+
         // First row: copy from arg to res.
         for(size_t c = 0; c < numCols; c++)
             valuesResCur[c] = valuesArg[c];
-        valuesArg += arg->getRowSkip();
-        valuesResCur += res->getRowSkip();
+        valuesArg += arg_inc;
+        valuesResCur += res_inc;
         // Remaining rows: calculate from previous res row and current arg row.
         for(size_t r = 1; r < numRows; r++) {
             for(size_t c = 0; c < numCols; c++)
                 valuesResCur[c] = func(valuesResPrv[c], valuesArg[c], ctx);
-            valuesArg += arg->getRowSkip();
-            valuesResPrv += res->getRowSkip();
-            valuesResCur += res->getRowSkip();
+            valuesArg += arg_inc;
+            valuesResPrv += res_inc;
+            valuesResCur += res_inc;
         }
     }
 };

--- a/src/runtime/local/kernels/AggRow.h
+++ b/src/runtime/local/kernels/AggRow.h
@@ -191,7 +191,7 @@ struct AggRow<DenseMatrix<VTRes>, CSRMatrix<VTArg>> {
         
             for(size_t r = 0; r < numRows; r++) {
                 *valuesRes = AggAll<VTRes, CSRMatrix<VTArg>>::aggArray(
-                        arg->getValues(r),
+                        arg->getRowValues(r),
                         arg->getNumNonZeros(r),
                         numCols,
                         func,
@@ -212,7 +212,7 @@ struct AggRow<DenseMatrix<VTRes>, CSRMatrix<VTArg>> {
             EwBinaryScaFuncPtr<VTRes, VTRes, VTRes> func = getEwBinaryScaFuncPtr<VTRes, VTRes, VTRes>(AggOpCodeUtils::getBinaryOpCode(AggOpCode::SUM));
             for (size_t r = 0; r < numRows; r++){
                 *valuesRes = AggAll<VTRes, CSRMatrix<VTArg>>::aggArray(
-                    arg->getValues(r),
+                    arg->getRowValues(r),
                     arg->getNumNonZeros(r),
                     numCols,
                     func,

--- a/src/runtime/local/kernels/CMakeLists.txt
+++ b/src/runtime/local/kernels/CMakeLists.txt
@@ -91,6 +91,8 @@ set(HEADERS_cpp_kernels
 set(SOURCES_cpp_kernels
         ${PREFIX}/MatMul.cpp
         ${PROJECT_SOURCE_DIR}/src/runtime/local/instrumentation/KernelInstrumentation.cpp
+        ${PROJECT_SOURCE_DIR}/src/runtime/distributed/coordinator/scheduling/LoadPartitioningDistributed.h
+        ${PROJECT_SOURCE_DIR}/src/runtime/local/kernels/DistributedPipeline.h
         ${PROJECT_BINARY_DIR}/src/runtime/local/kernels/kernels.cpp
         ${PROJECT_SOURCE_DIR}/src/runtime/local/kernels/CreateDaphneContext.cpp
         ${PROJECT_SOURCE_DIR}/src/runtime/local/kernels/Pooling.cpp
@@ -99,6 +101,7 @@ set(SOURCES_cpp_kernels
         ${PROJECT_SOURCE_DIR}/src/runtime/local/vectorized/MTWrapper_sparse.cpp
         ${PROJECT_SOURCE_DIR}/src/runtime/local/vectorized/Tasks.cpp
         ${PROJECT_SOURCE_DIR}/src/runtime/local/vectorized/WorkerCPU.h
+
         )
 # The library of pre-compiled kernels. Will be linked into the JIT-compiled user program.
 add_library(AllKernels SHARED ${SOURCES_cpp_kernels} ${HEADERS_cpp_kernels})

--- a/src/runtime/local/kernels/CheckEqApprox.h
+++ b/src/runtime/local/kernels/CheckEqApprox.h
@@ -141,8 +141,8 @@ struct CheckEqApprox<CSRMatrix<VT>> {
             return false;
        
         for(size_t r = 0; r < numRows; r++){
-            const VT * valuesLhs = lhs->getValues(r);
-            const VT * valuesRhs = rhs->getValues(r);
+            const VT * valuesLhs = lhs->getRowValues(r);
+            const VT * valuesRhs = rhs->getRowValues(r);
             const size_t nnzElementsLhs= lhs->getNumNonZeros(r);
             const size_t nnzElementsRhs= rhs->getNumNonZeros(r);
             if (nnzElementsLhs!=nnzElementsRhs)

--- a/src/runtime/local/kernels/DiagMatrix.h
+++ b/src/runtime/local/kernels/DiagMatrix.h
@@ -138,7 +138,7 @@ struct DiagMatrix<CSRMatrix<VT>, CSRMatrix<VT>> {
 
         for(size_t r = 0, pos = 0; r < numRowsCols; r++) {
             if (arg->getNumNonZeros(r)) {
-	        valuesRes[pos] = *(arg->getValues(r));
+	        valuesRes[pos] = *(arg->getRowValues(r));
 	        colIdxsRes[pos++] = r;
 	    }
 	    rowOffsetsRes[r + 1] = pos;

--- a/src/runtime/local/kernels/EwBinaryMat.h
+++ b/src/runtime/local/kernels/EwBinaryMat.h
@@ -149,12 +149,12 @@ struct EwBinaryMat<CSRMatrix<VT>, CSRMatrix<VT>, CSRMatrix<VT>> {
                     size_t nnzRowRhs = rhs->getNumNonZeros(rowIdx);
                     if(nnzRowLhs && nnzRowRhs) {
                         // merge within row
-                        const VT * valuesRowLhs = lhs->getValues(rowIdx);
-                        const VT * valuesRowRhs = rhs->getValues(rowIdx);
-                        VT * valuesRowRes = res->getValues(rowIdx);
-                        const size_t * colIdxsRowLhs = lhs->getColIdxs(rowIdx);
-                        const size_t * colIdxsRowRhs = rhs->getColIdxs(rowIdx);
-                        size_t * colIdxsRowRes = res->getColIdxs(rowIdx);
+                        const VT * valuesRowLhs = lhs->getRowValues(rowIdx);
+                        const VT * valuesRowRhs = rhs->getRowValues(rowIdx);
+                        VT * valuesRowRes = res->getRowValues(rowIdx);
+                        const size_t * colIdxsRowLhs = lhs->getColIdxsOfRow(rowIdx);
+                        const size_t * colIdxsRowRhs = rhs->getColIdxsOfRow(rowIdx);
+                        size_t * colIdxsRowRes = res->getColIdxsOfRow(rowIdx);
                         size_t posLhs = 0;
                         size_t posRhs = 0;
                         size_t posRes = 0;
@@ -190,14 +190,14 @@ struct EwBinaryMat<CSRMatrix<VT>, CSRMatrix<VT>, CSRMatrix<VT>> {
                     }
                     else if(nnzRowLhs) {
                         // copy from left
-                        memcpy(res->getValues(rowIdx), lhs->getValues(rowIdx), nnzRowLhs * sizeof(VT));
-                        memcpy(res->getColIdxs(rowIdx), lhs->getColIdxs(rowIdx), nnzRowLhs * sizeof(size_t));
+                        memcpy(res->getRowValues(rowIdx), lhs->getRowValues(rowIdx), nnzRowLhs * sizeof(VT));
+                        memcpy(res->getColIdxsOfRow(rowIdx), lhs->getColIdxsOfRow(rowIdx), nnzRowLhs * sizeof(size_t));
                         rowOffsetsRes[rowIdx + 1] = rowOffsetsRes[rowIdx] + nnzRowLhs;
                     }
                     else if(nnzRowRhs) {
                         // copy from right
-                        memcpy(res->getValues(rowIdx), rhs->getValues(rowIdx), nnzRowRhs * sizeof(VT));
-                        memcpy(res->getColIdxs(rowIdx), rhs->getColIdxs(rowIdx), nnzRowRhs * sizeof(size_t));
+                        memcpy(res->getRowValues(rowIdx), rhs->getRowValues(rowIdx), nnzRowRhs * sizeof(VT));
+                        memcpy(res->getColIdxsOfRow(rowIdx), rhs->getColIdxsOfRow(rowIdx), nnzRowRhs * sizeof(size_t));
                         rowOffsetsRes[rowIdx + 1] = rowOffsetsRes[rowIdx] + nnzRowRhs;
                     }
                     else
@@ -212,12 +212,12 @@ struct EwBinaryMat<CSRMatrix<VT>, CSRMatrix<VT>, CSRMatrix<VT>> {
                     size_t nnzRowRhs = rhs->getNumNonZeros(rowIdx);
                     if(nnzRowLhs && nnzRowRhs) {
                         // intersect within row
-                        const VT * valuesRowLhs = lhs->getValues(rowIdx);
-                        const VT * valuesRowRhs = rhs->getValues(rowIdx);
-                        VT * valuesRowRes = res->getValues(rowIdx);
-                        const size_t * colIdxsRowLhs = lhs->getColIdxs(rowIdx);
-                        const size_t * colIdxsRowRhs = rhs->getColIdxs(rowIdx);
-                        size_t * colIdxsRowRes = res->getColIdxs(rowIdx);
+                        const VT * valuesRowLhs = lhs->getRowValues(rowIdx);
+                        const VT * valuesRowRhs = rhs->getRowValues(rowIdx);
+                        VT * valuesRowRes = res->getRowValues(rowIdx);
+                        const size_t * colIdxsRowLhs = lhs->getColIdxsOfRow(rowIdx);
+                        const size_t * colIdxsRowRhs = rhs->getColIdxsOfRow(rowIdx);
+                        size_t * colIdxsRowRes = res->getColIdxsOfRow(rowIdx);
                         size_t posLhs = 0;
                         size_t posRhs = 0;
                         size_t posRes = 0;
@@ -288,10 +288,10 @@ struct EwBinaryMat<CSRMatrix<VT>, CSRMatrix<VT>, DenseMatrix<VT>> {
                 size_t nnzRowLhs = lhs->getNumNonZeros(rowIdx);
                 if(nnzRowLhs) {
                     // intersect within row
-                    const VT * valuesRowLhs = lhs->getValues(rowIdx);
-                    VT * valuesRowRes = res->getValues(rowIdx);
-                    const size_t * colIdxsRowLhs = lhs->getColIdxs(rowIdx);
-                    size_t * colIdxsRowRes = res->getColIdxs(rowIdx);
+                    const VT * valuesRowLhs = lhs->getRowValues(rowIdx);
+                    VT * valuesRowRes = res->getRowValues(rowIdx);
+                    const size_t * colIdxsRowLhs = lhs->getColIdxsOfRow(rowIdx);
+                    size_t * colIdxsRowRes = res->getColIdxsOfRow(rowIdx);
                     auto rhsRow = (rhs->getNumRows() == 1 ? 0 : rowIdx);
                     size_t posRes = 0;
                     for (size_t posLhs = 0; posLhs < nnzRowLhs; ++posLhs) {

--- a/src/runtime/local/kernels/Gemv.h
+++ b/src/runtime/local/kernels/Gemv.h
@@ -20,6 +20,8 @@
 #include <runtime/local/context/DaphneContext.h>
 #include <runtime/local/datastructures/DataObjectFactory.h>
 #include <runtime/local/datastructures/DenseMatrix.h>
+#include <runtime/local/datastructures/CSRMatrix.h>
+
 
 #include <cblas.h>
 
@@ -125,8 +127,8 @@ struct Gemv<DenseMatrix<VT>, CSRMatrix<VT>, DenseMatrix<VT>> {
         memset(valuesRes, VT(0), sizeof(VT) * nr1 * nc2);
         for(size_t r = 0; r < nr1; r++) {
             const size_t rowNumNonZeros = mat->getNumNonZeros(r);
-            const size_t * rowColIdxs = mat->getColIdxs(r);
-            const VT * rowValues = mat->getValues(r);
+            const size_t * rowColIdxs = mat->getColIdxsOfRow(r);
+            const VT * rowValues = mat->getRowValues(r);
 
             const size_t rowIdxRes = r * rowSkipRes;
             for(size_t i = 0; i < rowNumNonZeros; i++) {

--- a/src/runtime/local/kernels/HasSpecialValue.h
+++ b/src/runtime/local/kernels/HasSpecialValue.h
@@ -99,8 +99,8 @@ template <typename VT, typename TestType> struct HasSpecialValue<CSRMatrix<VT>, 
         auto numCols = arg->getNumCols();
         auto numNonZeros = arg->getNumNonZeros();
         auto numElements = numRows*numCols;
-        auto vBegin = arg->getValues(0);
-        auto vEnd = arg->getValues(numRows);
+        auto vBegin = arg->getRowValues(0);
+        auto vEnd = arg->getRowValues(numRows);
         auto hasZeroes = numNonZeros < numElements;
         auto zero = VT(0);
 

--- a/src/runtime/local/kernels/InsertCol.h
+++ b/src/runtime/local/kernels/InsertCol.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef SRC_RUNTIME_LOCAL_KERNELS_INSERTCOL_H
-#define SRC_RUNTIME_LOCAL_KERNELS_INSERTCOL_H
+#pragma once
 
 #include <runtime/local/context/DaphneContext.h>
 #include <runtime/local/datastructures/DataObjectFactory.h>
@@ -110,8 +109,8 @@ struct InsertCol<DenseMatrix<VTArg>, DenseMatrix<VTArg>, VTSel> {
         const size_t numRowsIns = ins->getNumRows();
         const size_t numColsIns = ins->getNumCols();
 
-        const size_t colLowerIncl_Size = static_cast<const size_t>(colLowerIncl);
-        const size_t colUpperExcl_Size = static_cast<const size_t>(colUpperExcl);
+        const auto colLowerIncl_Size = static_cast<const size_t>(colLowerIncl);
+        const auto colUpperExcl_Size = static_cast<const size_t>(colUpperExcl);
         
         validateArgsInsertCol(colLowerIncl_Size, colLowerIncl, colUpperExcl_Size, colUpperExcl,
                     numRowsArg, numColsArg, numRowsIns, numColsIns);
@@ -175,5 +174,3 @@ struct InsertCol<Matrix<VTArg>, Matrix<VTArg>, VTSel> {
         res->finishAppend();
     }
 };
-
-#endif //SRC_RUNTIME_LOCAL_KERNELS_INSERTROW_H

--- a/src/runtime/local/kernels/InsertRow.h
+++ b/src/runtime/local/kernels/InsertRow.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef SRC_RUNTIME_LOCAL_KERNELS_INSERTROW_H
-#define SRC_RUNTIME_LOCAL_KERNELS_INSERTROW_H
+#pragma once
 
 #include <runtime/local/context/DaphneContext.h>
 #include <runtime/local/datastructures/DataObjectFactory.h>
@@ -110,8 +109,8 @@ struct InsertRow<DenseMatrix<VT>, DenseMatrix<VT>, VTSel> {
         const size_t numRowsIns = ins->getNumRows();
         const size_t numColsIns = ins->getNumCols();
 
-        const size_t rowLowerIncl_Size = static_cast<const size_t>(rowLowerIncl);
-        const size_t rowUpperExcl_Size = static_cast<const size_t>(rowUpperExcl);
+        const auto rowLowerIncl_Size = static_cast<const size_t>(rowLowerIncl);
+        const auto rowUpperExcl_Size = static_cast<const size_t>(rowUpperExcl);
         
         validateArgsInsertRow(rowLowerIncl_Size, rowLowerIncl, rowUpperExcl_Size, rowUpperExcl,
                     numRowsArg, numColsArg, numRowsIns, numColsIns);
@@ -179,12 +178,10 @@ struct InsertRow<Matrix<VT>, Matrix<VT>, VTSel> {
         for (size_t r = rowLowerIncl_Size; r < rowUpperExcl_Size; ++r)
             for (size_t c = 0; c < numColsArg; ++c)
                 res->append(r, c, ins->get(r - rowLowerIncl_Size, c));
-                
+
         for (size_t r = rowUpperExcl_Size; r < numRowsArg; ++r)
             for (size_t c = 0; c < numColsArg; ++c)
                 res->append(r, c, arg->get(r, c));
         res->finishAppend();
     }
 };
-
-#endif //SRC_RUNTIME_LOCAL_KERNELS_INSERTROW_H

--- a/src/runtime/local/kernels/IsSymmetric.h
+++ b/src/runtime/local/kernels/IsSymmetric.h
@@ -105,8 +105,8 @@ template <typename VT> struct IsSymmetric<CSRMatrix<VT>> {
 
         for (size_t rowIdx = 0; rowIdx < numRows; rowIdx++) {
 
-            const VT* rowA = arg->getValues(rowIdx);
-            const size_t* colIdxsA = arg->getColIdxs(rowIdx);
+            const VT* rowA = arg->getRowValues(rowIdx);
+            const size_t* colIdxsA = arg->getColIdxsOfRow(rowIdx);
             const size_t numNonZerosA = arg->getNumNonZeros(rowIdx);
 
             for (size_t idx = 0;  idx < numNonZerosA; idx++) {
@@ -120,8 +120,8 @@ template <typename VT> struct IsSymmetric<CSRMatrix<VT>> {
                 VT valA = rowA[idx];
 
                 // B references the transposed element to compare for symmetry.
-                const VT* rowB = arg->getValues(colIdxA);
-                const size_t* colIdxsB = arg->getColIdxs(colIdxA);
+                const VT* rowB = arg->getRowValues(colIdxA);
+                const size_t* colIdxsB = arg->getColIdxsOfRow(colIdxA);
                 const size_t numNonZerosB = arg->getNumNonZeros(colIdxA);
 
                 positions[colIdxA]++; // colIdxA is rowIdxB

--- a/src/runtime/local/kernels/MatMul.h
+++ b/src/runtime/local/kernels/MatMul.h
@@ -80,8 +80,8 @@ struct MatMul<DenseMatrix<VT>, CSRMatrix<VT>, DenseMatrix<VT>> {
         memset(valuesRes, VT(0), sizeof(VT) * nr1 * nc2);
         for(size_t r = 0; r < nr1; r++) {
             const size_t rowNumNonZeros = lhs->getNumNonZeros(r);
-            const size_t * rowColIdxs = lhs->getColIdxs(r);
-            const VT * rowValues = lhs->getValues(r);
+            const size_t * rowColIdxs = lhs->getColIdxsOfRow(r);
+            const VT * rowValues = lhs->getRowValues(r);
 
             const size_t rowIdxRes = r * rowSkipRes;
             for(size_t i = 0; i < rowNumNonZeros; i++) {

--- a/src/runtime/local/kernels/NumDistinctApprox.h
+++ b/src/runtime/local/kernels/NumDistinctApprox.h
@@ -125,7 +125,7 @@ template <typename VT> struct NumDistinctApprox<CSRMatrix<VT>> {
         }
 
         for(size_t rowIdx = 0; rowIdx < numRows; rowIdx++) {
-            const VT* values = arg->getValues(rowIdx);
+            const VT* values = arg->getRowValues(rowIdx);
 
             const size_t numNonZerosInRow = arg->getNumNonZeros(rowIdx);
             for(size_t colIdx = 0; colIdx < numNonZerosInRow; colIdx++) {

--- a/src/runtime/local/kernels/Replace.h
+++ b/src/runtime/local/kernels/Replace.h
@@ -195,8 +195,8 @@ struct Replace<CSRMatrix<VT>, CSRMatrix<VT>, VT> {
         //--------main logic --------------------------
         if(pattern!=pattern){ // pattern is NaN
             for(size_t r = 0; r < numRows; r++){
-                const VT * allValues = arg->getValues(r);
-                VT * allUpdatedValues = res->getValues(r);
+                const VT * allValues = arg->getRowValues(r);
+                VT * allUpdatedValues = res->getRowValues(r);
                 const size_t nnzElementsRes= arg->getNumNonZeros(r);
                 for(size_t c = 0; c < nnzElementsRes; c++){
                     if(allValues[c]!=allValues[c]){
@@ -207,8 +207,8 @@ struct Replace<CSRMatrix<VT>, CSRMatrix<VT>, VT> {
         }
         else{
             for(size_t r = 0; r < numRows; r++){
-                const VT * allValues = arg->getValues(r);
-                VT * allUpdatedValues = res->getValues(r);
+                const VT * allValues = arg->getRowValues(r);
+                VT * allUpdatedValues = res->getRowValues(r);
                 const size_t nnzElementsRes= arg->getNumNonZeros(r);
                 for(size_t c = 0; c < nnzElementsRes; c++){
                     if(allValues[c]==pattern){

--- a/src/runtime/local/kernels/Reshape.h
+++ b/src/runtime/local/kernels/Reshape.h
@@ -58,8 +58,9 @@ struct Reshape<DenseMatrix<VT>, DenseMatrix<VT>> {
         if(numRows * numCols != arg->getNumRows() * arg->getNumCols())
             throw std::runtime_error("reshape must retain the number of cells");
 
-        if(arg->getRowSkip() == arg->getNumCols() && res == nullptr)
-            res = DataObjectFactory::create<DenseMatrix<VT>>(numRows, numCols, arg->getValuesSharedPtr());
+        if(arg->getRowSkip() == arg->getNumCols() && arg->isView() == false) {
+            res = DataObjectFactory::create<DenseMatrix<VT>>(numRows, numCols, arg);
+        }
         else {
             if(res == nullptr)
                 res = DataObjectFactory::create<DenseMatrix<VT>>(numRows, numCols, false);

--- a/src/runtime/local/kernels/Tri.h
+++ b/src/runtime/local/kernels/Tri.h
@@ -131,8 +131,8 @@ struct Tri<CSRMatrix<VT>> {
         rowOffsetsRes[0] = 0;
         for(size_t r = 0, pos = 0; r < numRows; r++, (*inc)++) {
             const size_t rowNumNonZeros = arg->getNumNonZeros(r);
-            const size_t * rowColIdxs = arg->getColIdxs(r);
-            const VT * rowValues = arg->getValues(r);
+            const size_t * rowColIdxs = arg->getColIdxsOfRow(r);
+            const VT * rowValues = arg->getRowValues(r);
 
             for(size_t i = 0; i < rowNumNonZeros; i++) {
                 const size_t c = rowColIdxs[i];

--- a/src/runtime/local/kernels/kernels.json
+++ b/src/runtime/local/kernels/kernels.json
@@ -2378,6 +2378,7 @@
             [["DenseMatrix", "int64_t"], "int64_t"],
             [["DenseMatrix", "uint8_t"], "uint8_t"],
             [["CSRMatrix", "double"], "double"],
+            [["CSRMatrix", "float"], "float"],
             [["CSRMatrix", "int64_t"], "int64_t"]
         ]
     },
@@ -2484,6 +2485,7 @@
             [["DenseMatrix", "uint8_t"]],
             [["CSRMatrix", "double"]],
             [["CSRMatrix", "float"]],
+            [["CSRMatrix", "int64_t"]],
             ["Frame"]
         ]
     },

--- a/test/runtime/local/datastructures/CSRMatrixTest.cpp
+++ b/test/runtime/local/datastructures/CSRMatrixTest.cpp
@@ -34,7 +34,7 @@ TEMPLATE_TEST_CASE("CSRMatrix allocates enough space", TAG_DATASTRUCTURES, ALL_V
     const size_t numCols = 2000;
     const size_t numNonZeros = 500;
     
-    CSRMatrix<ValueType> * m = DataObjectFactory::create<CSRMatrix<ValueType>>(numRows, numCols, numNonZeros, false);
+    auto m = DataObjectFactory::create<CSRMatrix<ValueType>>(numRows, numCols, numNonZeros, false);
     
     ValueType * values = m->getValues();
     size_t * colIdxs = m->getColIdxs();
@@ -60,8 +60,8 @@ TEST_CASE("CSRMatrix sub-matrix works properly", TAG_DATASTRUCTURES) {
     const size_t numColsOrig = 7;
     const size_t numNonZeros = 3;
     
-    CSRMatrix<ValueType> * mOrig = DataObjectFactory::create<CSRMatrix<ValueType>>(numRowsOrig, numColsOrig, numNonZeros, true);
-    CSRMatrix<ValueType> * mSub = DataObjectFactory::create<CSRMatrix<ValueType>>(mOrig, 3, 5);
+    auto mOrig = DataObjectFactory::create<CSRMatrix<ValueType>>(numRowsOrig, numColsOrig, numNonZeros, true);
+    auto mSub = DataObjectFactory::create<CSRMatrix<ValueType>>(mOrig, 3, 5);
     
     // Sub-matrix dimensions are as expected.
     CHECK(mSub->getNumRows() == 2);

--- a/test/runtime/local/datastructures/DenseMatrixTest.cpp
+++ b/test/runtime/local/datastructures/DenseMatrixTest.cpp
@@ -175,8 +175,8 @@ TEST_CASE("DenseMatrix sub-matrix works properly", TAG_DATASTRUCTURES) {
     const size_t numColsOrig = 7;
     const size_t numCellsOrig = numRowsOrig * numColsOrig;
     
-    DenseMatrix<ValueType> * mOrig = DataObjectFactory::create<DenseMatrix<ValueType>>(numRowsOrig, numColsOrig, true);
-    DenseMatrix<ValueType> * mSub = DataObjectFactory::create<DenseMatrix<ValueType>>(mOrig, 3, 5, 1, 4);
+    auto mOrig = DataObjectFactory::create<DenseMatrix<ValueType>>(numRowsOrig, numColsOrig, true);
+    auto mSub = DataObjectFactory::create<DenseMatrix<ValueType>>(mOrig, 3, 5, 1, 4);
     
     // Sub-matrix dimensions are as expected.
     CHECK(mSub->getNumRows() == 2);
@@ -184,8 +184,8 @@ TEST_CASE("DenseMatrix sub-matrix works properly", TAG_DATASTRUCTURES) {
     CHECK(mSub->getRowSkip() == numColsOrig);
 
     // Sub-matrix shares data array with original.
-    ValueType * valuesOrig = mOrig->getValues();
-    ValueType * valuesSub = mSub->getValues();
+    ValueType* valuesOrig = mOrig->getValues();
+    ValueType* valuesSub = mSub->getValues();
     CHECK((valuesSub >= valuesOrig && valuesSub < valuesOrig + numCellsOrig));
     valuesSub[0] = 123;
     CHECK(valuesOrig[3 * numColsOrig + 1] == 123);

--- a/test/runtime/local/kernels/CheckEqTest.cpp
+++ b/test/runtime/local/kernels/CheckEqTest.cpp
@@ -322,8 +322,8 @@ TEST_CASE("CheckEq, frames", TAG_KERNELS) {
     }
     SECTION("diff inst, same schema, same cont, same labels") {
         auto c3 = genGivenVals<DenseMatrix<VT2>>(numRows, {VT2(8.8), VT2(9.9), VT2(1.0), VT2(2.0)});
-        std::string * labels1 =  new std::string[3] {"ab", "cde", "fghi"};
-        std::string * labels2 =  new std::string[3] {"ab", "cde", "fghi"};
+        auto labels1 =  new std::string[3] {"ab", "cde", "fghi"};
+        auto labels2 =  new std::string[3] {"ab", "cde", "fghi"};
         frame1 = DataObjectFactory::create<Frame>(cols, labels1);
         std::vector<Structure *> cols2 = {c0, c1, c3};
         auto frame2 = DataObjectFactory::create<Frame>(cols2, labels2);
@@ -333,8 +333,8 @@ TEST_CASE("CheckEq, frames", TAG_KERNELS) {
     }
     SECTION("diff inst, same schema, same cont, diff labels") {
         auto c3 = genGivenVals<DenseMatrix<VT2>>(numRows, {VT2(8.8), VT2(9.9), VT2(1.0), VT2(2.0)});
-        std::string * labels1 =  new std::string[3] {"ab", "cde", "fghi"};
-        std::string * labels2 =  new std::string[3] {"ab", "cde", "fxyz"};
+        auto labels1 =  new std::string[3] {"ab", "cde", "fghi"};
+        auto labels2 =  new std::string[3] {"ab", "cde", "fxyz"};
         frame1 = DataObjectFactory::create<Frame>(cols, labels1);
         std::vector<Structure *> cols2 = {c0, c1, c3};
         auto frame2 = DataObjectFactory::create<Frame>(cols2, labels2);


### PR DESCRIPTION
This PR moves the MetaDataObject (MDO) functionality out of DenseMatrix and generalizes it to be used by other classes derived from Structure as well.

Furthermore, this contains a performance improvement to prevent excessive allocation ID lookups and a separation of ranged and full allocations. 

All tests are running except the distributed ones.