### PR TITLE
[#892] explicitly use MSTATIC in LoadPartitioning

### DIFF
--- a/src/runtime/local/vectorized/LoadPartitioning.h
+++ b/src/runtime/local/vectorized/LoadPartitioning.h
@@ -145,6 +145,7 @@ class LoadPartitioning {
             chunkSize = mfscChunk;
             break;
         }
+        case SelfSchedulingScheme::MSTATIC:
         default: {
             chunkSize = (uint64_t)ceil(totalTasks / totalWorkers / 4.0);
             break;


### PR DESCRIPTION
This patch adds MSTATIC to the switch case in the LoadPartitioning. Before, this was implicitly handled by the default case.

Closes #892