### PR TITLE
[DAPHNE-#773] Undetected invalid script args

### DIFF
--- a/test/api/cli/scriptargs/ScriptArgsTest.cpp
+++ b/test/api/cli/scriptargs/ScriptArgsTest.cpp
@@ -31,6 +31,14 @@ TEST_CASE("Print single script argument", TAG_SCRIPTARGS) {
     compareDaphneToStr("-123.45\n"    , scriptPath.c_str(), "--args", "foo=-123.45");
     compareDaphneToStr("1\n"          , scriptPath.c_str(), "--args", "foo=true");
     compareDaphneToStr("hello world\n", scriptPath.c_str(), "--args", "foo=\"hello world\"");
+    compareDaphneToStr("nan\n", scriptPath.c_str(), "--args", "foo=nan");
+    compareDaphneToStr("inf\n", scriptPath.c_str(), "--args", "foo=inf");
+    compareDaphneToStr("-inf\n", scriptPath.c_str(), "--args", "foo=-inf");
+    compareDaphneToStr("12.34\n", scriptPath.c_str(), "--args", "foo=12.34f");
+    compareDaphneToStr("120000\n", scriptPath.c_str(), "--args", "foo=1.2e5f");
+    compareDaphneToStr("1e-14\n", scriptPath.c_str(), "--args", "foo=1E-14");
+    compareDaphneToStr("1\n", scriptPath.c_str(), "--args", "foo=true");
+    compareDaphneToStr("0\n", scriptPath.c_str(), "--args", "foo=false");
 }
 
 TEST_CASE("Missing script argument", TAG_SCRIPTARGS) {
@@ -89,13 +97,15 @@ TEST_CASE("Ways of specifying script arguments", TAG_SCRIPTARGS) {
     CHECK(err.str() == "");
 }
 
-// TODO While DAPHNE does not evaluate the expressions provided as script arguments,
-// these invalid script arguments are not properly detected, either. DAPHNE succeeds
-// with unexpected results (see #773).
-#if 0
+
 TEST_CASE("Don't support general expressions as script arguments", TAG_SCRIPTARGS) {
     const std::string scriptPath = dirPath + "printSingleArg.daphne";
     checkDaphneFails(scriptPath.c_str(), "--args", "foo=10+10");
     checkDaphneFails(scriptPath.c_str(), "--args", "foo=sin(1.23)");
 }
-#endif
+
+TEST_CASE("Don't support literal mixtures ", TAG_SCRIPTARGS) {
+    const std::string scriptPath = dirPath + "printSingleArg.daphne";
+    checkDaphneFails(scriptPath.c_str(), "--args", "foo=10xyz23");
+    checkDaphneFails(scriptPath.c_str(), "--args", "foo=-0.0mo");
+}


### PR DESCRIPTION
When calling daphne, users can provide named script arguments that are available inside the DaphneDSL script. 
According to the [DaphneDSL language reference](https://daphne-eu.github.io/daphne/DaphneDSL/LanguageRef/#script-arguments), only literals may be passed as script arguments

However, the following calls of daphne with invalid script arguments all passed "successfully" (status code 0) and some didn't even indicate any error. 


- Fixed invalid script arguments that try to evaulate an expression
- `bin/daphne test/api/cli/scriptargs/printSingleArg.daphne foo="sin(1.23)"`
- `bin/daphne test/api/cli/scriptargs/printSingleArg.daphne foo="1.23*4.56"`
- Fixed invalid script arguments that were not literals
- `bin/daphne test/api/cli/scriptargs/printSingleArg.daphne foo=10xyz23`
- Added testcases for single script arguments
- Added testcases where Daphne fails in case of an invalid script arguments