### PR TITLE
VectorizedPipelineOp deduplication bug (#697)

### DIFF
--- a/src/ir/daphneir/Canonicalize.cpp
+++ b/src/ir/daphneir/Canonicalize.cpp
@@ -31,7 +31,7 @@ mlir::LogicalResult mlir::daphne::VectorizedPipelineOp::canonicalize(mlir::daphn
 
     for (size_t i = 0; i < currentSize; i++) {
         const auto &input = op.getInputs()[i];
-        const auto &split = op.getSplits()[i].cast<daphne::VectorSplitAttr>().getValue();
+        const auto &split = vSplitsAttrs[i].cast<daphne::VectorSplitAttr>().getValue();
 
         if (inputMap.count(input) == 0) {
             inputMap[input] = i;

--- a/test/api/cli/vectorized/VectorizedPipelineTest.cpp
+++ b/test/api/cli/vectorized/VectorizedPipelineTest.cpp
@@ -63,4 +63,4 @@ void compareDaphneToDaphneOtherArgs(const std::string &scriptFilePath) {
         }                                                                                                              \
     }
 
-MAKE_TEST_CASE("pipeline", 7)
+MAKE_TEST_CASE("pipeline", 9)

--- a/test/api/cli/vectorized/pipeline_8.daphne
+++ b/test/api/cli/vectorized/pipeline_8.daphne
@@ -1,0 +1,12 @@
+// From issue #697
+
+N = 1000;
+G = rand(N, N, 1.0, 1.0, 0.000001, -1);
+p = fill(1.0, N, 1);
+
+alpha = 0.85;
+one_minus_alpha = 1.0 - alpha;
+
+p = alpha * (G @ p) + one_minus_alpha * p;
+
+print(p[0,0]);

--- a/test/api/cli/vectorized/pipeline_9.daphne
+++ b/test/api/cli/vectorized/pipeline_9.daphne
@@ -1,0 +1,7 @@
+// From issue #697
+
+N = 100;
+G = fill(1.0, N, N);
+p = fill(1.0, N, 1);
+y = (G @ p) + p;
+print(sum(y));


### PR DESCRIPTION
See #697.

To find duplicates, the canonicalize method of the VectorizedPipelineOp uses a std::vector to store the VectorSplits of its inputs. In the actual loop, the canonicalize method didn't use this std::vector, but was still fetching the splits from the VectorizedPipelineOp itself. This patch fixes this mistake. Now inputs that are used multiple times and have multiple splits are correctly considered for each usage.

Closes #697