### PR TITLE
[DAPHNE-#717]  handle daphne failure in daphne lib

### DIFF
--- a/src/api/daphnelib/DaphneLibResult.h
+++ b/src/api/daphnelib/DaphneLibResult.h
@@ -17,6 +17,8 @@
 #pragma once
 
 #include <cinttypes>
+#include <string>
+
 
 struct DaphneLibResult {
     // For matrices.
@@ -28,4 +30,6 @@ struct DaphneLibResult {
     int64_t* vtcs;
     char** labels;
     void** columns;
+    // To pass error message to Python code.
+    std::string error_message;
 };

--- a/src/api/daphnelib/DaphneLibResult.h
+++ b/src/api/daphnelib/DaphneLibResult.h
@@ -30,6 +30,6 @@ struct DaphneLibResult {
     int64_t* vtcs;
     char** labels;
     void** columns;
-    // To pass error message to Python code.
+    // To pass error messages to Python code.
     std::string error_message;
 };

--- a/src/api/internal/daphne_internal.cpp
+++ b/src/api/internal/daphne_internal.cpp
@@ -668,11 +668,17 @@ int startDAPHNE(int argc, const char** argv, DaphneLibResult* daphneLibRes, int 
         }
     }
     catch (std::runtime_error& re) {
-        spdlog::error("Execution error: {}", re.what());
+        if(daphneLibRes != nullptr) // For DaphneLib (Python API), error message is handled later in script.py.
+           daphneLibRes->error_message = std::string(re.what());
+        else
+            spdlog::error("Execution error: {}", re.what());
         return StatusCode::EXECUTION_ERROR;
     }
     catch(std::exception & e){
-        spdlog::error("Execution error: {}", e.what());
+        if(daphneLibRes != nullptr) // For DaphneLib (Python API), error message is handled later in script.py.
+            daphneLibRes->error_message = std::string(e.what());
+        else
+            spdlog::error("Execution error: {}", e.what());
         return StatusCode::EXECUTION_ERROR;
     }
     clock::time_point tpEnd = clock::now();

--- a/src/api/python/daphne/script_building/script.py
+++ b/src/api/python/daphne/script_building/script.py
@@ -96,6 +96,15 @@ class DaphneDSLScript:
         
         #os.environ['OPENBLAS_NUM_THREADS'] = '1'
         res = DaphneLib.daphne(ctypes.c_char_p(str.encode(PROTOTYPE_PATH)), ctypes.c_char_p(str.encode(temp_out_path)))
+        if res == 3:
+            # Runtime Error Message with DSL code line
+            runtime_error_message = DaphneLib.getResult().error_message.decode("utf-8")
+            # Remove DSL code line from Runtime Error Message
+            index_code_line = runtime_error_message.find("Source file ->") - 29
+            runtime_error_message = runtime_error_message[:index_code_line]
+            
+            runtime_error = RuntimeError(f"Execution error in DSL script: {runtime_error_message}")
+            raise runtime_error
         #os.environ['OPENBLAS_NUM_THREADS'] = '32'
 
     def _dfs_dag_nodes(self, dag_node: VALID_INPUT_TYPES)->str:

--- a/src/api/python/daphne/script_building/script.py
+++ b/src/api/python/daphne/script_building/script.py
@@ -96,15 +96,14 @@ class DaphneDSLScript:
         
         #os.environ['OPENBLAS_NUM_THREADS'] = '1'
         res = DaphneLib.daphne(ctypes.c_char_p(str.encode(PROTOTYPE_PATH)), ctypes.c_char_p(str.encode(temp_out_path)))
-        if res == 3:
-            # Runtime Error Message with DSL code line
-            runtime_error_message = DaphneLib.getResult().error_message.decode("utf-8")
-            # Remove DSL code line from Runtime Error Message
-            index_code_line = runtime_error_message.find("Source file ->") - 29
-            runtime_error_message = runtime_error_message[:index_code_line]
+        if res != 0:
+            # Error message with DSL code line.
+            error_message = DaphneLib.getResult().error_message.decode("utf-8")
+            # Remove DSL code line from error message.
+            # index_code_line = error_message.find("Source file ->") - 29
+            # error_message = error_message[:index_code_line]
             
-            runtime_error = RuntimeError(f"Execution error in DSL script: {runtime_error_message}")
-            raise runtime_error
+            raise RuntimeError(f"Error in DaphneDSL script: {error_message}")
         #os.environ['OPENBLAS_NUM_THREADS'] = '32'
 
     def _dfs_dag_nodes(self, dag_node: VALID_INPUT_TYPES)->str:

--- a/src/api/python/daphne/utils/daphnelib.py
+++ b/src/api/python/daphne/utils/daphnelib.py
@@ -28,7 +28,9 @@ class DaphneLibResult(ctypes.Structure):
         # For frames.
         ("vtcs", ctypes.POINTER(ctypes.c_int64)),
         ("labels", ctypes.POINTER(ctypes.c_char_p)),
-        ("columns", ctypes.POINTER(ctypes.c_void_p))
+        ("columns", ctypes.POINTER(ctypes.c_void_p)),
+        # To pass error message to Python code.
+        ("error_message", ctypes.c_char_p)
     ]
 
 DaphneLib = ctypes.CDLL(os.path.join(PROTOTYPE_PATH, DAPHNELIB_FILENAME))

--- a/src/api/python/daphne/utils/daphnelib.py
+++ b/src/api/python/daphne/utils/daphnelib.py
@@ -29,7 +29,7 @@ class DaphneLibResult(ctypes.Structure):
         ("vtcs", ctypes.POINTER(ctypes.c_int64)),
         ("labels", ctypes.POINTER(ctypes.c_char_p)),
         ("columns", ctypes.POINTER(ctypes.c_void_p)),
-        # To pass error message to Python code.
+        # To pass error messages to Python code.
         ("error_message", ctypes.c_char_p)
     ]
 


### PR DESCRIPTION
[DaphneLib-#717]  handle daphne failure in daphne lib
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Summary
This PR closes issue #717 by handling execution errors in DaphneLib.

Changes:

* `error_message`: Introduced a new variable in DaphneLibResult to store execution error messages from DSL scripts.
* Error Handling in C++: Updated `src/api/internal/daphne_internal.cpp`  to capture and store execution error messages in the `error_message` variable when a DSL script fails.
* Error Handling in Python: Enhanced error handling in `src/api/python/daphne/script_building/script.py` to process and log execution error messages during DSL script execution.