### PR TITLE
[kernels] fix usage of C stdlib abs (#863)

### DIFF
--- a/src/runtime/local/kernels/EwUnarySca.h
+++ b/src/runtime/local/kernels/EwUnarySca.h
@@ -154,7 +154,7 @@ template <typename TRes, typename TArg> TRes ewUnarySca(UnaryOpCode opCode, TArg
 // One such line for each unary function to support.
 // Arithmetic/general math.
 MAKE_EW_UNARY_SCA(UnaryOpCode::MINUS, -arg);
-MAKE_EW_UNARY_SCA(UnaryOpCode::ABS, abs(arg));
+MAKE_EW_UNARY_SCA(UnaryOpCode::ABS, std::abs(arg));
 MAKE_EW_UNARY_SCA(UnaryOpCode::SIGN,
                   (arg == 0) ? 0 : ((arg < 0) ? -1 : ((arg > 0) ? 1 : std::numeric_limits<TRes>::quiet_NaN())));
 MAKE_EW_UNARY_SCA_OPEN_DOMAIN_ERROR(UnaryOpCode::SQRT, sqrt(arg), -0.0, "SQRT with domain [-0, inf]")

--- a/test/runtime/local/kernels/EwUnaryScaTest.cpp
+++ b/test/runtime/local/kernels/EwUnaryScaTest.cpp
@@ -57,11 +57,18 @@ template <UnaryOpCode opCode, typename VT> void checkEwUnaryScaNaN(const VT arg)
 // Arithmetic/general math
 // ****************************************************************************
 
-TEMPLATE_TEST_CASE(TEST_NAME("abs"), TAG_KERNELS, VALUE_TYPES) {
+TEMPLATE_TEST_CASE(TEST_NAME("abs int"), TAG_KERNELS, SI_VALUE_TYPES) {
     using VT = TestType;
     checkEwUnarySca<UnaryOpCode::ABS, VT>(0, 0);
     checkEwUnarySca<UnaryOpCode::ABS, VT>(2, 2);
     checkEwUnarySca<UnaryOpCode::ABS, VT>(-2, 2);
+}
+
+TEMPLATE_TEST_CASE(TEST_NAME("abs fp"), TAG_KERNELS, FP_VALUE_TYPES) {
+    using VT = TestType;
+    checkEwUnarySca<UnaryOpCode::ABS, VT>(0.5, 0.5);
+    checkEwUnarySca<UnaryOpCode::ABS, VT>(2.5, 2.5);
+    checkEwUnarySca<UnaryOpCode::ABS, VT>(-2.5, 2.5);
 }
 
 TEMPLATE_TEST_CASE(TEST_NAME("sign"), TAG_KERNELS, VALUE_TYPES) {


### PR DESCRIPTION
The EwUnary kernel used the C stdlib `abs` function which instead of the appropriate C++ `std::abs` function. This caused a bug where calling `abs` with floating point values were cast to integer values during conversion.

Closes #863