### PR TITLE
[DAPHNE-#774] Simplification rewrites for elementwise unary minus (ad…

### DIFF
--- a/src/ir/daphneir/DaphneDialect.cpp
+++ b/src/ir/daphneir/DaphneDialect.cpp
@@ -611,6 +611,26 @@ mlir::Attribute constFoldBinaryOp(mlir::Location loc, mlir::Type resultType, llv
     }
     return {};
 }
+template<class AttrElementT,
+    class ElementValueT = typename AttrElementT::ValueType,
+    class CalculationT = std::function<ElementValueT(const ElementValueT &)>>
+mlir::Attribute constFoldUnaryOp(mlir::Location loc, mlir::Type resultType, llvm::ArrayRef<mlir::Attribute> operands,
+                                 const CalculationT &calculate) {
+    if (operands.size() != 1)
+        throw ErrorHandler::compilerError(loc,
+                    "CanonicalizerPass (constFoldUnaryOp)",
+                    "unary op takes one operand but " + std::to_string(operands.size()) + " were given");
+
+    if (!operands[0])
+        return {};
+
+    if (llvm::isa<AttrElementT>(operands[0])) {
+        auto operand = operands[0].cast<AttrElementT>();
+
+        return AttrElementT::get(resultType, calculate(operand.getValue()));
+    }
+    return {};
+}
 
 // ****************************************************************************
 // Fold implementations
@@ -742,6 +762,19 @@ mlir::OpFoldResult mlir::daphne::EwDivOp::fold(FoldAdaptor adaptor) {
         if(auto res = constFoldBinaryOp<IntegerAttr>(getLoc(), getType(), operands, uintOp))
             return res;
     }
+    return {};
+}
+
+mlir::OpFoldResult mlir::daphne::EwMinusOp::fold(FoldAdaptor adaptor) {
+    ArrayRef<Attribute> operands = adaptor.getOperands();
+    auto intOp = [](const llvm::APInt &a) { return -a; };
+    auto floatOp = [](const llvm::APFloat &a) { return -a; };
+
+    if (auto res = constFoldUnaryOp<IntegerAttr>(getLoc(), getType(), operands, intOp))
+        return res;
+    if (auto res = constFoldUnaryOp<FloatAttr>(getLoc(), getType(), operands, floatOp))
+        return res;
+
     return {};
 }
 
@@ -1502,4 +1535,22 @@ mlir::LogicalResult mlir::daphne::RenameOp::canonicalize(
     // this operation during DaphneDSL parsing.
     rewriter.replaceOp(op, op.getArg());
     return mlir::success();
+}
+
+
+/**
+ * @brief Replaces `--a` by `a` (`a` scalar).
+ *
+ * @param op
+ * @param rewriter
+ * @return
+ */
+mlir::LogicalResult mlir::daphne::EwMinusOp::canonicalize(
+        mlir::daphne::EwMinusOp op, PatternRewriter &rewriter
+) {
+    if (auto innerOp = op.getOperand().getDefiningOp<mlir::daphne::EwMinusOp>()) {
+        rewriter.replaceOp(op, innerOp.getOperand());
+        return mlir::success();
+    }
+    return mlir::failure();
 }

--- a/src/ir/daphneir/DaphneOps.td
+++ b/src/ir/daphneir/DaphneOps.td
@@ -209,7 +209,10 @@ class Daphne_EwUnaryOp<string name, Type scalarType, list<Trait> traits = []> : 
 // ----------------------------------------------------------------------------
 
 // TODO EwMinusOp: Should an unsigned integer argument yield a signed integer result?
