### PR TITLE
[DAPHNE-#811] Extension of EwBinaryMat and EwUnaryMat Kernels to Support Sparse and Dense Matrix Addition

### DIFF
--- a/src/runtime/local/datastructures/CSRMatrix.h
+++ b/src/runtime/local/datastructures/CSRMatrix.h
@@ -185,6 +185,27 @@ public:
         // colIdxs arrays.
     }
 
+    void resize(size_t newMaxNumNonZeros) {
+        // Create a new matrix with the increased size
+        size_t numRows = this->getNumRows();
+        size_t numCols = this->getNumCols();
+        CSRMatrix<ValueType>* newRes = DataObjectFactory::create<CSRMatrix<ValueType>>(numRows, numCols, newMaxNumNonZeros, false);
+
+        // Copy the existing data to the new matrix
+        std::memcpy(newRes->getValues(), this->getValues(), this->getNumNonZeros() * sizeof(ValueType));
+        std::memcpy(newRes->getColIdxs(), this->getColIdxs(), this->getNumNonZeros() * sizeof(size_t));
+        std::memcpy(newRes->getRowOffsets(), this->getRowOffsets(), (numRows + 1) * sizeof(size_t));
+
+        // Update the internal pointers of the current object to the new buffers
+        std::swap(this->values, newRes->values);
+        std::swap(this->colIdxs, newRes->colIdxs);
+        std::swap(this->rowOffsets, newRes->rowOffsets);
+        this->maxNumNonZeros = newMaxNumNonZeros;
+
+        // Clean up the temporary newRes object
+        DataObjectFactory::destroy(newRes);
+    }
+
     ValueType * getValues() {
         return values.get();
     }

--- a/src/runtime/local/kernels/EwUnaryMat.h
+++ b/src/runtime/local/kernels/EwUnaryMat.h
@@ -111,7 +111,7 @@ struct EwUnaryMat<CSRMatrix<VT>, CSRMatrix<VT>> {
                 if (value != VT(0)) {
                     if (posRes >= res->getMaxNumNonZeros()) {
                         // Resize the result matrix to accommodate more non-zero values
-                        resizeResultMatrix(res, posRes + nnzRowArg);
+                        res->resize(posRes + nnzRowArg);
                     }
                     res->getValues()[posRes] = value;
                     res->getColIdxs()[posRes] = colIdxsRowArg[posArg];
@@ -127,7 +127,7 @@ struct EwUnaryMat<CSRMatrix<VT>, CSRMatrix<VT>> {
                     if (value != VT(0)) {
                         if (posRes >= res->getMaxNumNonZeros()) {
                             // Resize the result matrix to accommodate more non-zero values
-                            resizeResultMatrix(res, posRes + 1);
+                            res->resize(posRes + 1);
                         }
                         res->getValues()[posRes] = value;
                         res->getColIdxs()[posRes] = colIdx;
@@ -139,26 +139,7 @@ struct EwUnaryMat<CSRMatrix<VT>, CSRMatrix<VT>> {
             rowOffsetsRes[rowIdx + 1] = posRes;
         }
     }
-
-private:
-    static void resizeResultMatrix(CSRMatrix<VT>*& res, size_t newMaxNumNonZeros) {
-        // Create a new matrix with the increased size
-        size_t numRows = res->getNumRows();
-        size_t numCols = res->getNumCols();
-        CSRMatrix<VT>* newRes = DataObjectFactory::create<CSRMatrix<VT>>(numRows, numCols, newMaxNumNonZeros, false);
-
-        // Copy the existing data to the new matrix
-        std::memcpy(newRes->getValues(), res->getValues(), res->getNumNonZeros() * sizeof(VT));
-        std::memcpy(newRes->getColIdxs(), res->getColIdxs(), res->getNumNonZeros() * sizeof(size_t));
-        std::memcpy(newRes->getRowOffsets(), res->getRowOffsets(), (numRows + 1) * sizeof(size_t));
-
-        // Replace the old matrix with the new one
-        DataObjectFactory::destroy(res);
-        res = newRes;
-    }
 };
-
-
 
 // ----------------------------------------------------------------------------
 // Matrix <- Matrix

--- a/src/runtime/local/kernels/kernels.json
+++ b/src/runtime/local/kernels/kernels.json
@@ -936,6 +936,10 @@
                 },
                 {
                     "type": "uint64_t",
+                    "name": "propertyLoggerPtr"
+                },
+                {
+                    "type": "uint64_t",
                     "name": "stringRefCountPtr"
                 }
             ]
