### PR TITLE
Implementation of new SparsityOp

### DIFF
--- a/doc/DaphneDSL/Builtins.md
+++ b/doc/DaphneDSL/Builtins.md
@@ -100,6 +100,11 @@ The following built-in functions allow to find out the shape/dimensions of matri
 
     Returns the number of cells in `arg`.
     This is the product of the number of rows and the number of columns.
+  
+- **`sparsity`**`(arg:matrix)`
+
+    Returns the DAPHNE compiler's *estimate* of the argument's sparsity.
+    Note that this value may deviate from the *actual* sparsity of the data at run-time.
 
 ## Elementwise unary
 

--- a/src/ir/daphneir/DaphneDialect.cpp
+++ b/src/ir/daphneir/DaphneDialect.cpp
@@ -1191,7 +1191,7 @@ mlir::LogicalResult mlir::daphne::SparsityOp::canonicalize(
 
     if(sparsity != -1) {
         rewriter.replaceOpWithNewOp<mlir::daphne::ConstantOp>(
-                op, rewriter.getF64Type(), rewriter.getFloatAttr(rewriter.getF64Type(), sparsity)
+                op, sparsity
         );
         return mlir::success();
     }

--- a/src/ir/daphneir/DaphneDialect.cpp
+++ b/src/ir/daphneir/DaphneDialect.cpp
@@ -1177,6 +1177,28 @@ mlir::LogicalResult mlir::daphne::NumCellsOp::canonicalize(
 }
 
 /**
+ * @brief Replaces SparsityOp by a constant, if the sparsity of the input is known
+ * (e.g., due to sparsity inference).
+ */
+mlir::LogicalResult mlir::daphne::SparsityOp::canonicalize(
+        mlir::daphne::SparsityOp op, PatternRewriter &rewriter
+) {
+    double sparsity = -1.0;
+
+    mlir::Type inTy = op.getArg().getType();
+    if(auto t = inTy.dyn_cast<mlir::daphne::MatrixType>())
+        sparsity = t.getSparsity();
+
+    if(sparsity != -1) {
+        rewriter.replaceOpWithNewOp<mlir::daphne::ConstantOp>(
+                op, rewriter.getF64Type(), rewriter.getFloatAttr(rewriter.getF64Type(), sparsity)
+        );
+        return mlir::success();
+    }
+    return mlir::failure();
+}
+
+/**
  * @brief Replaces a `DistributeOp` by a `DistributedReadOp`, if its input
  * value (a) is defined by a `ReadOp`, and (b) is not used elsewhere.
  * @param context

--- a/src/ir/daphneir/DaphneOps.td
+++ b/src/ir/daphneir/DaphneOps.td
@@ -161,13 +161,6 @@ def Daphne_SeqOp : Daphne_Op<"seq", [
 // Matrix/frame dimensions
 // ****************************************************************************
 
-def SparsityOp : Daphne_Op<"sparsity", [DataTypeSca]> {
-  let arguments = (ins MatrixOf<[AnyScalar]>:$arg);
-  let results = (outs FloatScalar:$res);
-
-  let hasCanonicalizeMethod = 1;
-}
-
 class Daphne_NumOp<string name, list<Trait> traits = []> : Daphne_Op<name, !listconcat(traits, [
     DataTypeSca, ValueTypeSize, Pure
 ])> {
@@ -180,6 +173,13 @@ class Daphne_NumOp<string name, list<Trait> traits = []> : Daphne_Op<name, !list
 def Daphne_NumRowsOp : Daphne_NumOp<"numRows">;
 def Daphne_NumColsOp : Daphne_NumOp<"numCols">;
 def Daphne_NumCellsOp : Daphne_NumOp<"numCells">;
+
+def SparsityOp : Daphne_Op<"sparsity", [DataTypeSca]> {
+  let arguments = (ins MatrixOf<[AnyScalar]>:$arg);
+  let results = (outs FloatScalar:$res);
+
+  let hasCanonicalizeMethod = 1;
+}
 
 // ****************************************************************************
 // Matrix multiplication

--- a/src/ir/daphneir/DaphneOps.td
+++ b/src/ir/daphneir/DaphneOps.td
@@ -161,6 +161,13 @@ def Daphne_SeqOp : Daphne_Op<"seq", [
 // Matrix/frame dimensions
 // ****************************************************************************
 
+def SparsityOp : Daphne_Op<"sparsity", [DataTypeSca]> {
+  let arguments = (ins MatrixOf<[AnyScalar]>:$arg);
+  let results = (outs FloatScalar:$res);
+
+  let hasCanonicalizeMethod = 1;
+}
+
 class Daphne_NumOp<string name, list<Trait> traits = []> : Daphne_Op<name, !listconcat(traits, [
     DataTypeSca, ValueTypeSize, Pure
 ])> {

--- a/src/parser/daphnedsl/DaphneDSLBuiltins.cpp
+++ b/src/parser/daphnedsl/DaphneDSLBuiltins.cpp
@@ -464,6 +464,12 @@ antlrcpp::Any DaphneDSLBuiltins::build(mlir::Location loc, const std::string & f
         return createNumOp<NumColsOp>(loc, func, args);
     if(func == "ncell")
         return createNumOp<NumCellsOp>(loc, func, args);
+    
+    if(func == "sparsity") {
+        checkNumArgsExact(loc, func, numArgs, 1);
+        mlir::Value arg = args[0];
+        return static_cast<mlir::Value>(builder.create<SparsityOp>(loc, builder.getF64Type(), arg));
+    }
 
     // ********************************************************************
     // Elementwise unary

--- a/src/parser/daphnedsl/DaphneDSLBuiltins.cpp
+++ b/src/parser/daphnedsl/DaphneDSLBuiltins.cpp
@@ -464,7 +464,6 @@ antlrcpp::Any DaphneDSLBuiltins::build(mlir::Location loc, const std::string & f
         return createNumOp<NumColsOp>(loc, func, args);
     if(func == "ncell")
         return createNumOp<NumCellsOp>(loc, func, args);
-    
     if(func == "sparsity") {
         checkNumArgsExact(loc, func, numArgs, 1);
         mlir::Value arg = args[0];

--- a/src/runtime/local/kernels/Sparsity.h
+++ b/src/runtime/local/kernels/Sparsity.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 The DAPHNE Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_RUNTIME_LOCAL_KERNELS_SPARSITY_H
+#define SRC_RUNTIME_LOCAL_KERNELS_SPARSITY_H
+
+#include <runtime/local/context/DaphneContext.h>
+
+// ****************************************************************************
+// Convenience function
+// ****************************************************************************
+
+template<class DTArg>
+double sparsity(const DTArg * arg, DCTX(ctx)) {
+    return -1.0;
+}
+
+#endif //SRC_RUNTIME_LOCAL_KERNELS_SPARSITY_H

--- a/src/runtime/local/kernels/kernels.json
+++ b/src/runtime/local/kernels/kernels.json
@@ -2948,6 +2948,41 @@
     },
     {
         "kernelTemplate": {
+            "header": "Sparsity.h",
+            "opName": "sparsity",
+            "returnType": "double",
+            "templateParams": [
+                {
+                    "name": "DTArg",
+                    "isDataType": true
+                }
+            ],
+            "runtimeParams": [
+                {
+                    "type": "const DTArg *",
+                    "name": "arg"
+                }
+            ]
+        },
+        "instantiations":   [
+            [["DenseMatrix", "double"]],
+            [["DenseMatrix", "float"]],
+            [["DenseMatrix", "int64_t"]],
+            [["DenseMatrix", "int32_t"]],
+            [["DenseMatrix", "int8_t"]],
+            [["DenseMatrix", "uint64_t"]],
+            [["DenseMatrix", "uint32_t"]],
+            [["DenseMatrix", "uint8_t"]],
+            [["DenseMatrix", "bool"]],
+            [["DenseMatrix", "size_t"]],
+            [["CSRMatrix", "double"]],
+            [["CSRMatrix", "float"]],
+            [["CSRMatrix", "int64_t"]],
+            [["CSRMatrix", "uint8_t"]]
+        ]
+    },
+    {
+        "kernelTemplate": {
             "header": "NumCols.h",
             "opName": "numCols",
             "returnType": "size_t",


### PR DESCRIPTION
This PR introduces a new `SparsityOp` that allows users to print the compile-time sparsity estimate of a matrix to the screen. The function can be called using `sparsity(Matrix)`, which will be replaced with the sparsity value through canonicalization if the sparsity is known. If the sparsity is unknown, it will return -1.


This PR does not yet include tests. The SparsityOp functionality will be tested as part of [#766](https://github.com/daphne-eu/daphne/issues/766).