### PR TITLE
[#877] persist hwloc info in different pipelines

### DIFF
--- a/src/runtime/local/kernels/VectorizedPipeline.h
+++ b/src/runtime/local/kernels/VectorizedPipeline.h
@@ -21,6 +21,7 @@
 #include <runtime/local/datastructures/DataObjectFactory.h>
 #include <runtime/local/datastructures/DenseMatrix.h>
 #include <runtime/local/vectorized/MTWrapper.h>
+#include <runtime/local/vectorized/PipelineHWlocInfo.h>
 
 #include <cstddef>
 
@@ -35,7 +36,8 @@ template <class DTRes> struct VectorizedPipeline {
     static void apply(DTRes **outputs, size_t numOutputs, bool *isScalar, Structure **inputs, size_t numInputs,
                       int64_t *outRows, int64_t *outCols, int64_t *splits, int64_t *combines, size_t numFuncs,
                       void **fun, DCTX(ctx)) {
-        auto wrapper = std::make_unique<MTWrapper<DTRes>>(numFuncs, ctx);
+        static PipelineHWlocInfo topology{ctx};
+        auto wrapper = std::make_unique<MTWrapper<DTRes>>(numFuncs, topology, ctx);
 
         std::vector<std::function<void(DTRes ***, Structure **, DCTX(ctx))>> funcs;
         for (auto i = 0ul; i < numFuncs; ++i) {

--- a/src/runtime/local/vectorized/MTWrapper.h
+++ b/src/runtime/local/vectorized/MTWrapper.h
@@ -20,16 +20,20 @@
 #include "runtime/local/datastructures/AllocationDescriptorCUDA.h"
 #endif
 
+#include "PipelineHWlocInfo.h"
+
 #include <ir/daphneir/Daphne.h>
 #include <runtime/local/vectorized/LoadPartitioning.h>
 #include <runtime/local/vectorized/VectorizedDataSink.h>
 #include <runtime/local/vectorized/WorkerCPU.h>
 #include <runtime/local/vectorized/WorkerGPU.h>
 
+#include <spdlog/fmt/ranges.h>
 #include <spdlog/spdlog.h>
 
 #include <functional>
 #include <set>
+#include <utility>
 
 #include <hwloc.h>
 
@@ -42,9 +46,6 @@ template <typename DT> class MTWrapperBase {
   protected:
     std::vector<std::unique_ptr<Worker>> cuda_workers;
     std::vector<std::unique_ptr<Worker>> cpp_workers;
-    std::vector<int> topologyPhysicalIds;
-    std::vector<int> topologyUniqueThreads;
-    std::vector<int> topologyResponsibleThreads;
     size_t _numThreads{};
     uint32_t _numCPPThreads{};
     uint32_t _numCUDAThreads{};
@@ -52,6 +53,7 @@ template <typename DT> class MTWrapperBase {
     int _numQueues;
     VictimSelectionLogic _victimSelection;
     int _totalNumaDomains;
+    PipelineHWlocInfo _topology;
     DCTX(_ctx);
 
     std::pair<size_t, size_t> getInputProperties(Structure **inputs, size_t numInputs, VectorSplit *splits) {
@@ -68,55 +70,6 @@ template <typename DT> class MTWrapperBase {
         return std::make_pair(len, mem_required);
     }
 
-    void hwloc_recurse_topology(hwloc_topology_t topo, hwloc_obj_t obj, unsigned int parent_package_id,
-                                std::vector<int> &physicalIds, std::vector<int> &uniqueThreads,
-                                std::vector<int> &responsibleThreads) {
-        if (obj->type != HWLOC_OBJ_CORE) {
-            for (unsigned int i = 0; i < obj->arity; i++) {
-                hwloc_recurse_topology(topo, obj->children[i], parent_package_id, physicalIds, uniqueThreads,
-                                       responsibleThreads);
-            }
-        } else {
-            physicalIds.push_back(parent_package_id);
-            for (unsigned int i = 0; i < obj->arity; i++)
-                uniqueThreads.push_back(obj->children[i]->os_index);
-
-            switch (_ctx->getUserConfig().queueSetupScheme) {
-            case QueueTypeOption::CENTRALIZED: {
-                responsibleThreads.push_back(0);
-                break;
-            }
-            case QueueTypeOption::PERGROUP: {
-                if (responsibleThreads.size() == parent_package_id)
-                    responsibleThreads.push_back(obj->children[0]->os_index);
-                break;
-            }
-            case QueueTypeOption::PERCPU: {
-                responsibleThreads.push_back(obj->os_index);
-                break;
-            }
-            }
-        }
-    }
-
-    void get_topology(std::vector<int> &physicalIds, std::vector<int> &uniqueThreads,
-                      std::vector<int> &responsibleThreads) {
-        hwloc_topology_t topology = nullptr;
-
-        hwloc_topology_init(&topology);
-        hwloc_topology_load(topology);
-
-        hwloc_obj_t package = hwloc_get_next_obj_by_type(topology, HWLOC_OBJ_PACKAGE, nullptr);
-
-        while (package != nullptr) {
-            auto package_id = package->os_index;
-            hwloc_recurse_topology(topology, package, package_id, physicalIds, uniqueThreads, responsibleThreads);
-            package = hwloc_get_next_obj_by_type(topology, HWLOC_OBJ_PACKAGE, package);
-        }
-
-        hwloc_topology_destroy(topology);
-    }
-
     void initCPPWorkers(std::vector<TaskQueue *> &qvector, uint32_t batchSize, const bool verbose = false,
                         int numQueues = 0, QueueTypeOption queueMode = QueueTypeOption::CENTRALIZED,
                         bool pinWorkers = false) {
@@ -128,7 +81,9 @@ template <typename DT> class MTWrapperBase {
 
         int i = 0;
         for (auto &w : cpp_workers) {
-            w = std::make_unique<WorkerCPU>(qvector, topologyPhysicalIds, topologyUniqueThreads, _ctx, verbose, 0,
+            _ctx->logger->debug("creatign worker {} with topology {}, size={}", i, _topology.physicalIds,
+                                _topology.physicalIds.size());
+            w = std::make_unique<WorkerCPU>(qvector, _topology.physicalIds, _topology.uniqueThreads, _ctx, verbose, 0,
                                             batchSize, i, numQueues, queueMode, this->_victimSelection, pinWorkers);
             i++;
         }
@@ -181,17 +136,17 @@ template <typename DT> class MTWrapperBase {
     }
 
   public:
-    explicit MTWrapperBase(uint32_t numFunctions, DCTX(ctx)) : _ctx(ctx) {
+    explicit MTWrapperBase(uint32_t numFunctions, PipelineHWlocInfo topology, DCTX(ctx))
+        : _topology(std::move(topology)), _ctx(ctx) {
         _ctx->logger->debug("Querying cpu topology");
-        get_topology(topologyPhysicalIds, topologyUniqueThreads, topologyResponsibleThreads);
 
         if (ctx->config.numberOfThreads > 0)
             _numCPPThreads = ctx->config.numberOfThreads;
         else
-            _numCPPThreads = topologyPhysicalIds.size();
+            _numCPPThreads = _topology.physicalIds.size();
 
         if (_ctx->getUserConfig().queueSetupScheme != QueueTypeOption::CENTRALIZED)
-            _numCPPThreads = topologyUniqueThreads.size();
+            _numCPPThreads = _topology.uniqueThreads.size();
 
         // If the available CPUs from Slurm is less than the configured num
         // threads, use the value from Slurm
@@ -207,10 +162,10 @@ template <typename DT> class MTWrapperBase {
         _queueMode = QueueTypeOption::CENTRALIZED;
         _numQueues = 1;
         _victimSelection = _ctx->getUserConfig().victimSelection;
-        if (std::thread::hardware_concurrency() < topologyUniqueThreads.size() && _ctx->config.hyperthreadingEnabled)
-            topologyUniqueThreads.resize(_numCPPThreads);
+        if (std::thread::hardware_concurrency() < _topology.uniqueThreads.size() && _ctx->config.hyperthreadingEnabled)
+            _topology.uniqueThreads.resize(_numCPPThreads);
         _numThreads = _numCPPThreads + _numCUDAThreads;
-        _totalNumaDomains = std::set<double>(topologyPhysicalIds.begin(), topologyPhysicalIds.end()).size();
+        _totalNumaDomains = std::set<double>(_topology.physicalIds.begin(), _topology.physicalIds.end()).size();
 
         if (_ctx->getUserConfig().queueSetupScheme == QueueTypeOption::PERGROUP) {
             _queueMode = QueueTypeOption::PERGROUP;
@@ -223,15 +178,15 @@ template <typename DT> class MTWrapperBase {
         // ToDo: use logger
         if (_ctx->config.debugMultiThreading) {
             std::cout << "topologyPhysicalIds:" << std::endl;
-            for (const auto &topologyEntry : topologyPhysicalIds) {
+            for (const auto &topologyEntry : _topology.physicalIds) {
                 std::cout << topologyEntry << ',';
             }
             std::cout << std::endl << "topologyUniqueThreads:" << std::endl;
-            for (const auto &topologyEntry : topologyUniqueThreads) {
+            for (const auto &topologyEntry : _topology.uniqueThreads) {
                 std::cout << topologyEntry << ',';
             }
             std::cout << std::endl << "topologyResponsibleThreads:" << std::endl;
-            for (const auto &topologyEntry : topologyResponsibleThreads) {
+            for (const auto &topologyEntry : _topology.responsibleThreads) {
                 std::cout << topologyEntry << ',';
             }
             std::cout << std::endl << "_totalNumaDomains=" << _totalNumaDomains << std::endl;
@@ -250,7 +205,8 @@ template <typename VT> class MTWrapper<DenseMatrix<VT>> : public MTWrapperBase<D
   public:
     using PipelineFunc = void(DenseMatrix<VT> ***, Structure **, DCTX(ctx));
 
-    explicit MTWrapper(uint32_t numFunctions, DCTX(ctx)) : MTWrapperBase<DenseMatrix<VT>>(numFunctions, ctx) {}
+    explicit MTWrapper(uint32_t numFunctions, PipelineHWlocInfo topology, DCTX(ctx))
+        : MTWrapperBase<DenseMatrix<VT>>(numFunctions, topology, ctx) {}
 
     [[maybe_unused]] void executeSingleQueue(std::vector<std::function<PipelineFunc>> funcs, DenseMatrix<VT> ***res,
                                              const bool *isScalar, Structure **inputs, size_t numInputs,
@@ -276,7 +232,8 @@ template <typename VT> class MTWrapper<CSRMatrix<VT>> : public MTWrapperBase<CSR
   public:
     using PipelineFunc = void(CSRMatrix<VT> ***, Structure **, DCTX(ctx));
 
-    explicit MTWrapper(uint32_t numFunctions, DCTX(ctx)) : MTWrapperBase<CSRMatrix<VT>>(numFunctions, ctx) {}
+    explicit MTWrapper(uint32_t numFunctions, PipelineHWlocInfo topology, DCTX(ctx))
+        : MTWrapperBase<CSRMatrix<VT>>(numFunctions, topology, ctx) {}
 
     [[maybe_unused]] void executeSingleQueue(std::vector<std::function<PipelineFunc>> funcs, CSRMatrix<VT> ***res,
                                              const bool *isScalar, Structure **inputs, size_t numInputs,

--- a/src/runtime/local/vectorized/MTWrapper_dense.cpp
+++ b/src/runtime/local/vectorized/MTWrapper_dense.cpp
@@ -143,7 +143,7 @@ template <typename VT>
                                                     funcs, isScalar, inputs, numInputs, numOutputs, outRows, outCols,
                                                     splits, combines, startChunk, endChunk, outRows, outCols, 0, ctx},
                                                 resLock, res),
-                                            this->topologyResponsibleThreads[i]);
+                                            this->_topology.responsibleThreads[i]);
                     startChunk = endChunk;
                 }
             }
@@ -174,7 +174,7 @@ template <typename VT>
                                                      funcs, isScalar, inputs, numInputs, numOutputs, outRows, outCols,
                                                      splits, combines, startChunk, endChunk, outRows, outCols, 0, ctx},
                                                  resLock, res),
-                                             this->topologyUniqueThreads[target]);
+                                             this->_topology.uniqueThreads[target]);
                 startChunk = endChunk;
                 currentItr++;
             }

--- a/src/runtime/local/vectorized/MTWrapper_sparse.cpp
+++ b/src/runtime/local/vectorized/MTWrapper_sparse.cpp
@@ -89,7 +89,7 @@ void MTWrapper<CSRMatrix<VT>>::executeCpuQueues(
                                                     funcs, isScalar, inputs, numInputs, numOutputs, outRows, outCols,
                                                     splits, combines, startChunk, endChunk, outRows, outCols, 0, ctx},
                                                 dataSinks),
-                                            this->topologyResponsibleThreads[i]);
+                                            this->_topology.responsibleThreads[i]);
                     startChunk = endChunk;
                 }
             }

--- a/src/runtime/local/vectorized/PipelineHWlocInfo.h
+++ b/src/runtime/local/vectorized/PipelineHWlocInfo.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include "LoadPartitioningDefs.h"
+#include <hwloc.h>
+#include <runtime/local/context/DaphneContext.h>
+#include <vector>
+
+struct PipelineHWlocInfo {
+    std::vector<int> physicalIds;
+    std::vector<int> uniqueThreads;
+    std::vector<int> responsibleThreads;
+    bool hwloc_initialized = false;
+    QueueTypeOption queueSetupScheme = QueueTypeOption::CENTRALIZED;
+
+    PipelineHWlocInfo(DaphneContext *ctx) : PipelineHWlocInfo(ctx->getUserConfig().queueSetupScheme) {}
+    PipelineHWlocInfo(QueueTypeOption qss) : queueSetupScheme(qss) { get_topology(); }
+
+    void hwloc_recurse_topology(hwloc_topology_t topo, hwloc_obj_t obj, unsigned int parent_package_id) {
+        if (obj->type != HWLOC_OBJ_CORE) {
+            for (unsigned int i = 0; i < obj->arity; i++) {
+                hwloc_recurse_topology(topo, obj->children[i], parent_package_id);
+            }
+        } else {
+            physicalIds.push_back(parent_package_id);
+            for (unsigned int i = 0; i < obj->arity; i++)
+                uniqueThreads.push_back(obj->children[i]->os_index);
+
+            switch (queueSetupScheme) {
+            case QueueTypeOption::CENTRALIZED: {
+                responsibleThreads.push_back(0);
+            } break;
+            case QueueTypeOption::PERGROUP: {
+                if (responsibleThreads.size() == parent_package_id)
+                    responsibleThreads.push_back(obj->children[0]->os_index);
+            } break;
+            case QueueTypeOption::PERCPU: {
+                responsibleThreads.push_back(obj->os_index);
+            } break;
+            }
+        }
+    }
+
+    void get_topology() {
+        if (hwloc_initialized) {
+            return;
+        }
+
+        hwloc_topology_t topology = nullptr;
+
+        hwloc_topology_init(&topology);
+        hwloc_topology_load(topology);
+
+        hwloc_obj_t package = hwloc_get_next_obj_by_type(topology, HWLOC_OBJ_PACKAGE, nullptr);
+
+        while (package != nullptr) {
+            auto package_id = package->os_index;
+            hwloc_recurse_topology(topology, package, package_id);
+            package = hwloc_get_next_obj_by_type(topology, HWLOC_OBJ_PACKAGE, package);
+        }
+
+        hwloc_topology_destroy(topology);
+        hwloc_initialized = true;
+    }
+};

--- a/src/runtime/local/vectorized/WorkerCPU.h
+++ b/src/runtime/local/vectorized/WorkerCPU.h
@@ -61,6 +61,8 @@ class WorkerCPU : public Worker {
         }
 
         int currentDomain = _physical_ids[_threadID];
+        ctx->logger->debug("Thread{}, _physical_ids.size()={}, capacity={}, currentDomain={}", _threadID,
+                           _physical_ids.size(), _physical_ids.capacity(), currentDomain);
         int targetQueue = _threadID;
         if (_queueMode == QueueTypeOption::CENTRALIZED) {
             targetQueue = 0;

--- a/test/runtime/local/vectorized/MultiThreadedKernelTest.cpp
+++ b/test/runtime/local/vectorized/MultiThreadedKernelTest.cpp
@@ -53,7 +53,8 @@ TEMPLATE_PRODUCT_TEST_CASE("Multi-threaded-scheduling", TAG_VECTORIZED, (DATA_TY
     ewBinaryMat<DT, DT, DT>(BinaryOpCode::ADD, r1, m1, m2,
                             dctx.get()); // single-threaded
 
-    auto wrapper = std::make_unique<MTWrapper<DT>>(1, dctx.get());
+    static PipelineHWlocInfo topology{dctx->config.queueSetupScheme};
+    auto wrapper = std::make_unique<MTWrapper<DT>>(1, topology, dctx.get());
     DT **outputs[] = {&r2};
     bool isScalar[] = {false, false};
     Structure *inputs[] = {m1, m2};
@@ -90,7 +91,8 @@ TEMPLATE_PRODUCT_TEST_CASE("Multi-threaded X+Y", TAG_VECTORIZED, (DATA_TYPES),
     ewBinaryMat<DT, DT, DT>(BinaryOpCode::ADD, r1, m1, m2,
                             dctx.get()); // single-threaded
 
-    auto wrapper = std::make_unique<MTWrapper<DT>>(1, dctx.get());
+    static PipelineHWlocInfo topology{dctx->config.queueSetupScheme};
+    auto wrapper = std::make_unique<MTWrapper<DT>>(1, topology, dctx.get());
     DT **outputs[] = {&r2};
     bool isScalar[] = {false, false};
     Structure *inputs[] = {m1, m2};
@@ -127,7 +129,8 @@ TEMPLATE_PRODUCT_TEST_CASE("Multi-threaded X*Y", TAG_VECTORIZED, (DATA_TYPES),
     ewBinaryMat<DT, DT, DT>(BinaryOpCode::MUL, r1, m1, m2,
                             dctx.get()); // single-threaded
 
-    auto wrapper = std::make_unique<MTWrapper<DT>>(1, dctx.get());
+    static PipelineHWlocInfo topology{dctx->config.queueSetupScheme};
+    auto wrapper = std::make_unique<MTWrapper<DT>>(1, topology, dctx.get());
     DT **outputs[] = {&r2};
     bool isScalar[] = {false, false};
     Structure *inputs[] = {m1, m2};


### PR DESCRIPTION
This patch persists the hwloc topology info used in vectorized pipelines over the execution of multiple pipelines. This significantly reduces overhead in workloads that consint of multiple pipelines. With the tested script this patch reduced overall runtimes from ~6s to ~0.9s.

closes #877