### PR TITLE
Code formatting to 120 columns

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,2 +1,3 @@
 BasedOnStyle: LLVM
 IndentWidth: 4
+ColumnLimit: 120


### PR DESCRIPTION
Line length extended to accomodate for screen sizes that can't even be called modern nowadays.