### PR TITLE
[security] Remove polyfill.io dependency in docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,7 +39,6 @@ extra_css:
   - stylesheets/extra.css
 extra_javascript:
   - javascripts/mathjax.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
 repo_url: https://github.com/daphne-eu/daphne
 repo_name: daphne-eu/daphne


### PR DESCRIPTION
Currently, mkdocs uses `polyfill.io` to build the online Daphne documentation.
It has been reported that the site is involved in a supply chain attack delivering malicious code instead.
- https://blog.cloudflare.com/automatically-replacing-polyfill-io-links-with-cloudflares-mirror-for-a-safer-internet
- https://www.sonatype.com/blog/polyfill.io-supply-chain-attack-hits-100000-websites-all-you-need-to-know

This PR simply removes the dependency without replacement which should not impact the documentation in most browsers. If needed, e.g. Cloudflare currently provides polyfill over their cdn.