### PR TITLE
Update software requirements in doc

### DIFF
--- a/doc/GettingStarted.md
+++ b/doc/GettingStarted.md
@@ -199,6 +199,8 @@ Nevertheless, there are cases when more details are required, e.g., when DAPHNE 
 
 Please ensure that your development system meets the following requirements before trying to build DAPHNE.
 Note that the DAPHNE container images already ship with all these dependencies installed.
+There is a [convenience script](/install-ubuntu-packages.sh) to install all necessary dependencies to compile DAPHNE on Ubuntu distributions.
+However, in order to use optional features, such as CUDA or FPGA support, the respective requirements listed below still need to be installed separately.
 
 **(*)**
 You can view the version numbers as an orientation rather than a strict requirement.
@@ -206,12 +208,13 @@ Newer versions should work as well, older versions might work as well.
 
 #### Operating system
 
-| OS         | distribution/version known to work (*) | Comment                                                                    |
-|------------|----------------------------------------|----------------------------------------------------------------------------|
-| GNU/Linux  | Manjaro                                | Last checked in January 2023                                               ||
-| GNU/Linux  | Ubuntu 20.04 - 22.10                   | All versions in that range work. 20.04 needs CMake installed from Snap.    |
-| GNU/Linux  | Ubuntu 18.04                           | Used with Intel PAC D5005 FPGA, custom toolchain needed                    |
-| MS Windows | 10 Build 19041, 11                     | Should work in Ubuntu WSL, using the provided Docker images is recommended |
+| OS         | distribution/version known to work (*) | Comment                                                                             |
+|------------|----------------------------------------|-------------------------------------------------------------------------------------|
+| GNU/Linux  | Manjaro                                | Last checked in April 2024                                                          |
+| GNU/Linux  | Ubuntu 20.04 - 24.04                   | All versions in that range work. 20.04 needs CMake installed from Snap.             |
+| GNU/Linux  | Ubuntu 18.04                           | Used with Intel PAC D5005 FPGA, [custom toolchain](/doc/BuildEnvironment.md) needed |
+| GNU/Linux | RHEL 8 | [Custom toolchain](/doc/BuildEnvironment.md) needed                                 |
+| MS Windows | 10 Build 19041, 11                     | Works on Ubuntu WSL2, using the provided Docker images is recommended               |
 
 ##### Windows
 
@@ -222,30 +225,32 @@ launching DAPHNE via Docker (see below) should work the same way as in a native 
 
 | tool/lib                             | version known to work (*)    | comment                                                                                                                                 |
 |--------------------------------------|------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------|
-| GCC/G++                              | 9.3.0                        | Last checked version: 12.2                                                                                                              |
 | clang                                | 10.0.0                       |                                                                                                                                         |
 | cmake                                | 3.20                         | On Ubuntu 20.04, install by `sudo snap install cmake --classic` to fulfill the version requirement; `apt` provides only version 3.16.3. |
+| GCC/G++                              | 9.3.0                        | Last checked version: 13.2 (compiles with warnings)                                                                                     |
+| gfortran                             | 9.3.0                        |                                                                                                                                         |
 | git                                  | 2.25.1                       |                                                                                                                                         |