@@ -1323,7 +1327,9 @@
                     [["CSRMatrix", "double"], ["CSRMatrix", "double"], ["CSRMatrix", "double"]],
                     [["CSRMatrix", "float"], ["CSRMatrix", "float"], ["CSRMatrix", "float"]],
                     [["DenseMatrix", "float"], ["CSRMatrix", "float"], ["DenseMatrix", "float"]],
-                    [["DenseMatrix", "double"], ["CSRMatrix", "double"], ["DenseMatrix", "double"]]
+                    [["DenseMatrix", "double"], ["CSRMatrix", "double"], ["DenseMatrix", "double"]],
+                    [["DenseMatrix", "float"], ["DenseMatrix", "float"], ["CSRMatrix", "float"]],
+                    [["DenseMatrix", "double"], ["DenseMatrix", "double"], ["CSRMatrix", "double"]]
                 ],
                 "opCodes": ["ADD", "SUB", "MUL", "DIV", "POW", "LOG", "MOD", "EQ", "NEQ", "LT", "LE", "GT", "GE", "MIN", "MAX", "AND", "OR"]
             }
@@ -2204,6 +2210,44 @@
     },
     {
         "kernelTemplate": {
+            "header": "RecordProperties.h",
+            "opName": "recordProperties",
+            "returnType": "void",
+            "templateParams": [
+                {
+                    "name": "DTArg",
+                    "isDataType": true
+                }
+            ],
+            "runtimeParams": [
+                {
+                    "type": "const DTArg *",
+                    "name": "arg"
+                },
+                {
+                    "type": "uint32_t",
+                    "name": "value_id"
+                }
+            ]
+        },
+        "instantiations":[     
+            [["DenseMatrix", "double"]],
+            [["DenseMatrix", "float"]],
+            [["DenseMatrix", "int64_t"]],
+            [["DenseMatrix", "int32_t"]],
+            [["DenseMatrix", "int8_t"]],
+            [["DenseMatrix", "uint64_t"]],
+            [["DenseMatrix", "uint32_t"]],
+            [["DenseMatrix", "uint8_t"]],
+            [["DenseMatrix", "size_t"]],
+            [["CSRMatrix", "double"]],
+            [["CSRMatrix", "float"]],
+            [["CSRMatrix", "int64_t"]],
+            [["CSRMatrix", "uint8_t"]]
+        ]
+    },
+    {
+        "kernelTemplate": {
             "header": "MatMul.h",
             "opName": "matMul",
             "returnType": "void",
@@ -3076,6 +3120,7 @@
             [["CSRMatrix", "double"],["CSRMatrix", "double"]],
             [["CSRMatrix", "int64_t"],["CSRMatrix", "int64_t"]]
         ],
+
         "opCodes": ["MINUS", "SIGN", "SQRT", "EXP", "ABS", "FLOOR", "CEIL", "ROUND", "LN",
                     "SIN", "COS", "TAN", "ASIN", "ACOS", "ATAN", "SINH", "COSH", "TANH", "ISNAN"]
     },

--- a/src/runtime/local/kernels/kernels.json
+++ b/src/runtime/local/kernels/kernels.json
@@ -936,10 +936,6 @@
                 },
                 {
                     "type": "uint64_t",
-                    "name": "propertyLoggerPtr"
-                },
-                {
-                    "type": "uint64_t",
                     "name": "stringRefCountPtr"
                 }
             ]
@@ -2206,44 +2202,6 @@
             [["DenseMatrix", "uint8_t"], ["DenseMatrix", "uint64_t"]],
             [["DenseMatrix", "uint8_t"], ["DenseMatrix", "uint32_t"]],
             [["DenseMatrix", "uint8_t"], ["DenseMatrix", "uint8_t"]]
