### PR TITLE
Implementation of CSR/CSR Matrix Multiplication (`@`)

### DIFF
--- a/src/compiler/execution/DaphneIrExecutor.cpp
+++ b/src/compiler/execution/DaphneIrExecutor.cpp
@@ -131,9 +131,11 @@ bool DaphneIrExecutor::runPasses(mlir::ModuleOp module) {
     pm.addNestedPass<mlir::func::FuncOp>(mlir::daphne::createInferencePass());
     pm.addPass(mlir::createCanonicalizerPass());
 
-    if (selectMatrixRepresentations_)
-        pm.addNestedPass<mlir::func::FuncOp>(
-            mlir::daphne::createSelectMatrixRepresentationsPass(userConfig_));
+    if (selectMatrixRepresentations_) {
+        pm.addNestedPass<mlir::func::FuncOp>(mlir::daphne::createSelectMatrixRepresentationsPass(userConfig_));
+        pm.addNestedPass<mlir::func::FuncOp>(mlir::createCanonicalizerPass());
+    }
+
     if (userConfig_.explain_select_matrix_repr)
         pm.addPass(mlir::daphne::createPrintIRPass(
             "IR after selecting matrix representations:"));

--- a/src/ir/daphneir/DaphneDialect.cpp
+++ b/src/ir/daphneir/DaphneDialect.cpp
@@ -1119,6 +1119,15 @@ mlir::LogicalResult mlir::daphne::MatMulOp::canonicalize(
         return mlir::failure();
     }
 
+    // ToDo: This check prevents merging transpose into matrix multiplication because that is not yet supported by our
+    //   sparse kernels.
+    // ToDo: bring user config here for sparsity threshold or properly use MatrixRepresentation
+    if(auto t = rhs.getType().dyn_cast<mlir::daphne::MatrixType>()) {
+        auto sparsity = t.getSparsity();
+        if(sparsity < 0.25)
+            return mlir::failure();
+    }
+
 #if 0
     // TODO Adapt PhyOperatorSelectionPass once this code is turned on again.
     if(lhsTransposeOp) {

--- a/src/runtime/local/kernels/MatMul.h
+++ b/src/runtime/local/kernels/MatMul.h
@@ -129,3 +129,53 @@ struct MatMul<Matrix<VT>, Matrix<VT>, Matrix<VT>> {
         res->finishAppend();
     }
 };
+
+// ----------------------------------------------------------------------------
+// CSRMatrix <- CSRMatrix, CSRMatrix
+// ----------------------------------------------------------------------------
+
+template<typename VT>
+struct MatMul<CSRMatrix<VT>, CSRMatrix<VT>, CSRMatrix<VT>> { // ToDo: support transpose
+    static void apply(CSRMatrix<VT> *& res, const CSRMatrix<VT> * lhs, const CSRMatrix<VT> * rhs, bool transa, bool transb, DCTX(ctx)) {
+        const size_t nr1 = lhs->getNumRows();
+        const size_t nc1 = lhs->getNumCols();
+        const size_t nr2 = rhs->getNumRows();
+        const size_t nc2 = rhs->getNumCols();
+
+        if(nc1 != nr2)
+            throw std::runtime_error("#cols of lhs and #rows of rhs must be the same");
+
+        // TODO: Better estimation of the number of non-zeros
+        size_t estimationNumNonZeros = lhs->getNumNonZeros() * rhs->getNumNonZeros();
+        if(res == nullptr)
+            res = DataObjectFactory::create<CSRMatrix<VT>>(nr1, nc2, estimationNumNonZeros, true);
+
+        const VT* valuesLhs = lhs->getValues();
+        const size_t* colIdxsLhs = lhs->getColIdxs();
+        const size_t* rowOffsetsLhs = lhs->getRowOffsets();
+
+        const VT* valuesRhs = rhs->getValues();
+        const size_t* colIdxsRhs = rhs->getColIdxs();
+        const size_t* rowOffsetsRhs = rhs->getRowOffsets();
+
+        for (size_t row = 0; row < nr1; row++) {
+            for (size_t col = 0; col < nc2; col++) {
+                VT sum = VT(0);
+                // Dot product between the row `row` of Lhs and the col `col` of Rhs
+                for (size_t j = rowOffsetsLhs[row]; j < rowOffsetsLhs[row + 1]; j++) {
+                    size_t k = colIdxsLhs[j];
+                    // For this we need to find the values Rhs[k, col]
+                    // (we already have Lhs[row, k])
+                    size_t i = rowOffsetsRhs[k];
+                    size_t endRhsRow = rowOffsetsRhs[k + 1];
+                    // We are scanning the k^{th} row of Rhs to find a value at the col `col`
+                    while (i < endRhsRow && colIdxsRhs[i] < col)
+                        i++;
+                    if (i < endRhsRow && colIdxsRhs[i] == col)
+                        sum += valuesLhs[j] * valuesRhs[i];
+                }
+                res->set(row, col, sum);
+            }
+        }
+    }
+};

--- a/src/runtime/local/kernels/kernels.json
+++ b/src/runtime/local/kernels/kernels.json
@@ -2256,7 +2256,11 @@
                 "instantiations": [
                     [["DenseMatrix", "int32_t"], ["DenseMatrix", "int32_t"], ["DenseMatrix", "int32_t"]],
                     [["DenseMatrix", "int64_t"], ["DenseMatrix", "int64_t"], ["DenseMatrix", "int64_t"]],
-                    [["DenseMatrix", "double"], ["CSRMatrix", "double"], ["DenseMatrix", "double"]]
+                    [["DenseMatrix", "double"], ["CSRMatrix", "double"], ["DenseMatrix", "double"]],
+                    [["CSRMatrix", "double"], ["CSRMatrix", "double"], ["CSRMatrix", "double"]],
+                    [["CSRMatrix", "float"], ["CSRMatrix", "float"], ["CSRMatrix", "float"]],
+                    [["CSRMatrix", "int64_t"], ["CSRMatrix", "int64_t"], ["CSRMatrix", "int64_t"]],
+                    [["CSRMatrix", "int32_t"], ["CSRMatrix", "int32_t"], ["CSRMatrix", "int32_t"]]
                 ]
             },
              {

--- a/test/runtime/local/kernels/MatMulTest.cpp
+++ b/test/runtime/local/kernels/MatMulTest.cpp
@@ -20,7 +20,6 @@
 #include <runtime/local/context/DaphneContext.h>
 #include <runtime/local/datagen/GenGivenVals.h>
 #include <runtime/local/datastructures/DenseMatrix.h>
-#include <runtime/local/kernels/CheckEq.h>
 #include <runtime/local/kernels/MatMul.h>
 #include <runtime/local/kernels/SliceRow.h>
 #include <runtime/local/kernels/SliceCol.h>
@@ -43,7 +42,7 @@ void checkMatMul(const DT * lhs, const DT * rhs, const DT * exp, DCTX(dctx), boo
     DataObjectFactory::destroy(res);
 }
 
-TEMPLATE_PRODUCT_TEST_CASE("MatMul", TAG_KERNELS, (DATA_TYPES), (VALUE_TYPES)) {
+TEMPLATE_PRODUCT_TEST_CASE("MatMul", TAG_KERNELS, (CSRMatrix, DATA_TYPES), (VALUE_TYPES)) {
     auto dctx = setupContextAndLogger();
 
     using DT = TestType;


### PR DESCRIPTION
This PR implements a kernel for the matrix multiplication between two CSR matrices.

Related Issue: #793 

Fixes also #783 

## Questions

- I needed to provide an estimation of the number of non-zeros elements for the resulting matrix. I had a "guess" but probably this guess can be improved (maybe: https://link.springer.com/content/pdf/10.1023/A:1009716300509.pdf)
- I am not sure if I need to add more to the `kernels.json`? like for other types than `double`