-| libssl-dev                           | 1.1.1                        | Dependency introduced while optimizing grpc build (which used to build ssl unnecessarily)                                               |
+| java (e.g. openjdk)                  | 11 (1.7 should be fine)      |                                                                                                                                         |
+| jq                                   |                              | json commandline processor used in docker image generation scripts.                                                                     |
 | libpfm4-dev                          | 4.10                         | This dependency is needed for profiling support [DAPHNE-#479]                                                                           |
+| libssl-dev                           | 1.1.1                        | Dependency introduced while optimizing grpc build (which used to build ssl unnecessarily)                                               |
 | lld                                  | 10.0.0                       |                                                                                                                                         |
+| llvm-10-tools                        | 10, 15, 18                   | `apt` provides up to `llvm-10-tools` for Ubuntu 20.04 whereas 22.04 / 24.04 require a newer version such as `llvm-15-tools`.            |
 | ninja                                | 1.10.0                       |                                                                                                                                         |
-| pkg-config                           | 0.29.1                       |                                                                                                                                         |
-| python3                              | 3.8.5                        |                                                                                                                                         |
 | numpy                                | 1.19.5                       |                                                                                                                                         |
 | pandas                               | 0.25.3                       |                                                                                                                                         |
-| java (e.g. openjdk)                  | 11 (1.7 should be fine)      |                                                                                                                                         |
-| gfortran                             | 9.3.0                        |                                                                                                                                         |
+| pkg-config                           | 0.29.1                       |                                                                                                                                         |
+| python3                              | 3.8.5                        |                                                                                                                                         |
+| unzip                                | 6.0                          |                                                                                                                                         |
 | uuid-dev                             |                              |                                                                                                                                         |
-| llvm-10-tools                        | 10, 15                       | On Ubuntu 22.04 you may need to install a newer `llvm-*-tools` version, such as `llvm-15-tools`.                                        |
-| wget                                 |                              | Used to fetch additional dependencies and other artefacts                                                                               |
-| jq                                   |                              | json commandline processor used in docker image generation scripts                                                                      |
+| wget                                 |                              | Used to fetch additional dependencies and other artefacts.                                                                              |
+| zlib1g-dev                           |                              | Needed to satisfy cmake dependencies.                                                                                                   |
 | ***                                  | ***                          | ***                                                                                                                                     |
 | CUDA SDK                             | 11.7.1                       | Optional for CUDA ops                                                                                                                   |
-| OneAPI SDK                           | 2022.x                       | Optional for OneAPI ops                                                                                                                 |
 | Intel FPGA SDK or OneAPI FPGA Add-On | 2022.x                       | Optional for FPGAOPENCL ops                                                                                                             |
-| tensorflow                           | 2.13.1                       | Optional for data exchange between DaphneLib and TensorFlow |
-| torch                                | 2.3.0+cu121                  | Optional for data exchange between DaphneLib and PyTorch |
+| OneAPI SDK                           | 2022.x                       | Optional for OneAPI ops                                                                                                                 |
+| tensorflow                           | 2.13.1                       | Optional for data exchange between DaphneLib and TensorFlow                                                                             |
+| torch                                | 2.3.0+cu121                  | Optional for data exchange between DaphneLib and PyTorch                                                                                |
 
 #### Hardware
 

--- a/install-ubuntu-packages.sh
+++ b/install-ubuntu-packages.sh
@@ -15,6 +15,43 @@
 # limitations under the License.
 
 # This is a convenience script to install the required packages on Ubuntu 20+ systems to compile DAPHNE
-# On Ubuntu 22.04 you may need to change the version of llvm-10-tools to a newer one, such as llvm-15-tools.
-sudo apt install build-essential clang cmake git libssl-dev libpfm4-dev lld ninja-build pkg-config python3-numpy \
- python3-pandas default-jdk-headless gfortran uuid-dev wget unzip jq llvm-10-tools
+UbuntuVersion=$(lsb_release -sr)
+
+# Ubuntu Version is not 18.04, 20.04, 22.04 or 24.04
+function promptContinueOnUnknownVersion {
+    read -p "Support for Ubuntu $UbuntuVersion is not guaranteed - attempt to proceed anyway? (y/n) " res
+    case "$res" in
+        "y"|"Y")
+            sudo apt install cmake llvm-15-tools
+            ;;
+        *)
+            exit 1
+            ;;
+    esac
+}
+
+# Handle version dependent packages
+case "$UbuntuVersion" in
+    "18.04")
+        echo "Ubuntu $UbuntuVersion requires a custom toolchain. Please refer to the documentation (https://github.com/daphne-eu/daphne/blob/main/doc/GettingStarted.md)."
+        exit 1
+        ;;
+    "20.04")
+        sudo snap install cmake --classic
+        sudo apt install llvm-10-tools
+        ;;
+    "22.04")
+        sudo apt install cmake llvm-15-tools
+        ;;
+    "24.04")
+        sudo apt install cmake llvm-18-tools
+        ;;
+    *)
+        promptContinueOnUnknownVersion
+        ;;
+esac
+
+# Install version independent packages
+sudo apt install build-essential clang default-jdk-headless gfortran git jq \
+ libpfm4-dev libssl-dev lld ninja-build pkg-config python3-numpy python3-pandas \
+ unzip uuid-dev wget zlib1g-dev


### PR DESCRIPTION
This PR aims to update the software requirements needed to compile DAPHNE without containers.
The list of required packages has been sorted alphabetically and extended with `zlib1g-dev` to satisfy a `cmake` dependency and `unzip`.
Furthermore, the existing [install-ubuntu-packages.sh](https://github.com/daphne-eu/daphne/blob/main/install-ubuntu-packages.sh) script has been updated to install `cmake` using `snap` on `Ubuntu 20.04` to fulfill the version requirement, as well as a newer version of `llvm-*-tools` on current releases. However, there are two points to consider:
- For `Ubuntu 18.04` it references the documentation ("`custom toolchain needed`") but I am not aware of any further clarification in the documentation to help setup the environment, which makes it difficult to proceed with the setup.
- If the Ubuntu version is not `18.04`, `20.04`, `22.04`, or `24.04`, the script asks whether to continue or not and assumes `llvm-15-tools` is available with `apt` which is generally not guaranteed. Should the prompt be deleted perhaps or is this assumption acceptable?

I have tested the script as well as successful compilation and tests using `Ubuntu 20.04`, `22.04` and `24.04` using WSL2 on Windows 11.

There is an issue regarding a failing test with decision trees possibly relating to this (#787). I am not sure if this indicates more missing dependencies in the script that are present in the current docker container.

I found that e.g. `g++ 13.2` compiles correctly but triggers a lot of `overloaded-virtual` warnings for `virtual void rewrite` (`mlir::RewritePattern` in lowering passes) and `virtual bool antlr4::tree::ParseTree::operator==`. Perhaps this should be addressed in a new issue.