### PR TITLE
[DAPHNE-#772] Fix Constant folding crashes for values of different types

### DIFF
--- a/test/api/cli/operations/CanonicalizationConstantFoldingOpTest.cpp
+++ b/test/api/cli/operations/CanonicalizationConstantFoldingOpTest.cpp
@@ -40,3 +40,7 @@ TEST_CASE("additive_inverse_canonicalization", TAG_CODEGEN TAG_OPERATIONS) {
     compareDaphneParsingSimplifiedToRef(dirPath + testName + ".txt", dirPath + testName + ".daphne");
 }
 
+TEST_CASE("binary_operator_casts_constant_folding", TAG_CODEGEN TAG_OPERATIONS) {
+    const std::string testName = "binary_op_casts_constant_folding";
+    compareDaphneParsingSimplifiedToRef(dirPath + testName + ".txt", dirPath + testName + ".daphne");
+}

--- a/test/api/cli/operations/binary_op_casts_constant_folding.daphne
+++ b/test/api/cli/operations/binary_op_casts_constant_folding.daphne
@@ -1,0 +1,16 @@
+print(1 + as.si8(1));
+print(2 + as.si32(1));
+print(3 + as.si64(1));
+print(4 + as.ui8(1));
+print(5 + as.ui32(1));
+print(6 + as.ui64(1));
+
+print(10.0 + as.f32(1));
+print(11.0 + as.f64(1));
+
+print(as.si32(7) + as.si8(1));
+print(as.si64(8) + as.si32(1));
+print(as.si8(9) + as.si64(1));
+
+print(as.f64(12.0) + as.f32(1));
+print(as.f32(13.0) + as.f64(1));

--- a/test/api/cli/operations/binary_op_casts_constant_folding.txt
+++ b/test/api/cli/operations/binary_op_casts_constant_folding.txt
@@ -1,0 +1,34 @@
+IR after parsing and some simplifications:
+module {
+  func.func @main() {
+    %0 = "daphne.constant"() {value = 1.400000e+01 : f64} : () -> f64
+    %1 = "daphne.constant"() {value = 1.300000e+01 : f64} : () -> f64
+    %2 = "daphne.constant"() {value = 1.200000e+01 : f64} : () -> f64
+    %3 = "daphne.constant"() {value = 10 : si64} : () -> si64
+    %4 = "daphne.constant"() {value = 9 : si64} : () -> si64
+    %5 = "daphne.constant"() {value = 8 : si32} : () -> si32
+    %6 = "daphne.constant"() {value = 1.100000e+01 : f64} : () -> f64
+    %7 = "daphne.constant"() {value = 7 : ui64} : () -> ui64
+    %8 = "daphne.constant"() {value = 6 : si64} : () -> si64
+    %9 = "daphne.constant"() {value = 5 : si64} : () -> si64
+    %10 = "daphne.constant"() {value = 4 : si64} : () -> si64
+    %11 = "daphne.constant"() {value = 3 : si64} : () -> si64
+    %12 = "daphne.constant"() {value = 2 : si64} : () -> si64
+    %13 = "daphne.constant"() {value = false} : () -> i1
+    %14 = "daphne.constant"() {value = true} : () -> i1
+    "daphne.print"(%12, %14, %13) : (si64, i1, i1) -> ()
+    "daphne.print"(%11, %14, %13) : (si64, i1, i1) -> ()
+    "daphne.print"(%10, %14, %13) : (si64, i1, i1) -> ()
+    "daphne.print"(%9, %14, %13) : (si64, i1, i1) -> ()
+    "daphne.print"(%8, %14, %13) : (si64, i1, i1) -> ()
+    "daphne.print"(%7, %14, %13) : (ui64, i1, i1) -> ()
+    "daphne.print"(%6, %14, %13) : (f64, i1, i1) -> ()
+    "daphne.print"(%2, %14, %13) : (f64, i1, i1) -> ()
+    "daphne.print"(%5, %14, %13) : (si32, i1, i1) -> ()
+    "daphne.print"(%4, %14, %13) : (si64, i1, i1) -> ()
+    "daphne.print"(%3, %14, %13) : (si64, i1, i1) -> ()
+    "daphne.print"(%1, %14, %13) : (f64, i1, i1) -> ()
+    "daphne.print"(%0, %14, %13) : (f64, i1, i1) -> ()
+    "daphne.return"() : () -> ()
+  }
+}


### PR DESCRIPTION
Constant folding required the operands to have the same type. For instance, the following two DaphneDSL scripts would be perfectly amenable to constant folding, but make the DAPHNE compiler crash with the respective error messages:
`print(1 * as.si32(1));`

`daphne: /daphne/thirdparty/llvm-project/llvm/lib/Support/APInt.cpp:226: llvm::APInt llvm::APInt::operator*(const llvm::APInt &) const: Assertion BitWidth == RHS.BitWidth && "Bit widths must be the same"' failed.
...
Segmentation fault (core dumped)`

FIxed it by comparing the bit width in the `constFoldBinaryOp` method. If they are not the same, the smaller one is getting type promoted to the bigger one (reusing the `CastOp` method to perfom this type promotion).

Aded testcases for binary op of different types