-        ]
-    },
-    {
-        "kernelTemplate": {
-            "header": "RecordProperties.h",
-            "opName": "recordProperties",
-            "returnType": "void",
-            "templateParams": [
-                {
-                    "name": "DTArg",
-                    "isDataType": true
-                }
-            ],
-            "runtimeParams": [
-                {
-                    "type": "const DTArg *",
-                    "name": "arg"
-                },
-                {
-                    "type": "uint32_t",
-                    "name": "value_id"
-                }
-            ]
-        },
-        "instantiations":[     
-            [["DenseMatrix", "double"]],
-            [["DenseMatrix", "float"]],
-            [["DenseMatrix", "int64_t"]],
-            [["DenseMatrix", "int32_t"]],
-            [["DenseMatrix", "int8_t"]],
-            [["DenseMatrix", "uint64_t"]],
-            [["DenseMatrix", "uint32_t"]],
-            [["DenseMatrix", "uint8_t"]],
-            [["DenseMatrix", "size_t"]],
-            [["CSRMatrix", "double"]],
-            [["CSRMatrix", "float"]],
-            [["CSRMatrix", "int64_t"]],
-            [["CSRMatrix", "uint8_t"]]
         ]
     },
     {

--- a/src/runtime/local/kernels/kernels.json
+++ b/src/runtime/local/kernels/kernels.json
@@ -1319,10 +1319,11 @@
                 "name":  ["CPP"],
                 "instantiations": [
                     [["CSRMatrix", "double"], ["CSRMatrix", "double"], ["DenseMatrix", "double"]],
-                    [["CSRMatrix", "double"], ["CSRMatrix", "double"], ["CSRMatrix", "double"]],
                     [["CSRMatrix", "float"], ["CSRMatrix", "float"], ["DenseMatrix", "float"]],
-                    [["CSRMatrix", "float"], ["CSRMatrix", "float"], ["CSRMatrix", "float"]]
-
+                    [["CSRMatrix", "double"], ["CSRMatrix", "double"], ["CSRMatrix", "double"]],
+                    [["CSRMatrix", "float"], ["CSRMatrix", "float"], ["CSRMatrix", "float"]],
+                    [["DenseMatrix", "float"], ["CSRMatrix", "float"], ["DenseMatrix", "float"]],
+                    [["DenseMatrix", "double"], ["CSRMatrix", "double"], ["DenseMatrix", "double"]]
                 ],
                 "opCodes": ["ADD", "SUB", "MUL", "DIV", "POW", "LOG", "MOD", "EQ", "NEQ", "LT", "LE", "GT", "GE", "MIN", "MAX", "AND", "OR"]
             }
@@ -3071,7 +3072,9 @@
         },
         "instantiations": [
             [["DenseMatrix", "double"],["DenseMatrix", "double"]],
-            [["DenseMatrix", "int64_t"],["DenseMatrix", "int64_t"]]
+            [["DenseMatrix", "int64_t"],["DenseMatrix", "int64_t"]],
+            [["CSRMatrix", "double"],["CSRMatrix", "double"]],
+            [["CSRMatrix", "int64_t"],["CSRMatrix", "int64_t"]]
         ],
         "opCodes": ["MINUS", "SIGN", "SQRT", "EXP", "ABS", "FLOOR", "CEIL", "ROUND", "LN",
                     "SIN", "COS", "TAN", "ASIN", "ACOS", "ATAN", "SINH", "COSH", "TANH", "ISNAN"]

--- a/test/runtime/local/kernels/EwBinaryMatTest.cpp
+++ b/test/runtime/local/kernels/EwBinaryMatTest.cpp
@@ -24,8 +24,6 @@
 
 #include <catch.hpp>
 
-#include <vector>
-
 #include <cstdint>
 
 #define TEST_NAME(opName) "EwBinaryMat (" opName ")"
