### PR TITLE
[#731] refactor scheduling options to enum class

### DIFF
--- a/src/api/cli/DaphneUserConfig.h
+++ b/src/api/cli/DaphneUserConfig.h
@@ -78,9 +78,9 @@ struct DaphneUserConfig {
 
     bool force_cuda = false;
 
-    SelfSchedulingScheme taskPartitioningScheme = STATIC;
-    QueueTypeOption queueSetupScheme = CENTRALIZED;
-    VictimSelectionLogic victimSelection = SEQPRI;
+    SelfSchedulingScheme taskPartitioningScheme = SelfSchedulingScheme::STATIC;
+    QueueTypeOption queueSetupScheme = QueueTypeOption::CENTRALIZED;
+    VictimSelectionLogic victimSelection = VictimSelectionLogic::SEQPRI;
     ALLOCATION_TYPE distributedBackEndSetup = ALLOCATION_TYPE::DIST_MPI; // default value
     size_t max_distributed_serialization_chunk_size =
         std::numeric_limits<int>::max() - 1024; // 2GB (-1KB to make up for gRPC headers etc.) - which is the

--- a/src/api/internal/daphne_internal.cpp
+++ b/src/api/internal/daphne_internal.cpp
@@ -164,6 +164,9 @@ int startDAPHNE(int argc, const char **argv, DaphneLibResult *daphneLibRes, int 
                                      init(""));
 
     // Scheduling options
+    using enum SelfSchedulingScheme;
+    using enum QueueTypeOption;
+    using enum VictimSelectionLogic;
 
     static opt<SelfSchedulingScheme> taskPartitioningScheme(
         "partitioning", cat(schedulingOptions), desc("Choose task partitioning scheme:"),
@@ -179,11 +182,13 @@ int startDAPHNE(int argc, const char **argv, DaphneLibResult *daphneLibRes, int 
                                "i.e., MFSC does not require profiling information as FSC"),
                clEnumVal(PSS, "Probabilistic self-scheduling"), clEnumVal(AUTO, "Automatic partitioning")),
         init(STATIC));
+
     static opt<QueueTypeOption> queueSetupScheme(
         "queue_layout", cat(schedulingOptions), desc("Choose queue setup scheme:"),
         values(clEnumVal(CENTRALIZED, "One queue (default)"), clEnumVal(PERGROUP, "One queue per CPU group"),
                clEnumVal(PERCPU, "One queue per CPU core")),
         init(CENTRALIZED));
+
     static opt<VictimSelectionLogic> victimSelection(
         "victim_selection", cat(schedulingOptions), desc("Choose work stealing victim selection logic:"),
         values(clEnumVal(SEQ, "Steal from next adjacent worker (default)"),

--- a/src/parser/config/ConfigParser.h
+++ b/src/parser/config/ConfigParser.h
@@ -22,19 +22,19 @@
 #include <string>
 
 // must be in the same namespace as the enum SelfSchedulingScheme
-NLOHMANN_JSON_SERIALIZE_ENUM(SelfSchedulingScheme, {{INVALID, nullptr},
-                                                    {STATIC, "STATIC"},
-                                                    {SS, "SS"},
-                                                    {GSS, "GSS"},
-                                                    {TSS, "TSS"},
-                                                    {FAC2, "FAC2"},
-                                                    {TFSS, "TFSS"},
-                                                    {FISS, "FISS"},
-                                                    {VISS, "VISS"},
-                                                    {PLS, "PLS"},
-                                                    {MSTATIC, "MSTATIC"},
-                                                    {MFSC, "MFSC"},
-                                                    {PSS, "PSS"}})
+NLOHMANN_JSON_SERIALIZE_ENUM(SelfSchedulingScheme, {{SelfSchedulingScheme::INVALID, nullptr},
+                                                    {SelfSchedulingScheme::STATIC, "STATIC"},
+                                                    {SelfSchedulingScheme::SS, "SS"},
+                                                    {SelfSchedulingScheme::GSS, "GSS"},
+                                                    {SelfSchedulingScheme::TSS, "TSS"},
+                                                    {SelfSchedulingScheme::FAC2, "FAC2"},
+                                                    {SelfSchedulingScheme::TFSS, "TFSS"},
+                                                    {SelfSchedulingScheme::FISS, "FISS"},
+                                                    {SelfSchedulingScheme::VISS, "VISS"},
+                                                    {SelfSchedulingScheme::PLS, "PLS"},
+                                                    {SelfSchedulingScheme::MSTATIC, "MSTATIC"},
+                                                    {SelfSchedulingScheme::MFSC, "MFSC"},
+                                                    {SelfSchedulingScheme::PSS, "PSS"}})
 
 class ConfigParser {
   public:

--- a/src/runtime/local/vectorized/LoadPartitioningDefs.h
+++ b/src/runtime/local/vectorized/LoadPartitioningDefs.h
@@ -16,23 +16,23 @@
 
 #pragma once
 
-enum QueueTypeOption { CENTRALIZED = 0, PERGROUP, PERCPU };
+enum class QueueTypeOption { CENTRALIZED, PERGROUP, PERCPU };
 
-enum VictimSelectionLogic { SEQ = 0, SEQPRI, RANDOM, RANDOMPRI };
+enum class VictimSelectionLogic { SEQ, SEQPRI, RANDOM, RANDOMPRI };
 
-enum SelfSchedulingScheme {
-    STATIC = 0,
-    SS,
-    GSS,
-    TSS,
-    FAC2,
-    TFSS,
-    FISS,
-    VISS,
-    PLS,
+enum class SelfSchedulingScheme {
+    INVALID = -1,
+    STATIC,
+    SS,   // self-scheduling
+    GSS,  // guided self-scheduling
+    TSS,  // trapezoid self-scheduling
+    FAC2, // factoring
+    TFSS, // trapezoid factoring self-scheduling (TFSS)
+    FISS, // fixed increase self-scheduling
+    VISS, // variable increase self-scheduling
+    PLS,  // performance-based loop self-scheduling
+    PSS,  // probabilistic self-scheduling
     MSTATIC,
-    MFSC,
-    PSS,
+    MFSC, // modifed fixed-size chunk self-scheduling
     AUTO,
-    INVALID = -1 /* only for JSON enum conversion */
 };

--- a/src/runtime/local/vectorized/MTWrapper_dense.cpp
+++ b/src/runtime/local/vectorized/MTWrapper_dense.cpp
@@ -57,14 +57,14 @@ template <typename VT>
     // create tasks and close input
     uint64_t startChunk = 0;
     uint64_t endChunk = 0;
-    int method = ctx->config.taskPartitioningScheme;
+    SelfSchedulingScheme schedulingScheme = ctx->config.taskPartitioningScheme;
     int chunkParam = ctx->config.minimumTaskSize;
     if (chunkParam <= 0)
         chunkParam = 1;
     bool autoChunk = false;
-    if (method == AUTO)
+    if (schedulingScheme == SelfSchedulingScheme::AUTO)
         autoChunk = true;
-    LoadPartitioning lp(method, len, chunkParam, this->_numThreads, autoChunk);
+    LoadPartitioning lp(schedulingScheme, len, chunkParam, this->_numThreads, autoChunk);
     while (lp.hasNextChunk()) {
         endChunk += lp.getNextChunk();
         q->enqueueTask(new CompiledPipelineTask<DenseMatrix<VT>>(
@@ -122,7 +122,7 @@ template <typename VT>
     uint64_t endChunk = 0;
     uint64_t currentItr = 0;
     uint64_t target;
-    int method = ctx->config.taskPartitioningScheme;
+    SelfSchedulingScheme schedulingScheme = ctx->config.taskPartitioningScheme;
     int chunkParam = ctx->config.minimumTaskSize;
     if (chunkParam <= 0)
         chunkParam = 1;
@@ -130,9 +130,9 @@ template <typename VT>
         uint64_t oneChunk = len / this->_numQueues;
         int remainder = len - (oneChunk * this->_numQueues);
         std::vector<LoadPartitioning> lps;
-        lps.emplace_back(method, oneChunk + remainder, chunkParam, this->_numThreads, false);
+        lps.emplace_back(schedulingScheme, oneChunk + remainder, chunkParam, this->_numThreads, false);
         for (int i = 1; i < this->_numQueues; i++) {
-            lps.emplace_back(method, oneChunk, chunkParam, this->_numThreads, false);
+            lps.emplace_back(schedulingScheme, oneChunk, chunkParam, this->_numThreads, false);
         }
         if (ctx->getUserConfig().pinWorkers) {
             for (int i = 0; i < this->_numQueues; i++) {
@@ -163,9 +163,9 @@ template <typename VT>
         }
     } else {
         bool autoChunk = false;
-        if (method == AUTO)
+        if (schedulingScheme == SelfSchedulingScheme::AUTO)
             autoChunk = true;
-        LoadPartitioning lp(method, len, chunkParam, this->_numThreads, autoChunk);
+        LoadPartitioning lp(schedulingScheme, len, chunkParam, this->_numThreads, autoChunk);
         if (ctx->getUserConfig().pinWorkers) {
             while (lp.hasNextChunk()) {
                 endChunk += lp.getNextChunk();
@@ -297,12 +297,12 @@ template <typename VT>
         uint64_t endChunk = device_task_len;
         uint64_t currentItr = 0;
         uint64_t target;
-        int method = ctx->config.taskPartitioningScheme;
+        SelfSchedulingScheme method = ctx->config.taskPartitioningScheme;
         int chunkParam = ctx->config.minimumTaskSize;
         if (chunkParam <= 0)
             chunkParam = 1;
         bool autoChunk = false;
-        if (method == AUTO)
+        if (method == SelfSchedulingScheme::AUTO)
             autoChunk = true;
 
         LoadPartitioning lp(method, cpu_task_len, chunkParam, this->_numCPPThreads, autoChunk);

--- a/src/runtime/local/vectorized/MTWrapper_dense.cpp
+++ b/src/runtime/local/vectorized/MTWrapper_dense.cpp
@@ -37,7 +37,7 @@ template <typename VT>
 
     std::vector<TaskQueue *> tmp_q{q.get()};
     auto batchSize8M = std::max(100ul, static_cast<size_t>(std::ceil(8388608 / row_mem)));
-    this->initCPPWorkers(tmp_q, batchSize8M, verbose, 1, 0, false);
+    this->initCPPWorkers(tmp_q, batchSize8M, verbose, 1, QueueTypeOption::CENTRALIZED, false);
 
 #ifdef USE_CUDA
     if (this->_numCUDAThreads) {

--- a/test/runtime/local/vectorized/MultiThreadedKernelTest.cpp
+++ b/test/runtime/local/vectorized/MultiThreadedKernelTest.cpp
@@ -42,7 +42,7 @@ TEMPLATE_PRODUCT_TEST_CASE("Multi-threaded-scheduling", TAG_VECTORIZED, (DATA_TY
     using DT = TestType;
     using VT = typename DT::VT;
     auto dctx = setupContextAndLogger();
-    dctx->config.taskPartitioningScheme = GSS;
+    dctx->config.taskPartitioningScheme = SelfSchedulingScheme::GSS;
     dctx->config.minimumTaskSize = 50;
 
     DT *m1 = nullptr, *m2 = nullptr;


### PR DESCRIPTION
Refactors the code using the scheduling options in the
vectorized pipeline to the enum class types instead of hard-coded
integers.

With that, usage and readability of the concerning code is considerably improved.
- stronger type safety
- prevents accidental comparisons with integer or other enum types
- no implicit conversion to integers