-def Daphne_EwMinusOp : Daphne_EwUnaryOp<"ewMinus", NumScalar, [ValueTypeFromFirstArg]>;
+def Daphne_EwMinusOp : Daphne_EwUnaryOp<"ewMinus", NumScalar, [ValueTypeFromFirstArg]> {
+   let hasFolder = 1;
+   let hasCanonicalizeMethod = 1;
+}
 def Daphne_EwAbsOp : Daphne_EwUnaryOp<"ewAbs", NumScalar, [ValueTypeFromFirstArg]>;
 def Daphne_EwSignOp : Daphne_EwUnaryOp<"ewSign", NumScalar, [ValueTypeFromFirstArg]>;
 def Daphne_EwExpOp : Daphne_EwUnaryOp<"ewExp", NumScalar, [ValueTypeFromArgsFP]>;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -64,6 +64,7 @@ set(TEST_SOURCES
         codegen/MatMulAccuracyTest.cpp
 
         ir/daphneir/InferTypesTest.cpp
+        api/cli/operations/CanonicalizationConstantFoldingOpTest.cpp
 
         parser/config/ConfigParserTest.cpp
 

--- a/test/api/cli/operations/CanonicalizationConstantFoldingOpTest.cpp
+++ b/test/api/cli/operations/CanonicalizationConstantFoldingOpTest.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 The DAPHNE Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <api/cli/Utils.h>
+#include <tags.h>
+#include <string>
+
+
+const std::string dirPath = "test/api/cli/operations/";
+
+void compareDaphneParsingSimplifiedToRef(const std::string & refFilePath, const std::string & scriptFilePath) {
+    std::stringstream out;
+    std::stringstream err;
+	const std::string exp = readTextFile(refFilePath);
+    int status = runDaphne(out, err, "--explain=parsing_simplified", scriptFilePath.c_str());
+    CHECK(status == StatusCode::SUCCESS);
+    CHECK(err.str() == exp);
+}
+
+TEST_CASE("additive_inverse_constant_folding", TAG_CODEGEN TAG_OPERATIONS) {
+    const std::string testName = "addinv_constant_folding";
+    compareDaphneParsingSimplifiedToRef(dirPath + testName + ".txt", dirPath + testName + ".daphne");
+}
+
+TEST_CASE("additive_inverse_canonicalization", TAG_CODEGEN TAG_OPERATIONS) {
+    const std::string testName = "addinv_canonicalization";
+    compareDaphneParsingSimplifiedToRef(dirPath + testName + ".txt", dirPath + testName + ".daphne");
+}
+

--- a/test/api/cli/operations/addinv_canonicalization.daphne
+++ b/test/api/cli/operations/addinv_canonicalization.daphne
@@ -1,0 +1,5 @@
+print(--2);
+print(---3);
+print(----4);
+print(--log(2,2));
+print(---log(3,3));

--- a/test/api/cli/operations/addinv_canonicalization.txt
+++ b/test/api/cli/operations/addinv_canonicalization.txt
@@ -1,0 +1,20 @@
+IR after parsing and some simplifications:
+module {
+  func.func @main() {
+    %0 = "daphne.constant"() {value = 4 : si64} : () -> si64
+    %1 = "daphne.constant"() {value = -3 : si64} : () -> si64
+    %2 = "daphne.constant"() {value = 3 : si64} : () -> si64
+    %3 = "daphne.constant"() {value = 2 : si64} : () -> si64
+    %4 = "daphne.constant"() {value = false} : () -> i1
+    %5 = "daphne.constant"() {value = true} : () -> i1
+    "daphne.print"(%3, %5, %4) : (si64, i1, i1) -> ()
+    "daphne.print"(%1, %5, %4) : (si64, i1, i1) -> ()
+    "daphne.print"(%0, %5, %4) : (si64, i1, i1) -> ()
+    %6 = "daphne.ewLog"(%3, %3) : (si64, si64) -> f64
+    "daphne.print"(%6, %5, %4) : (f64, i1, i1) -> ()
+    %7 = "daphne.ewLog"(%2, %2) : (si64, si64) -> f64
+    %8 = "daphne.ewMinus"(%7) : (f64) -> f64
+    "daphne.print"(%8, %5, %4) : (f64, i1, i1) -> ()
+    "daphne.return"() : () -> ()
+  }
+}

--- a/test/api/cli/operations/addinv_constant_folding.daphne
+++ b/test/api/cli/operations/addinv_constant_folding.daphne
@@ -1,0 +1,9 @@
+print(-2);
+print(+2);
+print(--2);
+print(++2);
+print(+-2);
+print(+-+2);
+print(-(3*2));
+print(-(3+2));
+print(-(-2-3));

--- a/test/api/cli/operations/addinv_constant_folding.txt
+++ b/test/api/cli/operations/addinv_constant_folding.txt
@@ -1,0 +1,22 @@
+IR after parsing and some simplifications:
+module {
+  func.func @main() {
+    %0 = "daphne.constant"() {value = 5 : si64} : () -> si64
+    %1 = "daphne.constant"() {value = -5 : si64} : () -> si64
+    %2 = "daphne.constant"() {value = -2 : si64} : () -> si64
+    %3 = "daphne.constant"() {value = -6 : si64} : () -> si64
+    %4 = "daphne.constant"() {value = 2 : si64} : () -> si64
+    %5 = "daphne.constant"() {value = false} : () -> i1
+    %6 = "daphne.constant"() {value = true} : () -> i1
+    "daphne.print"(%2, %6, %5) : (si64, i1, i1) -> ()
+    "daphne.print"(%4, %6, %5) : (si64, i1, i1) -> ()
+    "daphne.print"(%4, %6, %5) : (si64, i1, i1) -> ()
+    "daphne.print"(%4, %6, %5) : (si64, i1, i1) -> ()
+    "daphne.print"(%2, %6, %5) : (si64, i1, i1) -> ()
+    "daphne.print"(%2, %6, %5) : (si64, i1, i1) -> ()
+    "daphne.print"(%3, %6, %5) : (si64, i1, i1) -> ()
+    "daphne.print"(%1, %6, %5) : (si64, i1, i1) -> ()
+    "daphne.print"(%0, %6, %5) : (si64, i1, i1) -> ()
+    "daphne.return"() : () -> ()
+  }
+}


### PR DESCRIPTION
**Task**: This task is to add typical simplifications of this operation to the DAPHNE compiler, such as:

- Constant folding: Expressions like -123 could be evaluated at compile-time.
- Static rewrites: E.g., --x to x.

Overall, such simplications can make the IR simpler and more readable, unlock further simplifications of consuming operations, and reduce the computational effort at run-time.

- Implemented canonicalization rule: --x simplifies to x
- Added constant folding for -x where applicable
- Added relevant test cases to verify new simplifications rewrites

Tests were performed as an end to end test where the Output of Daphne is compared with a Referencefile. To verify that the rewrite pattern and constant folding for additive inverse are working, Daphne is being executed with the explain=parser_simplified flag.