### PR TITLE
Issue #518: Add Loop Vectorization

### DIFF
--- a/UserConfig.json
+++ b/UserConfig.json
@@ -15,6 +15,7 @@
     "debug_llvm": false,
     "explain_kernels": false,
     "explain_llvm": false,
+    "explain_loop_vectorization": false,
     "explain_parsing": false,
     "explain_parsing_simplified": false,
     "explain_property_inference": false,

--- a/src/api/cli/DaphneUserConfig.h
+++ b/src/api/cli/DaphneUserConfig.h
@@ -65,6 +65,7 @@ struct DaphneUserConfig {
     bool debug_llvm = false;
     bool explain_kernels = false;
     bool explain_llvm = false;
+    bool explain_loop_vectorization = false;
     bool explain_parsing = false;
     bool explain_parsing_simplified = false;
     bool explain_property_inference = false;

--- a/src/api/internal/daphne_internal.cpp
+++ b/src/api/internal/daphne_internal.cpp
@@ -323,6 +323,7 @@ int startDAPHNE(int argc, const char** argv, DaphneLibResult* daphneLibRes, int 
     enum ExplainArgs {
       kernels,
       llvm,
+      loop_vectorization,
       parsing,
       parsing_simplified,
       property_inference,
@@ -344,6 +345,7 @@ int startDAPHNE(int argc, const char** argv, DaphneLibResult* daphneLibRes, int 
             clEnumVal(parsing_simplified, "Show DaphneIR after parsing and some simplifications"),
             clEnumVal(sql, "Show DaphneIR after SQL parsing"),
             clEnumVal(property_inference, "Show DaphneIR after property inference"),
+            clEnumVal(loop_vectorization, "Show DaphneIR after loop vectorization"),
             clEnumVal(select_matrix_repr, "Show DaphneIR after selecting physical matrix representations"),
             clEnumVal(phy_op_selection, "Show DaphneIR after selecting physical operators"),
             clEnumVal(type_adaptation, "Show DaphneIR after adapting types to available kernels"),
@@ -485,6 +487,9 @@ int startDAPHNE(int argc, const char** argv, DaphneLibResult* daphneLibRes, int 
                 break;
             case llvm:
                 user_config.explain_llvm = true;
+                break;
+            case loop_vectorization:
+                user_config.explain_loop_vectorization = true;
                 break;
             case parsing:
                 user_config.explain_parsing = true;

--- a/src/compiler/execution/DaphneIrExecutor.cpp
+++ b/src/compiler/execution/DaphneIrExecutor.cpp
@@ -18,14 +18,13 @@
 #include <util/ErrorHandler.h>
 
 #include <ir/daphneir/Daphne.h>
-#include <ir/daphneir/Passes.h>
 #include <ir/daphneir/Passes.h.inc>
+#include <ir/daphneir/Passes.h>
 #include <mlir/Dialect/LLVMIR/LLVMDialect.h>
 #include <mlir/Dialect/LLVMIR/Transforms/Passes.h>
 
 #include <filesystem>
 
-#include "llvm/Support/TargetSelect.h"
 #include "mlir/Conversion/AffineToStandard/AffineToStandard.h"
 #include "mlir/Conversion/LinalgToLLVM/LinalgToLLVM.h"
 #include "mlir/Conversion/MathToLLVM/MathToLLVM.h"
@@ -47,13 +46,15 @@
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.h"
 #include "mlir/Transforms/Passes.h"
+#include "llvm/Support/TargetSelect.h"
 
 DaphneIrExecutor::DaphneIrExecutor(bool selectMatrixRepresentations,
                                    DaphneUserConfig cfg)
     : userConfig_(std::move(cfg)),
       selectMatrixRepresentations_(selectMatrixRepresentations) {
     // register loggers
-    if (userConfig_.log_ptr != nullptr) userConfig_.log_ptr->registerLoggers();
+    if (userConfig_.log_ptr != nullptr)
+        userConfig_.log_ptr->registerLoggers();
 
     context_.getOrLoadDialect<mlir::daphne::DaphneDialect>();
     context_.getOrLoadDialect<mlir::arith::ArithDialect>();
@@ -78,7 +79,8 @@ bool DaphneIrExecutor::runPasses(mlir::ModuleOp module) {
     // return false;
     //}
 
-    if (!module) return false;
+    if (!module)
+        return false;
 
     // This flag is really useful to figure out why the lowering failed
     llvm::DebugFlag = userConfig_.debug_llvm;
@@ -98,7 +100,7 @@ bool DaphneIrExecutor::runPasses(mlir::ModuleOp module) {
             pm.addPass(mlir::daphne::createPrintIRPass(
                 "IR after parsing and some simplifications:"));
 
-        pm.addPass(mlir::daphne::createRewriteSqlOpPass());  // calls SQL Parser
+        pm.addPass(mlir::daphne::createRewriteSqlOpPass()); // calls SQL Parser
         if (userConfig_.explain_sql)
             pm.addPass(
                 mlir::daphne::createPrintIRPass("IR after SQL parsing:"));
@@ -114,7 +116,7 @@ bool DaphneIrExecutor::runPasses(mlir::ModuleOp module) {
                 module->emitError("module pass error");
                 return false;
             }
-        } catch(...) {
+        } catch (...) {
             ErrorHandler::dumpModuleToDisk(module);
             throw;
         }
@@ -130,6 +132,11 @@ bool DaphneIrExecutor::runPasses(mlir::ModuleOp module) {
     // run only three iterations of both passes (see #173).
     pm.addNestedPass<mlir::func::FuncOp>(mlir::daphne::createInferencePass());
     pm.addPass(mlir::createCanonicalizerPass());
+
+    pm.addPass(mlir::daphne::createLoopVectorizationPass());
+    if (userConfig_.explain_loop_vectorization)
+        pm.addPass(
+            mlir::daphne::createPrintIRPass("IR after loop vectorization:"));
 
     if (selectMatrixRepresentations_)
         pm.addNestedPass<mlir::func::FuncOp>(
@@ -168,7 +175,8 @@ bool DaphneIrExecutor::runPasses(mlir::ModuleOp module) {
     if (userConfig_.use_distributed)
         pm.addPass(mlir::daphne::createDistributePipelinesPass());
 
-    if (userConfig_.use_mlir_codegen || userConfig_.use_mlir_hybrid_codegen) buildCodegenPipeline(pm);
+    if (userConfig_.use_mlir_codegen || userConfig_.use_mlir_hybrid_codegen)
+        buildCodegenPipeline(pm);
 
     if (userConfig_.enable_profiling)
         pm.addNestedPass<mlir::func::FuncOp>(
@@ -205,7 +213,8 @@ bool DaphneIrExecutor::runPasses(mlir::ModuleOp module) {
             "IR after managing object references:"));
 
     pm.addNestedPass<mlir::func::FuncOp>(
-        mlir::daphne::createRewriteToCallKernelOpPass(userConfig_, usedLibPaths));
+        mlir::daphne::createRewriteToCallKernelOpPass(userConfig_,
+                                                      usedLibPaths));
     if (userConfig_.explain_kernels)
         pm.addPass(
             mlir::daphne::createPrintIRPass("IR after kernel lowering:"));
@@ -220,7 +229,7 @@ bool DaphneIrExecutor::runPasses(mlir::ModuleOp module) {
 
     // Initialize the use of each distinct kernels library to false.
     usedLibPaths = userConfig_.kernelCatalog.getLibPaths();
-    
+
     try {
         if (failed(pm.run(module))) {
             module->dump();
@@ -235,30 +244,31 @@ bool DaphneIrExecutor::runPasses(mlir::ModuleOp module) {
     return true;
 }
 
-std::unique_ptr<mlir::ExecutionEngine> DaphneIrExecutor::createExecutionEngine(
-    mlir::ModuleOp module) {
-    if (!module) return nullptr;
+std::unique_ptr<mlir::ExecutionEngine>
+DaphneIrExecutor::createExecutionEngine(mlir::ModuleOp module) {
+    if (!module)
+        return nullptr;
     // An optimization pipeline to use within the execution engine.
     unsigned optLevel = 0;
     unsigned sizeLevel = 0;
     llvm::TargetMachine *targetMachine = nullptr;
-    auto optPipeline = mlir::makeOptimizingTransformer(optLevel, sizeLevel, targetMachine);
+    auto optPipeline =
+        mlir::makeOptimizingTransformer(optLevel, sizeLevel, targetMachine);
 
     // Determine the actually used kernels libraries.
     std::vector<llvm::StringRef> sharedLibRefs;
-    for(auto it = usedLibPaths.begin(); it != usedLibPaths.end(); it++)
-        if(it->second) {
+    for (auto it = usedLibPaths.begin(); it != usedLibPaths.end(); it++)
+        if (it->second) {
             std::string usedLibPath = it->first;
             sharedLibRefPaths.push_back(usedLibPath);
             sharedLibRefs.emplace_back(sharedLibRefPaths.back());
 
-            // Check if the used kernels library really exists at the expected path
-            // and throw an understandable error, otherwise.
-            if(!std::filesystem::exists(usedLibPath))
+            // Check if the used kernels library really exists at the expected
+            // path and throw an understandable error, otherwise.
+            if (!std::filesystem::exists(usedLibPath))
                 throw std::runtime_error(
                     "the shared library `" + usedLibPath +
-                    "` is needed for some kernel, but the file does not exist"
-                );
+                    "` is needed for some kernel, but the file does not exist");
         }
 
     registerLLVMDialectTranslation(context_);
@@ -296,15 +306,16 @@ void DaphneIrExecutor::buildCodegenPipeline(mlir::PassManager &pm) {
 
     if (!userConfig_.use_mlir_hybrid_codegen) {
         pm.addPass(mlir::daphne::createMatMulOpLoweringPass(
-        userConfig_.matmul_tile, userConfig_.matmul_vec_size_bits,
-        userConfig_.matmul_fixed_tile_sizes,
-        userConfig_.matmul_use_fixed_tile_sizes,
-        userConfig_.matmul_unroll_factor, userConfig_.matmul_unroll_jam_factor,
-        userConfig_.matmul_num_vec_registers,
-        userConfig_.matmul_invert_loops));
+            userConfig_.matmul_tile, userConfig_.matmul_vec_size_bits,
+            userConfig_.matmul_fixed_tile_sizes,
+            userConfig_.matmul_use_fixed_tile_sizes,
+            userConfig_.matmul_unroll_factor,
+            userConfig_.matmul_unroll_jam_factor,
+            userConfig_.matmul_num_vec_registers,
+            userConfig_.matmul_invert_loops));
         if (userConfig_.explain_mlir_codegen)
-        pm.addPass(
-            mlir::daphne::createPrintIRPass("IR directly after lowering MatMulOp."));
+            pm.addPass(mlir::daphne::createPrintIRPass(
+                "IR directly after lowering MatMulOp."));
     }
 
     pm.addPass(mlir::createConvertMathToLLVMPass());
@@ -316,7 +327,7 @@ void DaphneIrExecutor::buildCodegenPipeline(mlir::PassManager &pm) {
     pm.addPass(mlir::createLowerAffinePass());
     mlir::LowerVectorToLLVMOptions lowerVectorToLLVMOptions;
     pm.addPass(mlir::createConvertVectorToLLVMPass(lowerVectorToLLVMOptions));
-    
+
     if (userConfig_.explain_mlir_codegen)
         pm.addPass(
             mlir::daphne::createPrintIRPass("IR after codegen pipeline"));

--- a/src/compiler/lowering/CMakeLists.txt
+++ b/src/compiler/lowering/CMakeLists.txt
@@ -33,6 +33,7 @@ add_mlir_dialect_library(MLIRDaphneTransforms
     MapOpLowering.cpp
     MatMulOpLowering.cpp
     AggAllOpLowering.cpp
+    LoopVectorizationPass.cpp
 
     DEPENDS
     MLIRDaphneOpsIncGen

--- a/src/compiler/lowering/LoopVectorizationPass.cpp
+++ b/src/compiler/lowering/LoopVectorizationPass.cpp
@@ -1,0 +1,572 @@
+/*
+ * Copyright 2021 The DAPHNE Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <ir/daphneir/Daphne.h>
+#include <ir/daphneir/Passes.h>
+#include <mlir/dialect/SCF/IR/SCF.h>
+
+using namespace mlir;
+
+/**
+ * @brief Replace loops with indexed matrix accesses by
+ * their corresponding element wise matrix operations whenever possible.
+ */
+class LoopVectorizationPass
+    : public PassWrapper<LoopVectorizationPass, OperationPass<ModuleOp>> {
+  public:
+    LoopVectorizationPass() {}
+
+    void runOnOperation() final;
+
+    StringRef getArgument() const final { return "loop-vectorization"; }
+    StringRef getDescription() const final {
+        return "Replace loops with indexed matrix accesses by their "
+               "corresponding element wise matrix operations whenever possible";
+    }
+};
+
+// Helper functions
+
+// Check if a value is a constant integer with the value i
+bool isConstantInteger(mlir::Value value, int i) {
+    if (auto op = dyn_cast<daphne::ConstantOp>(value.getDefiningOp())) {
+        auto val = op.getValue();
+        if (val.isa<IntegerAttr>() &&
+            val.dyn_cast<IntegerAttr>().getValue() == i) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+// Check if a loop returns only matrices of the same dimensions
+// If yes, return the dimensions of the matrices
+std::optional<std::pair<long int, long int>>
+getHomogenousReturnSize(scf::ForOp &loop) {
+    long int rows = 0;
+    long int cols = 0;
+
+    for (auto resType : loop.getResultTypes()) {
+        // Result must be a matrix type to even be considered
+        if (auto res = dyn_cast<daphne::MatrixType>(resType)) {
+            // Since Matrix types always have a size with cols, rows > 0, we can
+            // simply initialize them with 0 and then set them to the first
+            // value we encounter
+            if (rows == 0) {
+                rows = res.getNumRows();
+            }
+            if (cols == 0) {
+                cols = res.getNumCols();
+            }
+
+            // Ensure that all the matrix types returned have exactly the same
+            // size
+            if (rows != res.getNumRows() || cols != res.getNumCols()) {
+                return std::nullopt;
+            }
+        } else {
+            return std::nullopt;
+        }
+    }
+
+    return std::make_pair(rows, cols);
+}
+
+// Indices are generally not referenced directly in the loop body, but rather by
+// a sequence of multiplications by 1 and casts. This function resolves these.
+mlir::Value resolveIndex(mlir::Value val) {
+    if (val.isa<BlockArgument>()) {
+        return val;
+    }
+
+    auto def = val.getDefiningOp();
+    if (auto castOp = dyn_cast<daphne::CastOp>(def)) {
+        return resolveIndex(castOp.getOperand());
+    } else if (auto mulOp = dyn_cast<daphne::EwMulOp>(def)) {
+        if (isConstantInteger(mulOp.getOperand(1), 1)) {
+            return resolveIndex(mulOp.getOperand(0));
+        } else {
+            return val;
+        }
+    } else {
+        return val;
+    }
+}
+
+// Check if a loop has no side effects (we can only vectorize such loops)
+bool loopHasNoSideEffects(scf::ForOp &loopOp) {
+    bool result = true;
+
+    loopOp.getBody()->walk([&](mlir::Operation *op) {
+        if (auto memInterface = dyn_cast<MemoryEffectOpInterface>(op)) {
+            if (!memInterface.hasNoEffect()) {
+                result = false;
+            }
+        } else {
+            // Some ops don't implement the MemoryEffectOpInterface but are
+            // still treated as being side-effect-less for our purposes.
+            if (!dyn_cast<daphne::SliceColOp>(op) &&
+                !dyn_cast<daphne::SliceRowOp>(op) &&
+                !dyn_cast<daphne::InsertColOp>(op) &&
+                !dyn_cast<daphne::InsertRowOp>(op) &&
+                !dyn_cast<daphne::CastOp>(op)) {
+                result = false;
+            }
+        }
+    });
+
+    return result;
+}
+
+// An InnerLoop represents a loop whose body we are trying to vectorize
+class InnerLoop : public scf::ForOp {
+  public:
+    // Try to create an InnerLoop from an outer loop
+    static std::optional<InnerLoop>
+    getCompatibleInnerLoop(scf::ForOp &outerLoop, mlir::Location loc,
+                           OpBuilder &builder) {
+        auto returnSize = getHomogenousReturnSize(outerLoop);
+
+        if (!returnSize.has_value()) {
+            return std::nullopt;
+        }
+
+        auto [outerRows, outerCols] = *returnSize;
+
+        // Can only optimize with step sizes of 1 and lower bounds of 0
+        if (!isConstantInteger(outerLoop.getStep(), 1) ||
+            !isConstantInteger(outerLoop.getLowerBound(), 0)) {
+            return std::nullopt;
+        }
+
+        auto &body = outerLoop.getBody()->getOperations();
+        // Body must contain exactly 4 ops: CastOp, EwMulOp, ForOp, YieldOp
+        if (body.size() != 4) {
+            return std::nullopt;
+        }
+
+        // First Op must be a CastOp
+        auto it = body.begin();
+        if (!dyn_cast<daphne::CastOp>(it)) {
+            return std::nullopt;
+        }
+
+        // Second Op must be EwMulOp
+        it++;
+        if (!dyn_cast<daphne::EwMulOp>(&(*it))) {
+            return std::nullopt;
+        }
+
+        it++;
+        // Third Op is the actual inner loop
+        if (auto innerLoop = dyn_cast<scf::ForOp>(&(*it))) {
+            auto innerReturnSize = getHomogenousReturnSize(innerLoop);
+
+            if (!loopHasNoSideEffects(
+                    innerLoop) || // Must not have any side effects
+                !innerReturnSize.has_value()) {
+                return std::nullopt;
+            }
+
+            auto [innerRows, innerCols] = *innerReturnSize;
+
+            if (!isConstantInteger(innerLoop.getStep(), 1) ||
+                !isConstantInteger(innerLoop.getLowerBound(), 0)) {
+                return std::nullopt;
+            }
+
+            // inner and outer dimensions and number of results must match
+            if (innerRows == outerRows && innerCols == outerCols &&
+                innerLoop.getNumResults() == outerLoop.getNumResults()) {
+                // determine if i refers to rows or cols
+                if (isConstantInteger(innerLoop.getUpperBound(), outerCols) &&
+                    isConstantInteger(outerLoop.getUpperBound(), outerRows)) {
+                    return InnerLoop(
+                        innerLoop, outerRows, outerCols,
+                        outerLoop
+                            .getInductionVar(), // outerLoop var is rows (i) and
+                        innerLoop
+                            .getInductionVar(), // innerLoop var is cols (j)
+                        loc, builder);
+                }
+                if (isConstantInteger(outerLoop.getUpperBound(), outerCols) &&
+                    isConstantInteger(innerLoop.getUpperBound(), outerRows)) {
+                    return InnerLoop(
+                        innerLoop, outerRows, outerCols,
+                        innerLoop
+                            .getInductionVar(), // innerLoop var is rows (i) and
+                        outerLoop
+                            .getInductionVar(), // outerLoop var is cols (j)
+                        loc, builder);
+                }
+            }
+        }
+
+        return std::nullopt;
+    }
+
+    // If vectorization fails, we must delete all the extra values we created
+    void flushBuiltVals() {
+        for (auto it = builtVals.rbegin(); it != builtVals.rend(); it++) {
+            it->getDefiningOp()->erase();
+        }
+        builtVals.clear();
+    }
+
+    // Delete all the unnecessary casts we inserted.
+    // This naive implementation is safe because we only insert trivial casts
+    void flushBuiltCasts() {
+        for (auto val : builtVals) {
+            if (auto castOp = dyn_cast<daphne::CastOp>(val.getDefiningOp())) {
+                castOp.getResult().replaceAllUsesWith(castOp.getOperand());
+                castOp.erase();
+            }
+        }
+    }
+
+    // Check whether an operation inserts a value into a matrix of the correct
+    // size at position i, j and return the value that is inserted if so.
+    std::optional<mlir::Value> ijInsert(mlir::Operation *op) {
+        if (auto insertRowOp = dyn_cast<daphne::InsertRowOp>(op)) {
+            auto insertColOp = static_cast<daphne::InsertColOp>(
+                insertRowOp.getOperand(1)
+                    .getDefiningOp()); // Accesses always happen this way, so
+                                       // static_cast is fine.
+            auto resultType = static_cast<daphne::MatrixType>(
+                insertRowOp.getResult().getType().cast<daphne::MatrixType>());
+
+            if (resultType.getNumRows() != rows ||
+                resultType.getNumCols() != cols) {
+                return std::nullopt;
+            }
+
+            // Make sure the insertion indices are correct
+            if (isi(insertRowOp.getOperand(2)) &&
+                isj(insertColOp.getOperand(2)) &&
+                isiplus1(insertRowOp.getOperand(3)) &&
+                isjplus1(insertColOp.getOperand(3))) {
+                return insertColOp.getOperand(1);
+            }
+        }
+        return std::nullopt;
+    }
+
+    std::optional<mlir::Value> buildVectorized(mlir::Operation *op) {
+        if (auto sliceColOp = dyn_cast<daphne::SliceColOp>(*op)) {
+            if (auto access = ijAccess(sliceColOp)) {
+                auto built_val =
+                    builder
+                        .create<daphne::CastOp>(loc, access->getType(),
+                                                *access)
+                        .getResult(); // insert an empty cast. Will be removed
+                                      // at the end of the pass. Necessary
+                                      // to move values outside of the loop.
+                builtVals.push_back(built_val);
+                return built_val;
+            }
+        } else if (auto constantOp = dyn_cast<daphne::ConstantOp>(*op)) {
+            return constantOp.getResult();
+        } else if (auto ewAddOp = dyn_cast<daphne::EwAddOp>(*op)) {
+            return vectorizeBinOp(ewAddOp);
+        } else if (auto ewMulOp = dyn_cast<daphne::EwMulOp>(*op)) {
+            return vectorizeBinOp(ewMulOp);
+        } else if (auto ewSubOp = dyn_cast<daphne::EwSubOp>(*op)) {
+            return vectorizeBinOp(ewSubOp);
+        } else if (auto ewDivOp = dyn_cast<daphne::EwDivOp>(*op)) {
+            auto lhs = buildVectorized(ewDivOp.getOperand(0).getDefiningOp());
+            auto rhs = buildVectorized(ewDivOp.getOperand(1).getDefiningOp());
+
+            if (lhs.has_value() && rhs.has_value()) {
+                // needs typechecking (lhs must be float)
+                if (lhs->getType().isa<FloatType>()) {
+                    auto built_val =
+                        builder.create<daphne::EwDivOp>(loc, *lhs, *rhs)
+                            .getResult();
+                    builtVals.push_back(built_val);
+                    return built_val;
+                }
+            }
+
+            return std::nullopt;
+        } else if (auto ewPowOp = dyn_cast<daphne::EwPowOp>(*op)) {
+            return vectorizeBinOpLmatrix(ewPowOp);
+        } else if (auto ewModOp = dyn_cast<daphne::EwModOp>(*op)) {
+            return vectorizeBinOpLmatrix(ewModOp);
+        } else if (auto ewAndOp = dyn_cast<daphne::EwAndOp>(*op)) {
+            return vectorizeBinOpLmatrix(ewAndOp);
+        } else if (auto ewOrOp = dyn_cast<daphne::EwOrOp>(*op)) {
+            return vectorizeBinOpLmatrix(ewOrOp);
+        } else if (auto ewLogOp = dyn_cast<daphne::EwLogOp>(*op)) {
+            return vectorizeBinOpLmatrix(ewLogOp);
+        } else if (auto ewMinOp = dyn_cast<daphne::EwMinOp>(*op)) {
+            return vectorizeBinOpLmatrix(ewMinOp);
+        } else if (auto ewMaxOp = dyn_cast<daphne::EwMaxOp>(*op)) {
+            return vectorizeBinOpLmatrix(ewMaxOp);
+        } else if (auto ewLeOp = dyn_cast<daphne::EwLeOp>(*op)) {
+            return vectorizeBinOpLmatrix(ewLeOp);
+        } else if (auto ewLtOp = dyn_cast<daphne::EwLtOp>(*op)) {
+            return vectorizeBinOpLmatrix(ewLtOp);
+        } else if (auto ewGeOp = dyn_cast<daphne::EwGeOp>(*op)) {
+            return vectorizeBinOpLmatrix(ewGeOp);
+        } else if (auto ewGtOp = dyn_cast<daphne::EwGtOp>(*op)) {
+            return vectorizeBinOpLmatrix(ewGtOp);
+        } else if (auto ewEqOp = dyn_cast<daphne::EwEqOp>(*op)) {
+            return vectorizeBinOpLmatrix(ewEqOp);
+        } else if (auto ewNeqOp = dyn_cast<daphne::EwNeqOp>(*op)) {
+            return vectorizeBinOpLmatrix(ewNeqOp);
+        } else if (auto ewAbsOp = dyn_cast<daphne::EwAbsOp>(*op)) {
+            return vectorizeUnOp(ewAbsOp);
+        } else if (auto ewSignOp = dyn_cast<daphne::EwSignOp>(*op)) {
+            return vectorizeUnOp(ewSignOp);
+        } else if (auto ewExpOp = dyn_cast<daphne::EwExpOp>(*op)) {
+            return vectorizeUnOp(ewExpOp);
+        } else if (auto ewLnOp = dyn_cast<daphne::EwLnOp>(*op)) {
+            return vectorizeUnOp(ewLnOp);
+        } else if (auto ewSqrtOp = dyn_cast<daphne::EwSqrtOp>(*op)) {
+            return vectorizeUnOp(ewSqrtOp);
+        } else if (auto ewSinOp = dyn_cast<daphne::EwSinOp>(*op)) {
+            return vectorizeUnOp(ewSinOp);
+        } else if (auto ewCosOp = dyn_cast<daphne::EwCosOp>(*op)) {
+            return vectorizeUnOp(ewCosOp);
+        } else if (auto ewTanOp = dyn_cast<daphne::EwTanOp>(*op)) {
+            return vectorizeUnOp(ewTanOp);
+        } else if (auto ewAsinOp = dyn_cast<daphne::EwAsinOp>(*op)) {
+            return vectorizeUnOp(ewAsinOp);
+        } else if (auto ewAcosOp = dyn_cast<daphne::EwAcosOp>(*op)) {
+            return vectorizeUnOp(ewAcosOp);
+        } else if (auto ewAtanOp = dyn_cast<daphne::EwAtanOp>(*op)) {
+            return vectorizeUnOp(ewAtanOp);
+        } else if (auto ewSinhOp = dyn_cast<daphne::EwSinhOp>(*op)) {
+            return vectorizeUnOp(ewSinhOp);
+        } else if (auto ewCoshOp = dyn_cast<daphne::EwCoshOp>(*op)) {
+            return vectorizeUnOp(ewCoshOp);
+        } else if (auto ewTanhOp = dyn_cast<daphne::EwTanhOp>(*op)) {
+            return vectorizeUnOp(ewTanhOp);
+        }
+
+        return std::nullopt;
+    }
+
+  private:
+    InnerLoop(scf::ForOp &loop,                         // The loop itself
+              const long int rows, const long int cols, // Matrix dimensions
+              mlir::Value i, // Induction variable of the outer loop
+              mlir::Value j, mlir::Location loc,
+              OpBuilder &builder) // Module and builder
+        : scf::ForOp(loop), rows(rows), cols(cols), i(i), j(j), loc(loc),
+          builder(builder) {}
+
+    // Check if a SliceColOp accesses the i, j matrix element and return the
+    // original matrix if so
+    std::optional<mlir::Value> ijAccess(daphne::SliceColOp &sliceColOp) {
+        auto sliceRowOp = static_cast<daphne::SliceRowOp>(
+            sliceColOp.getSource().getDefiningOp());
+        if (auto sourceType = dyn_cast<daphne::MatrixType>(
+                sliceRowOp.getSource().getType())) {
+            if (sourceType.getNumRows() != rows ||
+                sourceType.getNumCols() != cols) {
+                return std::nullopt;
+            }
+        }
+
+        auto source = sliceRowOp.getSource();
+        if (auto blockArgument = dyn_cast<mlir::BlockArgument>(source)) {
+            // If this is an iteration argument, we need to get its
+            // original source from outside the outer loop
+            if (blockArgument.getOwner() == getBody()) {
+                auto outerLoop = static_cast<scf::ForOp>(
+                    blockArgument.getOwner()
+                        ->getParentOp()
+                        ->getParentOp()); // safe because we know we're in a
+                                          // nested loop
+                source =
+                    outerLoop.getInitArgs()[blockArgument.getArgNumber() -
+                                            1]; // - 1 because the InductionVar
+                                                // is counted in the ArgNumber
+            }
+        }
+
+        if (isi(sliceRowOp.getOperand(1)) &&
+            isiplus1(sliceRowOp.getOperand(2)) &&
+            isj(sliceColOp.getOperand(1)) &&
+            isjplus1(sliceColOp.getOperand(2))) {
+            return source;
+        }
+
+        return std::nullopt;
+    }
+
+    // Helper functions
+    bool isi(mlir::Value val) { return i == resolveIndex(val); }
+    bool isj(mlir::Value val) { return j == resolveIndex(val); }
+
+    bool isiplus1(mlir::Value val) {
+        if (auto castOp = dyn_cast<daphne::CastOp>(val.getDefiningOp())) {
+            if (auto addOp = dyn_cast<daphne::EwAddOp>(
+                    castOp.getOperand().getDefiningOp())) {
+                if (isi(addOp.getOperand(0)) &&
+                    isConstantInteger(addOp.getOperand(1), 1)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    bool isjplus1(mlir::Value val) {
+        if (auto castOp = dyn_cast<daphne::CastOp>(val.getDefiningOp())) {
+            if (auto addOp = dyn_cast<daphne::EwAddOp>(
+                    castOp.getOperand().getDefiningOp())) {
+                if (isj(addOp.getOperand(0)) &&
+                    isConstantInteger(addOp.getOperand(1), 1)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    // Vectorize a binary operation
+    template <typename T> std::optional<mlir::Value> vectorizeBinOp(T binOp) {
+        auto lhs = buildVectorized(binOp.getOperand(0).getDefiningOp());
+        auto rhs = buildVectorized(binOp.getOperand(1).getDefiningOp());
+
+        if (lhs.has_value() && rhs.has_value()) {
+            auto built_val = builder.create<T>(loc, *lhs, *rhs).getResult();
+            builtVals.push_back(built_val);
+            return built_val;
+        }
+        return std::nullopt;
+    }
+
+    // Vectorize a binary operation, ensuring that the lhs is a matrix
+    template <typename T>
+    std::optional<mlir::Value> vectorizeBinOpLmatrix(T binOp) {
+        auto lhs = buildVectorized(binOp.getOperand(0).getDefiningOp());
+        auto rhs = buildVectorized(binOp.getOperand(1).getDefiningOp());
+
+        if (lhs.has_value() && rhs.has_value()) {
+            // Some operations are not defined when lhs is a scalar, so we check
+            // for this
+            if (dyn_cast<daphne::MatrixType>(lhs->getType())) {
+                auto built_val = builder.create<T>(loc, *lhs, *rhs).getResult();
+                builtVals.push_back(built_val);
+                return built_val;
+            }
+        }
+
+        return std::nullopt;
+    }
+
+    // Vectorize a unary operation
+    template <typename T> std::optional<mlir::Value> vectorizeUnOp(T unOp) {
+        auto elementType = unOp.getResult().getType();
+        if (auto matrixType = dyn_cast<daphne::MatrixType>(elementType)) {
+            elementType = matrixType.getElementType();
+        }
+
+        if (auto operand = buildVectorized(unOp.getOperand().getDefiningOp())) {
+            // Make sure to preserve the matrix element type
+            auto type = operand->getType();
+            if (auto matrixType = dyn_cast<daphne::MatrixType>(type)) {
+                type = matrixType.withElementType(elementType);
+            }
+            auto built_val = builder.create<T>(loc, type, *operand).getResult();
+            builtVals.push_back(built_val);
+            return built_val;
+        }
+        return std::nullopt;
+    }
+
+    std::vector<mlir::Value> builtVals;
+
+    const long int rows;
+    const long int cols;
+
+    mlir::Value i;
+    mlir::Value j;
+
+    mlir::Location loc;
+    mlir::OpBuilder builder;
+};
+
+void LoopVectorizationPass::runOnOperation() {
+    auto module = getOperation();
+    auto loc = module.getLoc();
+    mlir::OpBuilder builder(module);
+
+    module.walk([&](mlir::Operation *op) {
+        if (auto loopOp = dyn_cast<scf::ForOp>(op)) {
+            // Set insertion point right before the loop
+            builder.setInsertionPoint(loopOp);
+
+            // Check if inner loop could potentially be vectorized
+            if (auto innerLoop =
+                    InnerLoop::getCompatibleInnerLoop(loopOp, loc, builder)) {
+                auto yieldOp = static_cast<scf::YieldOp>(
+                    &innerLoop->getBody()
+                         ->getOperations()
+                         .back()); // safe because we know the last operation is
+                                   // a YieldOp
+
+                // New results for the YieldOp
+                std::vector<mlir::Value> newResults;
+
+                for (auto yieldRes : yieldOp.getOperands()) {
+                    if (auto insertedVal =
+                            innerLoop->ijInsert(yieldRes.getDefiningOp())) {
+                        if (auto vectorized = innerLoop->buildVectorized(
+                                insertedVal->getDefiningOp())) {
+
+                            // If type conflicts happen, don't vectorize
+                            if (yieldRes.getType() == vectorized->getType()) {
+                                newResults.push_back(*vectorized);
+                            }
+                        }
+                    }
+                }
+                // Only commit results if we successfully vectorized all of them
+                if (newResults.size() == yieldOp.getNumOperands()) {
+                    for (uint i = 0; i < newResults.size(); i++) {
+                        auto result = newResults[i];
+                        // Replace the old results with the new ones (even
+                        // though we delete the yield, this is useful for loops
+                        // that return multiple interdependent values)
+                        yieldOp.getOperand(i).replaceAllUsesWith(result);
+                        // Replace the old results with the new ones outside of
+                        // the loop
+                        loopOp.getResult(i).replaceAllUsesWith(result);
+                    }
+                    // Delete the unnecessary casts
+                    innerLoop->flushBuiltCasts();
+                    // Delete the entire loop
+                    loopOp.erase();
+                } else {
+                    // Failed to vectorize yields, delete all the extra values
+                    // we created
+                    innerLoop->flushBuiltVals();
+                }
+            }
+        }
+    });
+}
+
+std::unique_ptr<Pass> daphne::createLoopVectorizationPass() {
+    return std::make_unique<LoopVectorizationPass>();
+}

--- a/src/ir/daphneir/Passes.h
+++ b/src/ir/daphneir/Passes.h
@@ -29,61 +29,64 @@
 #include <unordered_map>
 
 namespace mlir::daphne {
-    struct InferenceConfig {
-        InferenceConfig(bool partialInferenceAllowed,
-                        bool typeInference,
-                        bool shapeInference,
-                        bool frameLabelInference,
-                        bool sparsityInference);
-        bool partialInferenceAllowed;
-        bool typeInference;
-        bool shapeInference;
-        bool frameLabelInference;
-        bool sparsityInference;
-    };
+struct InferenceConfig {
+    InferenceConfig(bool partialInferenceAllowed, bool typeInference,
+                    bool shapeInference, bool frameLabelInference,
+                    bool sparsityInference);
+    bool partialInferenceAllowed;
+    bool typeInference;
+    bool shapeInference;
+    bool frameLabelInference;
+    bool sparsityInference;
+};
 
-    // alphabetically sorted list of passes
-    std::unique_ptr<Pass> createAdaptTypesToKernelsPass();
-    std::unique_ptr<Pass> createDistributeComputationsPass();
-    std::unique_ptr<Pass> createDistributePipelinesPass();
-    std::unique_ptr<Pass> createMapOpLoweringPass();
-    std::unique_ptr<Pass> createEwOpLoweringPass();
-    std::unique_ptr<Pass> createModOpLoweringPass();
-    std::unique_ptr<Pass> createInferencePass(InferenceConfig cfg = {false, true, true, true, true});
-    std::unique_ptr<Pass> createInsertDaphneContextPass(const DaphneUserConfig& cfg);
-    std::unique_ptr<Pass> createDaphneOptPass();
-    std::unique_ptr<OperationPass<ModuleOp>> createMatMulOpLoweringPass(bool matmul_tile,
-        int matmul_vec_size_bits = 0,
-        std::vector<unsigned> matmul_fixed_tile_sizes = {},
-        bool matmul_use_fixed_tile_sizes = false,
-        int matmul_unroll_factor = 1,
-        int matmul_unroll_jam_factor = 4,
-        int matmul_num_vec_registers = 16,
-        bool matmul_invert_loops = false);
-    std::unique_ptr<OperationPass<ModuleOp>>  createMatMulOpLoweringPass();
-    std::unique_ptr<Pass> createAggAllOpLoweringPass();
-    std::unique_ptr<Pass> createMemRefTestPass();
-    std::unique_ptr<Pass> createProfilingPass();
-    std::unique_ptr<Pass> createLowerToLLVMPass(const DaphneUserConfig& cfg);
-    std::unique_ptr<Pass> createManageObjRefsPass();
-    std::unique_ptr<Pass> createPhyOperatorSelectionPass();
-    std::unique_ptr<Pass> createPrintIRPass(std::string message = "");
-    std::unique_ptr<Pass> createRewriteSqlOpPass();
-    std::unique_ptr<Pass> createRewriteToCallKernelOpPass(const DaphneUserConfig& cfg, std::unordered_map<std::string, bool> & usedLibPaths);
-    std::unique_ptr<Pass> createSelectMatrixRepresentationsPass(const DaphneUserConfig& cfg);
-    std::unique_ptr<Pass> createSpecializeGenericFunctionsPass(const DaphneUserConfig& cfg);
-    std::unique_ptr<Pass> createVectorizeComputationsPass();
-    std::unique_ptr<Pass> createWhileLoopInvariantCodeMotionPass();
+// alphabetically sorted list of passes
+std::unique_ptr<Pass> createAdaptTypesToKernelsPass();
+std::unique_ptr<Pass> createDistributeComputationsPass();
+std::unique_ptr<Pass> createDistributePipelinesPass();
+std::unique_ptr<Pass> createMapOpLoweringPass();
+std::unique_ptr<Pass> createEwOpLoweringPass();
+std::unique_ptr<Pass> createModOpLoweringPass();
+std::unique_ptr<Pass> createInferencePass(InferenceConfig cfg = {
+                                              false, true, true, true, true});
+std::unique_ptr<Pass>
+createInsertDaphneContextPass(const DaphneUserConfig &cfg);
+std::unique_ptr<Pass> createDaphneOptPass();
+std::unique_ptr<OperationPass<ModuleOp>> createMatMulOpLoweringPass(
+    bool matmul_tile, int matmul_vec_size_bits = 0,
+    std::vector<unsigned> matmul_fixed_tile_sizes = {},
+    bool matmul_use_fixed_tile_sizes = false, int matmul_unroll_factor = 1,
+    int matmul_unroll_jam_factor = 4, int matmul_num_vec_registers = 16,
+    bool matmul_invert_loops = false);
+std::unique_ptr<OperationPass<ModuleOp>> createMatMulOpLoweringPass();
+std::unique_ptr<Pass> createAggAllOpLoweringPass();
+std::unique_ptr<Pass> createMemRefTestPass();
+std::unique_ptr<Pass> createProfilingPass();
+std::unique_ptr<Pass> createLoopVectorizationPass();
+std::unique_ptr<Pass> createLowerToLLVMPass(const DaphneUserConfig &cfg);
+std::unique_ptr<Pass> createManageObjRefsPass();
+std::unique_ptr<Pass> createPhyOperatorSelectionPass();
+std::unique_ptr<Pass> createPrintIRPass(std::string message = "");
+std::unique_ptr<Pass> createRewriteSqlOpPass();
+std::unique_ptr<Pass> createRewriteToCallKernelOpPass(
+    const DaphneUserConfig &cfg,
+    std::unordered_map<std::string, bool> &usedLibPaths);
+std::unique_ptr<Pass>
+createSelectMatrixRepresentationsPass(const DaphneUserConfig &cfg);
+std::unique_ptr<Pass>
+createSpecializeGenericFunctionsPass(const DaphneUserConfig &cfg);
+std::unique_ptr<Pass> createVectorizeComputationsPass();
+std::unique_ptr<Pass> createWhileLoopInvariantCodeMotionPass();
 #ifdef USE_CUDA
-    std::unique_ptr<Pass> createMarkCUDAOpsPass(const DaphneUserConfig& cfg);
+std::unique_ptr<Pass> createMarkCUDAOpsPass(const DaphneUserConfig &cfg);
 #endif
 
 #ifdef USE_FPGAOPENCL
-    std::unique_ptr<Pass> createMarkFPGAOPENCLOpsPass(const DaphneUserConfig& cfg);
+std::unique_ptr<Pass> createMarkFPGAOPENCLOpsPass(const DaphneUserConfig &cfg);
 #endif
 
 #define GEN_PASS_REGISTRATION
 #include "ir/daphneir/Passes.h.inc"
 } // namespace mlir::daphne
 
-#endif //SRC_IR_DAPHNEIR_PASSES_H
+#endif // SRC_IR_DAPHNEIR_PASSES_H

--- a/src/ir/daphneir/Passes.td
+++ b/src/ir/daphneir/Passes.td
@@ -63,6 +63,10 @@ def MapOpLoweringPass: Pass<"lower-map", "::mlir::func::FuncOp"> {
     let constructor = "mlir::daphne::createMapOpLoweringPass()";
 }
 
+def LoopVectorizationPass: Pass<"loop-vectorization", "::mlir::ModuleOp"> {
+    let constructor = "mlir::daphne::createLoopVectorizationPass()";
+}
+
 def MatMulOpLoweringPass: Pass<"lower-mm", "::mlir::ModuleOp"> {
   let summary = "Lower the MatMulOp acting on Daphne matrices to an affine loop structure.";
   let dependentDialects = ["vector::VectorDialect", "mlir::LLVM::LLVMDialect", "mlir::AffineDialect",

--- a/src/parser/config/ConfigParser.cpp
+++ b/src/parser/config/ConfigParser.cpp
@@ -80,6 +80,8 @@ void ConfigParser::readUserConfig(const std::string& filename, DaphneUserConfig&
         config.explain_kernels = jf.at(DaphneConfigJsonParams::EXPLAIN_KERNELS).get<bool>();
     if (keyExists(jf, DaphneConfigJsonParams::EXPLAIN_LLVM))
         config.explain_llvm = jf.at(DaphneConfigJsonParams::EXPLAIN_LLVM).get<bool>();
+    if (keyExists(jf, DaphneConfigJsonParams::EXPLAIN_LOOP_VECTORIZATION))
+        config.explain_llvm = jf.at(DaphneConfigJsonParams::EXPLAIN_LOOP_VECTORIZATION).get<bool>();
     if (keyExists(jf, DaphneConfigJsonParams::EXPLAIN_PARSING))
         config.explain_parsing = jf.at(DaphneConfigJsonParams::EXPLAIN_PARSING).get<bool>();
     if (keyExists(jf, DaphneConfigJsonParams::EXPLAIN_PARSING_SIMPLIFIED))

--- a/src/parser/config/JsonParams.h
+++ b/src/parser/config/JsonParams.h
@@ -44,6 +44,7 @@ struct DaphneConfigJsonParams {
     inline static const std::string DEBUG_LLVM = "debug_llvm";
     inline static const std::string EXPLAIN_KERNELS = "explain_kernels";
     inline static const std::string EXPLAIN_LLVM = "explain_llvm";
+    inline static const std::string EXPLAIN_LOOP_VECTORIZATION = "explain_loop_vectorization";
     inline static const std::string EXPLAIN_PARSING = "explain_parsing";
     inline static const std::string EXPLAIN_PARSING_SIMPLIFIED = "explain_parsing_simplified";
     inline static const std::string EXPLAIN_PROPERTY_INFERENCE = "explain_property_inference";
@@ -84,6 +85,7 @@ struct DaphneConfigJsonParams {
             DEBUG_LLVM,
             EXPLAIN_KERNELS,
             EXPLAIN_LLVM,
+            EXPLAIN_LOOP_VECTORIZATION,
             EXPLAIN_PARSING,
             EXPLAIN_PARSING_SIMPLIFIED,
             EXPLAIN_PROPERTY_INFERENCE,

--- a/test/codegen/loop-vectorization.mlir
+++ b/test/codegen/loop-vectorization.mlir
@@ -1,0 +1,282 @@
+// RUN: daphne-opt --loop-vectorization %s | FileCheck %s
+module {
+    // CHECK-LABEL: func.func @"e-6"
+    func.func @"e-6"() {
+    %0 = "daphne.constant"() {value = 1 : index} : () -> index
+    %1 = "daphne.constant"() {value = 3 : index} : () -> index
+    %2 = "daphne.constant"() {value = 0 : index} : () -> index
+    %3 = "daphne.constant"() {value = 1 : si64} : () -> si64
+    %4 = "daphne.constant"() {value = 9 : index} : () -> index
+    %5 = "daphne.constant"() {value = 187651264387696 : ui64} : () -> ui64
+    %6 = "daphne.matrixConstant"(%5) : (ui64) -> !daphne.Matrix<9x1xsi64>
+    %7 = "daphne.reshape"(%6, %4, %0) : (!daphne.Matrix<9x1xsi64>, index, index) -> !daphne.Matrix<9x1xsi64>
+    %8 = "daphne.reshape"(%7, %1, %1) : (!daphne.Matrix<9x1xsi64>, index, index) -> !daphne.Matrix<3x3xsi64>
+    %9 = "daphne.ewCos"(%8) : (!daphne.Matrix<3x3xsi64>) -> !daphne.Matrix<3x3xf64>
+    %10 = "daphne.ewSin"(%8) : (!daphne.Matrix<3x3xsi64>) -> !daphne.Matrix<3x3xf64>
+    // CHECK: scf.for
+    // CHECK-NEXT: daphne.cast
+    // CHECK-NEXT: daphne.ewMul
+    // CHECK-NEXT: scf.for
+    %11 = scf.for %arg0 = %2 to %1 step %0 iter_args(%arg1 = %9) -> (!daphne.Matrix<3x3xf64>) {
+      %12 = "daphne.cast"(%arg0) : (index) -> si64
+      %13 = "daphne.ewMul"(%12, %3) : (si64, si64) -> si64
+      %14 = scf.for %arg2 = %2 to %1 step %0 iter_args(%arg3 = %arg1) -> (!daphne.Matrix<3x3xf64>) {
+        %15 = "daphne.cast"(%arg2) : (index) -> si64
+        %16 = "daphne.ewMul"(%15, %3) : (si64, si64) -> si64
+        %17 = "daphne.ewAdd"(%13, %3) : (si64, si64) -> ui64
+        %18 = "daphne.cast"(%17) : (ui64) -> si64
+        %19 = "daphne.sliceRow"(%10, %13, %18) : (!daphne.Matrix<3x3xf64>, si64, si64) -> !daphne.Matrix<?x3xf64>
+        %20 = "daphne.ewAdd"(%16, %3) : (si64, si64) -> ui64
+        %21 = "daphne.cast"(%20) : (ui64) -> si64
+        %22 = "daphne.sliceCol"(%19, %16, %21) : (!daphne.Matrix<?x3xf64>, si64, si64) -> !daphne.Matrix<?x?xf64>
+        %23 = "daphne.cast"(%20) : (ui64) -> si64
+        %24 = "daphne.sliceRow"(%arg3, %16, %23) : (!daphne.Matrix<3x3xf64>, si64, si64) -> !daphne.Matrix<?x3xf64>
+        %25 = "daphne.cast"(%17) : (ui64) -> si64
+        %26 = "daphne.insertCol"(%24, %22, %13, %25) : (!daphne.Matrix<?x3xf64>, !daphne.Matrix<?x?xf64>, si64, si64) -> !daphne.Matrix<?x3xf64>
+        %27 = "daphne.cast"(%20) : (ui64) -> si64
+        %28 = "daphne.insertRow"(%arg3, %26, %16, %27) : (!daphne.Matrix<3x3xf64>, !daphne.Matrix<?x3xf64>, si64, si64) -> !daphne.Matrix<3x3xf64>
+        scf.yield %28 : !daphne.Matrix<3x3xf64>
+      }
+      scf.yield %14 : !daphne.Matrix<3x3xf64>
+    }
+    "daphne.return"() : () -> ()
+  }
+  // CHECK-LABEL: func.func @"f-5"
+  func.func @"f-5"() {
+    %0 = "daphne.constant"() {value = 1 : index} : () -> index
+    %1 = "daphne.constant"() {value = 3 : index} : () -> index
+    %2 = "daphne.constant"() {value = 0 : index} : () -> index
+    %3 = "daphne.constant"() {value = 1 : si64} : () -> si64
+    %4 = "daphne.constant"() {value = 2 : index} : () -> index
+    %5 = "daphne.constant"() {value = 6 : index} : () -> index
+    %6 = "daphne.constant"() {value = 187651263218944 : ui64} : () -> ui64
+    %7 = "daphne.matrixConstant"(%6) : (ui64) -> !daphne.Matrix<6x1xsi64>
+    %8 = "daphne.reshape"(%7, %5, %0) : (!daphne.Matrix<6x1xsi64>, index, index) -> !daphne.Matrix<6x1xsi64>
+    %9 = "daphne.reshape"(%8, %4, %1) : (!daphne.Matrix<6x1xsi64>, index, index) -> !daphne.Matrix<2x3xsi64>
+    %10 = "daphne.ewCos"(%9) : (!daphne.Matrix<2x3xsi64>) -> !daphne.Matrix<2x3xf64>
+    %11 = "daphne.ewSin"(%9) : (!daphne.Matrix<2x3xsi64>) -> !daphne.Matrix<2x3xf64>
+    // CHECK-NO: scf.for
+    %12 = scf.for %arg0 = %2 to %1 step %0 iter_args(%arg1 = %10) -> (!daphne.Matrix<2x3xf64>) {
+      %13 = "daphne.cast"(%arg0) : (index) -> si64
+      %14 = "daphne.ewMul"(%13, %3) : (si64, si64) -> si64
+      %15 = scf.for %arg2 = %2 to %4 step %0 iter_args(%arg3 = %arg1) -> (!daphne.Matrix<2x3xf64>) {
+        %16 = "daphne.cast"(%arg2) : (index) -> si64
+        %17 = "daphne.ewMul"(%16, %3) : (si64, si64) -> si64
+        %18 = "daphne.ewAdd"(%17, %3) : (si64, si64) -> ui64
+        %19 = "daphne.cast"(%18) : (ui64) -> si64
+        %20 = "daphne.sliceRow"(%11, %17, %19) : (!daphne.Matrix<2x3xf64>, si64, si64) -> !daphne.Matrix<?x3xf64>
+        %21 = "daphne.ewAdd"(%14, %3) : (si64, si64) -> ui64
+        %22 = "daphne.cast"(%21) : (ui64) -> si64
+        %23 = "daphne.sliceCol"(%20, %14, %22) : (!daphne.Matrix<?x3xf64>, si64, si64) -> !daphne.Matrix<?x?xf64>
+        %24 = "daphne.cast"(%18) : (ui64) -> si64
+        %25 = "daphne.sliceRow"(%arg3, %17, %24) : (!daphne.Matrix<2x3xf64>, si64, si64) -> !daphne.Matrix<?x3xf64>
+        %26 = "daphne.cast"(%21) : (ui64) -> si64
+        %27 = "daphne.insertCol"(%25, %23, %14, %26) : (!daphne.Matrix<?x3xf64>, !daphne.Matrix<?x?xf64>, si64, si64) -> !daphne.Matrix<?x3xf64>
+        %28 = "daphne.cast"(%18) : (ui64) -> si64
+        %29 = "daphne.insertRow"(%arg3, %27, %17, %28) : (!daphne.Matrix<2x3xf64>, !daphne.Matrix<?x3xf64>, si64, si64) -> !daphne.Matrix<2x3xf64>
+        scf.yield %29 : !daphne.Matrix<2x3xf64>
+      }
+      scf.yield %15 : !daphne.Matrix<2x3xf64>
+    }
+    "daphne.return"() : () -> ()
+  }
+  // CHECK-LABEL: func.func @"d-4"
+  func.func @"d-4"() {
+    %0 = "daphne.constant"() {value = 3 : index} : () -> index
+    %1 = "daphne.constant"() {value = 1 : si64} : () -> si64
+    %2 = "daphne.constant"() {value = 2 : index} : () -> index
+    %3 = "daphne.constant"() {value = 1 : index} : () -> index
+    %4 = "daphne.constant"() {value = 11 : index} : () -> index
+    %5 = "daphne.constant"() {value = 0 : index} : () -> index
+    %6 = "daphne.constant"() {value = 6 : index} : () -> index
+    %7 = "daphne.constant"() {value = 187651262036512 : ui64} : () -> ui64
+    %8 = "daphne.matrixConstant"(%7) : (ui64) -> !daphne.Matrix<6x1xsi64>
+    %9 = "daphne.reshape"(%8, %6, %3) : (!daphne.Matrix<6x1xsi64>, index, index) -> !daphne.Matrix<6x1xsi64>
+    %10 = "daphne.reshape"(%9, %2, %0) : (!daphne.Matrix<6x1xsi64>, index, index) -> !daphne.Matrix<2x3xsi64>
+    %11 = "daphne.ewCos"(%10) : (!daphne.Matrix<2x3xsi64>) -> !daphne.Matrix<2x3xf64>
+    // CHECK: scf.for
+    // CHECK-NEXT: daphne.cast
+    // CHECK-NEXT: daphne.ewAdd
+    %12 = scf.for %arg0 = %5 to %4 step %3 iter_args(%arg1 = %11) -> (!daphne.Matrix<2x3xf64>) {
+      %13 = "daphne.cast"(%arg0) : (index) -> si64
+      %14 = scf.for %arg2 = %5 to %0 step %3 iter_args(%arg3 = %arg1) -> (!daphne.Matrix<2x3xf64>) {
+        %15 = "daphne.cast"(%arg2) : (index) -> si64
+        %16 = "daphne.ewMul"(%15, %1) : (si64, si64) -> si64
+        %17 = scf.for %arg4 = %5 to %2 step %3 iter_args(%arg5 = %arg3) -> (!daphne.Matrix<2x3xf64>) {
+          %18 = "daphne.cast"(%arg4) : (index) -> si64
+          %19 = "daphne.ewMul"(%18, %1) : (si64, si64) -> si64
+          %20 = "daphne.ewAdd"(%19, %1) : (si64, si64) -> ui64
+          %21 = "daphne.cast"(%20) : (ui64) -> si64
+          %22 = "daphne.sliceRow"(%arg5, %19, %21) : (!daphne.Matrix<2x3xf64>, si64, si64) -> !daphne.Matrix<?x3xf64>
+          %23 = "daphne.ewAdd"(%16, %1) : (si64, si64) -> ui64
+          %24 = "daphne.cast"(%23) : (ui64) -> si64
+          %25 = "daphne.sliceCol"(%22, %16, %24) : (!daphne.Matrix<?x3xf64>, si64, si64) -> !daphne.Matrix<?x?xf64>
+          %26 = "daphne.ewAdd"(%25, %1) : (!daphne.Matrix<?x?xf64>, si64) -> !daphne.Matrix<?x?xf64>
+          %27 = "daphne.cast"(%20) : (ui64) -> si64
+          %28 = "daphne.sliceRow"(%arg5, %19, %27) : (!daphne.Matrix<2x3xf64>, si64, si64) -> !daphne.Matrix<?x3xf64>
+          %29 = "daphne.cast"(%23) : (ui64) -> si64
+          %30 = "daphne.insertCol"(%28, %26, %16, %29) : (!daphne.Matrix<?x3xf64>, !daphne.Matrix<?x?xf64>, si64, si64) -> !daphne.Matrix<?x3xf64>
+          %31 = "daphne.cast"(%20) : (ui64) -> si64
+          %32 = "daphne.insertRow"(%arg5, %30, %19, %31) : (!daphne.Matrix<2x3xf64>, !daphne.Matrix<?x3xf64>, si64, si64) -> !daphne.Matrix<2x3xf64>
+          scf.yield %32 : !daphne.Matrix<2x3xf64>
+        }
+        scf.yield %17 : !daphne.Matrix<2x3xf64>
+      }
+      scf.yield %14 : !daphne.Matrix<2x3xf64>
+    }
+    "daphne.return"() : () -> ()
+  }
+  // CHECK-LABEL: func.func @"c-3"
+  func.func @"c-3"() {
+    %0 = "daphne.constant"() {value = 1 : index} : () -> index
+    %1 = "daphne.constant"() {value = 2 : index} : () -> index
+    %2 = "daphne.constant"() {value = 0 : index} : () -> index
+    %3 = "daphne.constant"() {value = 1 : si64} : () -> si64
+    %4 = "daphne.constant"() {value = 3 : index} : () -> index
+    %5 = "daphne.constant"() {value = 6 : index} : () -> index
+    %6 = "daphne.constant"() {value = false} : () -> i1
+    %7 = "daphne.constant"() {value = true} : () -> i1
+    %8 = "daphne.constant"() {value = 187651262016688 : ui64} : () -> ui64
+    %9 = "daphne.matrixConstant"(%8) : (ui64) -> !daphne.Matrix<6x1xsi64>
+    %10 = "daphne.reshape"(%9, %5, %0) : (!daphne.Matrix<6x1xsi64>, index, index) -> !daphne.Matrix<6x1xsi64>
+    %11 = "daphne.reshape"(%10, %1, %4) : (!daphne.Matrix<6x1xsi64>, index, index) -> !daphne.Matrix<2x3xsi64>
+    %12 = "daphne.ewCos"(%11) : (!daphne.Matrix<2x3xsi64>) -> !daphne.Matrix<2x3xf64>
+    %13 = "daphne.ewSin"(%11) : (!daphne.Matrix<2x3xsi64>) -> !daphne.Matrix<2x3xf64>
+    // CHECK: scf.for
+    // CHECK-NEXT: daphne.cast
+    // CHECK-NEXT: daphne.ewMul
+    // CHECK-NEXT: scf.for
+    %14 = scf.for %arg0 = %2 to %1 step %0 iter_args(%arg1 = %12) -> (!daphne.Matrix<2x3xf64>) {
+      %15 = "daphne.cast"(%arg0) : (index) -> si64
+      %16 = "daphne.ewMul"(%15, %3) : (si64, si64) -> si64
+      %17 = scf.for %arg2 = %2 to %4 step %0 iter_args(%arg3 = %arg1) -> (!daphne.Matrix<2x3xf64>) {
+        %18 = "daphne.cast"(%arg2) : (index) -> si64
+        %19 = "daphne.ewMul"(%18, %3) : (si64, si64) -> si64
+        "daphne.print"(%16, %7, %6) : (si64, i1, i1) -> ()
+        %20 = "daphne.ewAdd"(%16, %3) : (si64, si64) -> ui64
+        %21 = "daphne.cast"(%20) : (ui64) -> si64
+        %22 = "daphne.sliceRow"(%13, %16, %21) : (!daphne.Matrix<2x3xf64>, si64, si64) -> !daphne.Matrix<?x3xf64>
+        %23 = "daphne.ewAdd"(%19, %3) : (si64, si64) -> ui64
+        %24 = "daphne.cast"(%23) : (ui64) -> si64
+        %25 = "daphne.sliceCol"(%22, %19, %24) : (!daphne.Matrix<?x3xf64>, si64, si64) -> !daphne.Matrix<?x?xf64>
+        %26 = "daphne.cast"(%20) : (ui64) -> si64
+        %27 = "daphne.sliceRow"(%arg3, %16, %26) : (!daphne.Matrix<2x3xf64>, si64, si64) -> !daphne.Matrix<?x3xf64>
+        %28 = "daphne.cast"(%23) : (ui64) -> si64
+        %29 = "daphne.insertCol"(%27, %25, %19, %28) : (!daphne.Matrix<?x3xf64>, !daphne.Matrix<?x?xf64>, si64, si64) -> !daphne.Matrix<?x3xf64>
+        %30 = "daphne.cast"(%20) : (ui64) -> si64
+        %31 = "daphne.insertRow"(%arg3, %29, %16, %30) : (!daphne.Matrix<2x3xf64>, !daphne.Matrix<?x3xf64>, si64, si64) -> !daphne.Matrix<2x3xf64>
+        scf.yield %31 : !daphne.Matrix<2x3xf64>
+      }
+      scf.yield %17 : !daphne.Matrix<2x3xf64>
+    }
+    "daphne.return"() : () -> ()
+  }
+  
+  // CHECK-LABEL: func.func @"b-2"
+  func.func @"b-2"() {
+    %0 = "daphne.constant"() {value = 1 : index} : () -> index
+    %1 = "daphne.constant"() {value = 2 : index} : () -> index
+    %2 = "daphne.constant"() {value = 0 : index} : () -> index
+    %3 = "daphne.constant"() {value = 1 : si64} : () -> si64
+    %4 = "daphne.constant"() {value = 3 : index} : () -> index
+    %5 = "daphne.constant"() {value = 6 : index} : () -> index
+    %6 = "daphne.constant"() {value = 187651262003680 : ui64} : () -> ui64
+    %7 = "daphne.matrixConstant"(%6) : (ui64) -> !daphne.Matrix<6x1xsi64>
+    %8 = "daphne.reshape"(%7, %5, %0) : (!daphne.Matrix<6x1xsi64>, index, index) -> !daphne.Matrix<6x1xsi64>
+    %9 = "daphne.reshape"(%8, %1, %4) : (!daphne.Matrix<6x1xsi64>, index, index) -> !daphne.Matrix<2x3xsi64>
+    %10 = "daphne.ewCos"(%9) : (!daphne.Matrix<2x3xsi64>) -> !daphne.Matrix<2x3xf64>
+    %11 = "daphne.ewSin"(%9) : (!daphne.Matrix<2x3xsi64>) -> !daphne.Matrix<2x3xf64>
+    // CHECK-NOT: scf.for
+    // CHECK: daphne.ewSin
+    // CHECK-NEXT: daphne.return
+    %12 = scf.for %arg0 = %2 to %1 step %0 iter_args(%arg1 = %10) -> (!daphne.Matrix<2x3xf64>) {
+      %13 = "daphne.cast"(%arg0) : (index) -> si64
+      %14 = "daphne.ewMul"(%13, %3) : (si64, si64) -> si64
+      %15 = scf.for %arg2 = %2 to %4 step %0 iter_args(%arg3 = %arg1) -> (!daphne.Matrix<2x3xf64>) {
+        %16 = "daphne.cast"(%arg2) : (index) -> si64
+        %17 = "daphne.ewMul"(%16, %3) : (si64, si64) -> si64
+        %18 = "daphne.ewAdd"(%14, %3) : (si64, si64) -> ui64
+        %19 = "daphne.cast"(%18) : (ui64) -> si64
+        %20 = "daphne.sliceRow"(%11, %14, %19) : (!daphne.Matrix<2x3xf64>, si64, si64) -> !daphne.Matrix<?x3xf64>
+        %21 = "daphne.ewAdd"(%17, %3) : (si64, si64) -> ui64
+        %22 = "daphne.cast"(%21) : (ui64) -> si64
+        %23 = "daphne.sliceCol"(%20, %17, %22) : (!daphne.Matrix<?x3xf64>, si64, si64) -> !daphne.Matrix<?x?xf64>
+        %24 = "daphne.cast"(%18) : (ui64) -> si64
+        %25 = "daphne.sliceRow"(%arg3, %14, %24) : (!daphne.Matrix<2x3xf64>, si64, si64) -> !daphne.Matrix<?x3xf64>
+        %26 = "daphne.cast"(%21) : (ui64) -> si64
+        %27 = "daphne.insertCol"(%25, %23, %17, %26) : (!daphne.Matrix<?x3xf64>, !daphne.Matrix<?x?xf64>, si64, si64) -> !daphne.Matrix<?x3xf64>
+        %28 = "daphne.cast"(%18) : (ui64) -> si64
+        %29 = "daphne.insertRow"(%arg3, %27, %14, %28) : (!daphne.Matrix<2x3xf64>, !daphne.Matrix<?x3xf64>, si64, si64) -> !daphne.Matrix<2x3xf64>
+        scf.yield %29 : !daphne.Matrix<2x3xf64>
+      }
+      scf.yield %15 : !daphne.Matrix<2x3xf64>
+    }
+    "daphne.return"() : () -> ()
+  }
+
+  // CHECK-LABEL: func.func @"a-1"
+  func.func @"a-1"() {
+    %0 = "daphne.constant"() {value = 1 : index} : () -> index
+    %1 = "daphne.constant"() {value = 2 : index} : () -> index
+    %2 = "daphne.constant"() {value = 0 : index} : () -> index
+    %3 = "daphne.constant"() {value = 1 : si64} : () -> si64
+    %4 = "daphne.constant"() {value = 3 : index} : () -> index
+    %5 = "daphne.constant"() {value = 6 : index} : () -> index
+    %6 = "daphne.constant"() {value = 187651261662912 : ui64} : () -> ui64
+    %7 = "daphne.matrixConstant"(%6) : (ui64) -> !daphne.Matrix<6x1xsi64>
+    %8 = "daphne.reshape"(%7, %5, %0) : (!daphne.Matrix<6x1xsi64>, index, index) -> !daphne.Matrix<6x1xsi64>
+    %9 = "daphne.reshape"(%8, %1, %4) : (!daphne.Matrix<6x1xsi64>, index, index) -> !daphne.Matrix<2x3xsi64>
+    %10 = "daphne.ewCos"(%9) : (!daphne.Matrix<2x3xsi64>) -> !daphne.Matrix<2x3xf64>
+    %11 = "daphne.ewSin"(%9) : (!daphne.Matrix<2x3xsi64>) -> !daphne.Matrix<2x3xf64>
+    // CHECK-NOT: scf.for
+    // CHECK: daphne.ewAbs
+    // CHECK-NEXT: daphne.ewSqrt
+    // CHECK-NEXT: daphne.ewAdd
+    %12:2 = scf.for %arg0 = %2 to %1 step %0 iter_args(%arg1 = %11, %arg2 = %10) -> (!daphne.Matrix<2x3xf64>, !daphne.Matrix<2x3xf64>) {
+      %13 = "daphne.cast"(%arg0) : (index) -> si64
+      %14 = "daphne.ewMul"(%13, %3) : (si64, si64) -> si64
+      %15:2 = scf.for %arg3 = %2 to %4 step %0 iter_args(%arg4 = %arg1, %arg5 = %arg2) -> (!daphne.Matrix<2x3xf64>, !daphne.Matrix<2x3xf64>) {
+        %16 = "daphne.cast"(%arg3) : (index) -> si64
+        %17 = "daphne.ewMul"(%16, %3) : (si64, si64) -> si64
+        %18 = "daphne.ewAdd"(%14, %3) : (si64, si64) -> ui64
+        %19 = "daphne.cast"(%18) : (ui64) -> si64
+        %20 = "daphne.sliceRow"(%arg5, %14, %19) : (!daphne.Matrix<2x3xf64>, si64, si64) -> !daphne.Matrix<?x3xf64>
+        %21 = "daphne.ewAdd"(%17, %3) : (si64, si64) -> ui64
+        %22 = "daphne.cast"(%21) : (ui64) -> si64
+        %23 = "daphne.sliceCol"(%20, %17, %22) : (!daphne.Matrix<?x3xf64>, si64, si64) -> !daphne.Matrix<?x?xf64>
+        %24 = "daphne.cast"(%18) : (ui64) -> si64
+        %25 = "daphne.sliceRow"(%arg5, %14, %24) : (!daphne.Matrix<2x3xf64>, si64, si64) -> !daphne.Matrix<?x3xf64>
+        %26 = "daphne.cast"(%21) : (ui64) -> si64
+        %27 = "daphne.sliceCol"(%25, %17, %26) : (!daphne.Matrix<?x3xf64>, si64, si64) -> !daphne.Matrix<?x?xf64>
+        %28 = "daphne.ewAbs"(%27) : (!daphne.Matrix<?x?xf64>) -> !daphne.Matrix<?x?xf64>
+        %29 = "daphne.ewSqrt"(%28) : (!daphne.Matrix<?x?xf64>) -> !daphne.Matrix<?x?xf64>
+        %30 = "daphne.ewAdd"(%23, %29) : (!daphne.Matrix<?x?xf64>, !daphne.Matrix<?x?xf64>) -> !daphne.Matrix<?x?xf64>
+        %31 = "daphne.cast"(%18) : (ui64) -> si64
+        %32 = "daphne.sliceRow"(%arg4, %14, %31) : (!daphne.Matrix<2x3xf64>, si64, si64) -> !daphne.Matrix<?x3xf64>
+        %33 = "daphne.cast"(%21) : (ui64) -> si64
+        %34 = "daphne.sliceCol"(%32, %17, %33) : (!daphne.Matrix<?x3xf64>, si64, si64) -> !daphne.Matrix<?x?xf64>
+        %35 = "daphne.ewCos"(%34) : (!daphne.Matrix<?x?xf64>) -> !daphne.Matrix<?x?xf64>
+        %36 = "daphne.ewAdd"(%30, %35) : (!daphne.Matrix<?x?xf64>, !daphne.Matrix<?x?xf64>) -> !daphne.Matrix<?x?xf64>
+        %37 = "daphne.cast"(%18) : (ui64) -> si64
+        %38 = "daphne.sliceRow"(%arg4, %14, %37) : (!daphne.Matrix<2x3xf64>, si64, si64) -> !daphne.Matrix<?x3xf64>
+        %39 = "daphne.cast"(%21) : (ui64) -> si64
+        %40 = "daphne.insertCol"(%38, %36, %17, %39) : (!daphne.Matrix<?x3xf64>, !daphne.Matrix<?x?xf64>, si64, si64) -> !daphne.Matrix<?x3xf64>
+        %41 = "daphne.cast"(%18) : (ui64) -> si64
+        %42 = "daphne.insertRow"(%arg4, %40, %14, %41) : (!daphne.Matrix<2x3xf64>, !daphne.Matrix<?x3xf64>, si64, si64) -> !daphne.Matrix<2x3xf64>
+        %43 = "daphne.cast"(%18) : (ui64) -> si64
+        %44 = "daphne.sliceRow"(%42, %14, %43) : (!daphne.Matrix<2x3xf64>, si64, si64) -> !daphne.Matrix<?x3xf64>
+        %45 = "daphne.cast"(%21) : (ui64) -> si64
+        %46 = "daphne.sliceCol"(%44, %17, %45) : (!daphne.Matrix<?x3xf64>, si64, si64) -> !daphne.Matrix<?x?xf64>
+        %47 = "daphne.cast"(%18) : (ui64) -> si64
+        %48 = "daphne.sliceRow"(%arg5, %14, %47) : (!daphne.Matrix<2x3xf64>, si64, si64) -> !daphne.Matrix<?x3xf64>
+        %49 = "daphne.cast"(%21) : (ui64) -> si64
+        %50 = "daphne.insertCol"(%48, %46, %17, %49) : (!daphne.Matrix<?x3xf64>, !daphne.Matrix<?x?xf64>, si64, si64) -> !daphne.Matrix<?x3xf64>
+        %51 = "daphne.cast"(%18) : (ui64) -> si64
+        %52 = "daphne.insertRow"(%arg5, %50, %14, %51) : (!daphne.Matrix<2x3xf64>, !daphne.Matrix<?x3xf64>, si64, si64) -> !daphne.Matrix<2x3xf64>
+        scf.yield %42, %52 : !daphne.Matrix<2x3xf64>, !daphne.Matrix<2x3xf64>
+      }
+      scf.yield %15#0, %15#1 : !daphne.Matrix<2x3xf64>, !daphne.Matrix<2x3xf64>
+    }
+    "daphne.return"() : () -> ()
+  }
+}


### PR DESCRIPTION
Implements #518: Loop Vectorization.
All ew-Binary and Unary Operations are implemented, as well as nested expressions of these.
Currently **not supported** are casts and aggregation.
The test case `loop-vectorization.mlir` corresponds to [this daphne code](https://gist.github.com/nuernbergk/50a2ff08d1e1944225a485641217bcc6).

Note that there are formatting changes in `DaphneIrExectur.cpp` and `Passes.h`, as I used the `.clang-format` provided in #723.
If necessary, I can of course revert these.