@@ -171,6 +169,52 @@ TEMPLATE_TEST_CASE(TEST_NAME("mul_sparse_dense"), TAG_KERNELS, VALUE_TYPES) {
     checkSparseDenseEwBinaryMat(BinaryOpCode::MUL, m0, m3, m0);
 
     DataObjectFactory::destroy(m0, m1, m2, m3, exp0, exp1);
+}
+
+TEMPLATE_TEST_CASE(TEST_NAME("add_sparse_dense"), TAG_KERNELS, VALUE_TYPES) {
+    using VT = TestType;
+    using SparseDT = CSRMatrix<VT>;
+    using DenseDT = DenseMatrix<VT>;
+
+    auto m0 = genGivenVals<SparseDT>(4, {
+        0, 1, 1, 0, 0, 0,
+        0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0,
+    });
+
+    auto m1 = genGivenVals<DenseDT>(4, {
+        1, 2, 0, 0, 1, 3,
+        0, 1, 0, 2, 0, 3,
+        0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0,
+    });
+
+    auto m2 = genGivenVals<DenseDT>(4, {
+        3, 0, 3, 3, 3, 3,
+        1, 2, 3, 1, 1, 1,
+        1, 1, 1, 1, 1, 1,
+        1, 2, 3, 1, 3, 2,
+    });
+
+    auto expAdd0 = genGivenVals<SparseDT>(4, {
+        1, 3, 1, 0, 1, 3,
+        0, 1, 0, 2, 0, 3,
+        0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0,
+    });
+
+    auto expAdd1 = genGivenVals<SparseDT>(4, {
+        3, 1, 4, 3, 3, 3,
+        1, 2, 3, 1, 1, 1,
+        1, 1, 1, 1, 1, 1,
+        1, 2, 3, 1, 3, 2,
+    });
+
+    checkSparseDenseEwBinaryMat(BinaryOpCode::ADD, m0, m1, expAdd0);
+    checkSparseDenseEwBinaryMat(BinaryOpCode::ADD, m0, m2, expAdd1);
+
+    DataObjectFactory::destroy(m0, m1, m2, expAdd0, expAdd1);
 }
 
 TEMPLATE_PRODUCT_TEST_CASE(TEST_NAME("div"), TAG_KERNELS, (DATA_TYPES_NO_CSR), (VALUE_TYPES)) {

--- a/test/runtime/local/kernels/EwUnaryMatTest.cpp
+++ b/test/runtime/local/kernels/EwUnaryMatTest.cpp
@@ -31,7 +31,7 @@
 #include <cstdint>
 
 #define TEST_NAME(opName) "EwUnaryMat (" opName ")"
-#define DATA_TYPES DenseMatrix, Matrix
+#define DATA_TYPES DenseMatrix, Matrix, CSRMatrix
 #define VALUE_TYPES int32_t, double
 
 template<typename DTRes, typename DTArg>


### PR DESCRIPTION
### Overview

This draft pull request introduces an extension to the `EwBinaryMat` and `EwUnaryMat` kernels to support efficient operations for matrix addition between dense and sparse matrices. The following kernels have been added:

- **EwBinaryMat Kernels:**
  - `DenseMatrix <- CSRMatrix, DenseMatrix`
  - `DenseMatrix <- DenseMatrix, CSRMatrix`
  - `CSRMatrix <- CSRMatrix, DenseMatrix`

- **EwUnaryMat Kernels:**
  - `CSRMatrix <- CSRMatrix`

#### Implementation Details
As part of this implementation, a `resize` method was added to the `CSRMatrix` class to dynamically handle the reallocation of memory when the number of non-zero elements exceeds the initially allocated space.

### Questions Regarding `resize` Method Implementation

The `resize` method is essential for managing dynamic memory allocation within sparse matrices, especially when the number of non-zero elements increases during operations.

1. **Comparison with Dense Matrices**: In some scenarios, the memory usage of a CSR matrix may approach or even exceed that of a dense matrix, particularly when the matrix is nearly dense or when the overhead from storing indices becomes significant. Is it advisable to dynamically adjust the size of the CSR matrix in these cases, considering that the most efficient representation should have already been chosen in a previous compiler pass?
    
2. **Alternative Approaches**: Are there alternative methods that could offer more efficiency in handling dynamic resizing, especially in the context of sparse matrices?