### PR TITLE
EwBinary codegen broadcasting tests

### DIFF
--- a/test/api/cli/codegen/EwBinaryTest.cpp
+++ b/test/api/cli/codegen/EwBinaryTest.cpp
@@ -49,11 +49,17 @@ void test_binary_lowering(const std::string op, const std::string kernel_call, c
     CHECK(out.str() == result);
 }
 
-TEST_CASE("ewBinaryAddScalar", TAG_CODEGEN) {
+TEST_CASE("ewBinaryAdd", TAG_CODEGEN) {
     // clang-format off
     std::string result = "DenseMatrix(2x3, double)\n"
                             "2 4 6\n"
                             "8 10 12\n"
+                        "DenseMatrix(2x3, double)\n"
+                            "6 6 6\n"
+                            "9 9 9\n"
+                        "DenseMatrix(2x3, double)\n"
+                            "5 6 7\n"
+                            "7 8 9\n"
                         "DenseMatrix(2x3, double)\n"
                             "3 4 5\n"
                             "6 7 8\n"
@@ -62,6 +68,12 @@ TEST_CASE("ewBinaryAddScalar", TAG_CODEGEN) {
                             "2 4 6\n"
                             "8 10 12\n"
                         "DenseMatrix(2x3, int64_t)\n"
+                            "6 6 6\n"
+                            "9 9 9\n"
+                        "DenseMatrix(2x3, int64_t)\n"
+                            "5 6 7\n"
+                            "7 8 9\n"
+                        "DenseMatrix(2x3, int64_t)\n"
                             "3 4 5\n"
                             "6 7 8\n"
                         "6\n";
@@ -69,11 +81,17 @@ TEST_CASE("ewBinaryAddScalar", TAG_CODEGEN) {
     test_binary_lowering("add", "llvm.call @_ewAdd__", "llvm.add", result);
 }
 
-TEST_CASE("ewBinarySubScalar", TAG_CODEGEN) {
+TEST_CASE("ewBinarySub", TAG_CODEGEN) {
     // clang-format off
     std::string result = "DenseMatrix(2x3, double)\n"
                             "-5 -3 -1\n"
                             "1 3 5\n"
+                        "DenseMatrix(2x3, double)\n"
+                            "-4 -2 0\n"
+                            "-1 1 3\n"
+                        "DenseMatrix(2x3, double)\n"
+                            "-3 -2 -1\n"
+                            "1 2 3\n"
                         "DenseMatrix(2x3, double)\n"
                             "-1 0 1\n"
                             "2 3 4\n"
@@ -82,6 +100,12 @@ TEST_CASE("ewBinarySubScalar", TAG_CODEGEN) {
                             "-5 -3 -1\n"
                             "1 3 5\n"
                         "DenseMatrix(2x3, int64_t)\n"
+                            "-4 -2 0\n"
+                            "-1 1 3\n"
+                        "DenseMatrix(2x3, int64_t)\n"
+                            "-3 -2 -1\n"
+                            "1 2 3\n"
+                        "DenseMatrix(2x3, int64_t)\n"
                             "-1 0 1\n"
                             "2 3 4\n"
                         "-2\n";
@@ -89,11 +113,17 @@ TEST_CASE("ewBinarySubScalar", TAG_CODEGEN) {
     test_binary_lowering("sub", "llvm.call @_ewSub__", "llvm.sub", result);
 }
 
-TEST_CASE("ewBinaryMulScalar", TAG_CODEGEN) {
+TEST_CASE("ewBinaryMul", TAG_CODEGEN) {
     // clang-format off
     std::string result = "DenseMatrix(2x3, double)\n"
                             "1 4 9\n"
                             "16 25 36\n"
+                        "DenseMatrix(2x3, double)\n"
+                            "5 8 9\n"
+                            "20 20 18\n"
+                        "DenseMatrix(2x3, double)\n"
+                            "4 8 12\n"
+                            "12 15 18\n"
                         "DenseMatrix(2x3, double)\n"
                             "2 4 6\n"
                             "8 10 12\n"
@@ -102,6 +132,12 @@ TEST_CASE("ewBinaryMulScalar", TAG_CODEGEN) {
                             "1 4 9\n"
                             "16 25 36\n"
                         "DenseMatrix(2x3, int64_t)\n"
+                            "5 8 9\n"
+                            "20 20 18\n"
+                        "DenseMatrix(2x3, int64_t)\n"
+                            "4 8 12\n"
+                            "12 15 18\n"
+                        "DenseMatrix(2x3, int64_t)\n"
                             "2 4 6\n"
                             "8 10 12\n"
                         "8\n";
@@ -109,11 +145,17 @@ TEST_CASE("ewBinaryMulScalar", TAG_CODEGEN) {
     test_binary_lowering("mul", "llvm.call @_ewMul__", "llvm.mul", result);
 }
 
-TEST_CASE("ewBinaryDivScalar", TAG_CODEGEN) {
+TEST_CASE("ewBinaryDiv", TAG_CODEGEN) {
     // clang-format off
     std::string result = "DenseMatrix(2x3, double)\n"
                             "1 1 1\n"
                             "1 1 1\n"
+                        "DenseMatrix(2x3, double)\n"
+                            "0.2 0.5 1\n"
+                            "0.8 1.25 2\n"
+                        "DenseMatrix(2x3, double)\n"
+                            "0.25 0.5 0.75\n"
+                            "1.33333 1.66667 2\n"
                         "DenseMatrix(2x3, double)\n"
                             "0.5 1 1.5\n"
                             "2 2.5 3\n"
@@ -122,12 +164,24 @@ TEST_CASE("ewBinaryDivScalar", TAG_CODEGEN) {
                             "1 1 1\n"
                             "1 1 1\n"
                         "DenseMatrix(2x3, int64_t)\n"
+                            "0 0 1\n"
+                            "0 1 2\n"
+                        "DenseMatrix(2x3, int64_t)\n"
+                            "0 0 0\n"
+                            "1 1 2\n"
+                        "DenseMatrix(2x3, int64_t)\n"
                             "0 0 0\n"
                             "1 1 1\n"
                         "2\n"
                         "DenseMatrix(2x3, uint64_t)\n"
                             "1 1 1\n"
                             "1 1 1\n"
+                        "DenseMatrix(2x3, uint64_t)\n"
+                            "0 0 1\n"
+                            "0 1 2\n"
+                        "DenseMatrix(2x3, uint64_t)\n"
+                            "0 0 0\n"
+                            "1 1 2\n"
                         "DenseMatrix(2x3, uint64_t)\n"
                             "0 0 0\n"
                             "1 1 1\n"
@@ -136,7 +190,7 @@ TEST_CASE("ewBinaryDivScalar", TAG_CODEGEN) {
     test_binary_lowering("div", "llvm.call @_ewDiv__", "llvm.fdiv", result);
 }
 
-// TEST_CASE("ewBinaryPowScalar", TAG_CODEGEN) {
+// TEST_CASE("ewBinaryPow", TAG_CODEGEN) {
 //     // clang-format off
 //     std::string result = "DenseMatrix(2x3, double)\n"
 //                             "1 4 27\n"
@@ -156,11 +210,17 @@ TEST_CASE("ewBinaryDivScalar", TAG_CODEGEN) {
 //     test_binary_lowering("pow", "llvm.call @_ewPow__", "llvm.intr.pow", result);
 // }
 
-TEST_CASE("ewBinaryMinScalar", TAG_CODEGEN) {
+TEST_CASE("ewBinaryMin", TAG_CODEGEN) {
     // clang-format off
     std::string result = "DenseMatrix(2x3, double)\n"
                             "0 1 3\n"
                             "4 3 2\n"
+                        "DenseMatrix(2x3, double)\n"
+                            "1 2 1\n"
+                            "2 4 1\n"
+                        "DenseMatrix(2x3, double)\n"
+                            "1 2 3\n"
+                            "3 3 3\n"
                         "DenseMatrix(2x3, double)\n"
                             "1 2 3\n"
                             "4 4 4\n"
@@ -169,12 +229,24 @@ TEST_CASE("ewBinaryMinScalar", TAG_CODEGEN) {
                             "0 1 3\n"
                             "4 3 2\n"
                         "DenseMatrix(2x3, int64_t)\n"
+                            "1 2 1\n"
+                            "2 4 1\n"
+                        "DenseMatrix(2x3, int64_t)\n"
+                            "1 2 3\n"
+                            "3 3 3\n"
+                        "DenseMatrix(2x3, int64_t)\n"
                             "1 2 3\n"
                             "4 4 4\n"
                         "2\n"
                         "DenseMatrix(2x3, uint64_t)\n"
                             "0 1 3\n"
                             "4 3 2\n"
+                        "DenseMatrix(2x3, uint64_t)\n"
+                            "1 2 1\n"
+                            "2 4 1\n"
+                        "DenseMatrix(2x3, uint64_t)\n"
+                            "1 2 3\n"
+                            "3 3 3\n"
                         "DenseMatrix(2x3, uint64_t)\n"
                             "1 2 3\n"
                             "4 4 4\n"
@@ -183,11 +255,17 @@ TEST_CASE("ewBinaryMinScalar", TAG_CODEGEN) {
     test_binary_lowering("min", "llvm.call @_ewMin__", "llvm.intr.minnum", result);
 }
 
-TEST_CASE("ewBinaryMaxScalar", TAG_CODEGEN) {
+TEST_CASE("ewBinaryMax", TAG_CODEGEN) {
     // clang-format off
     std::string result = "DenseMatrix(2x3, double)\n"
                             "1 2 4\n"
                             "11 5 6\n"
+                        "DenseMatrix(2x3, double)\n"
+                            "5 2 3\n"
+                            "5 5 6\n"
+                        "DenseMatrix(2x3, double)\n"
+                            "3 3 3\n"
+                            "4 5 6\n"
                         "DenseMatrix(2x3, double)\n"
                             "4 4 4\n"
                             "4 5 6\n"
@@ -196,12 +274,24 @@ TEST_CASE("ewBinaryMaxScalar", TAG_CODEGEN) {
                             "1 2 4\n"
                             "11 5 6\n"
                         "DenseMatrix(2x3, int64_t)\n"
+                            "5 2 3\n"
+                            "5 5 6\n"
+                        "DenseMatrix(2x3, int64_t)\n"
+                            "3 3 3\n"
+                            "4 5 6\n"
+                        "DenseMatrix(2x3, int64_t)\n"
                             "4 4 4\n"
                             "4 5 6\n"
                         "4\n"
                         "DenseMatrix(2x3, uint64_t)\n"
                             "1 2 4\n"
                             "11 5 6\n"
+                        "DenseMatrix(2x3, uint64_t)\n"
+                            "5 2 3\n"
+                            "5 5 6\n"
+                        "DenseMatrix(2x3, uint64_t)\n"
+                            "3 3 3\n"
+                            "4 5 6\n"
                         "DenseMatrix(2x3, uint64_t)\n"
                             "4 4 4\n"
                             "4 5 6\n"

--- a/test/api/cli/codegen/ewbinary_add.daphne
+++ b/test/api/cli/codegen/ewbinary_add.daphne
@@ -4,18 +4,26 @@
 
 // f64
 X = [1.0, 2, 3, 4, 5, 6](2, 3);
+rowVec = [5.0, 4, 3](1,);
+colVec = [4.0, 3](,1);
 a = as.scalar(X[0:1, 1:2]); // 2
 b = as.scalar(X[1:2, 0:1]); // 4
 
-print(X + X); // mat + mat
-print(X + a); // mat + scalar (broadcasting)
-print(a + b); // scalar + scalar
+print(X + X);       // mat + mat
+print(X + rowVec);  // mat + mat (broadcasting along columns)
+print(X + colVec);  // mat + mat (broadcasting along rows)
+print(X + a);       // mat + scalar (broadcasting)
+print(a + b);       // scalar + scalar
 
 // si64
 X = [1, 2, 3, 4, 5, 6](2, 3);
+rowVec = [5, 4, 3](1,);
+colVec = [4, 3](,1);
 a = as.scalar(X[0:1, 1:2]); // 2
 b = as.scalar(X[1:2, 0:1]); // 4
 
-print(X + X); // mat + mat
-print(X + a); // mat + scalar (broadcasting)
-print(a + b); // scalar + scalar
+print(X + X);       // mat + mat
+print(X + rowVec);  // mat + mat (broadcasting along columns)
+print(X + colVec);  // mat + mat (broadcasting along rows)
+print(X + a);       // mat + scalar (broadcasting)
+print(a + b);       // scalar + scalar

--- a/test/api/cli/codegen/ewbinary_div.daphne
+++ b/test/api/cli/codegen/ewbinary_div.daphne
@@ -4,27 +4,39 @@
 
 // f64
 X = [1.0, 2, 3, 4, 5, 6](2, 3);
+rowVec = [5.0, 4, 3](1,);
+colVec = [4.0, 3](,1);
 a = as.scalar(X[0:1, 1:2]); // 2
 b = as.scalar(X[1:2, 0:1]); // 4
 
-print(X / X); // mat / mat
-print(X / a); // mat / scalar (broadcasting)
-print(a / b); // scalar / scalar
+print(X / X);       // mat / mat
+print(X / rowVec);  // mat / mat (broadcasting along columns)
+print(X / colVec);  // mat / mat (broadcasting along rows)
+print(X / a);       // mat / scalar (broadcasting)
+print(a / b);       // scalar / scalar
 
 // si64
 X = [1, 2, 3, 4, 5, 6](2, 3);
+rowVec = [5, 4, 3](1,);
+colVec = [4, 3](,1);
 a = as.scalar(X[1:2, 0:1]); // 4
 b = as.scalar(X[0:1, 1:2]); // 2
 
-print(X / X); // mat / mat
-print(X / a); // mat / scalar (broadcasting)
-print(a / b); // scalar / scalar
+print(X / X);       // mat / mat
+print(X / rowVec);  // mat / mat (broadcasting along columns)
+print(X / colVec);  // mat / mat (broadcasting along rows)
+print(X / a);       // mat / scalar (broadcasting)
+print(a / b);       // scalar / scalar
 
 // ui64
 X = [1u, 2u, 3u, 4u, 5u, 6u](2, 3);
+rowVec = [5u, 4u, 3u](1,);
+colVec = [4u, 3u](,1);
 a = as.scalar(X[1:2, 0:1]); // 4
 b = as.scalar(X[0:1, 1:2]); // 2
 
-print(X / X); // mat / mat
-print(X / a); // mat / scalar (broadcasting)
-print(a / b); // scalar / scalar
+print(X / X);       // mat / mat
+print(X / rowVec);  // mat / mat (broadcasting along columns)
+print(X / colVec);  // mat / mat (broadcasting along rows)
+print(X / a);       // mat / scalar (broadcasting)
+print(a / b);       // scalar / scalar

--- a/test/api/cli/codegen/ewbinary_max.daphne
+++ b/test/api/cli/codegen/ewbinary_max.daphne
@@ -5,29 +5,41 @@
 // f64
 X = [1.0, 2, 3, 4, 5, 6](2, 3);
 Y = [0.0, 1, 4, 11, 5, 0](2, 3);
+rowVec = [5.0, 1, 3](1,);
+colVec = [3.0, 3](,1);
 a = as.scalar(X[1:2, 0:1]); // 4
 b = as.scalar(X[0:1, 1:2]); // 2
 
-print(max(X, Y)); // mat, mat
-print(max(X, a)); // mat, scalar (broadcasting)
-print(max(a, b)); // scalar, scalar
+print(max(X, Y));       // mat, mat
+print(max(X, rowVec));  // mat, mat (broadcasting along columns)
+print(max(X, colVec));  // mat, mat (broadcasting along rows)
+print(max(X, a));       // mat, scalar (broadcasting)
+print(max(a, b));       // scalar, scalar
 
 // si64
 X = [1, 2, 3, 4, 5, 6](2, 3);
 Y = [0, 1, 4, 11, 5, 0](2, 3);
+rowVec = [5, 1, 3](1,);
+colVec = [3, 3](,1);
 a = as.scalar(X[1:2, 0:1]); // 4
 b = as.scalar(X[0:1, 1:2]); // 2
 
-print(max(X, Y)); // mat, mat
-print(max(X, a)); // mat, scalar (broadcasting)
-print(max(a, b)); // scalar, scalar
+print(max(X, Y));       // mat, mat
+print(max(X, rowVec));  // mat, mat (broadcasting along columns)
+print(max(X, colVec));  // mat, mat (broadcasting along rows)
+print(max(X, a));       // mat, scalar (broadcasting)
+print(max(a, b));       // scalar, scalar
 
 // ui64
 X = [1u, 2u, 3u, 4u, 5u, 6u](2, 3);
 Y = [0u, 1u, 4u, 11u, 5u, 0u](2, 3);
+rowVec = [5u, 1u, 3u](1,);
+colVec = [3u, 3u](,1);
 a = as.scalar(X[1:2, 0:1]); // 4
 b = as.scalar(X[0:1, 1:2]); // 2
 
-print(max(X, Y)); // mat, mat
-print(max(X, a)); // mat, scalar (broadcasting)
-print(max(a, b)); // scalar, scalar
+print(max(X, Y));       // mat, mat
+print(max(X, rowVec));  // mat, mat (broadcasting along columns)
+print(max(X, colVec));  // mat, mat (broadcasting along rows)
+print(max(X, a));       // mat, scalar (broadcasting)
+print(max(a, b));       // scalar, scalar

--- a/test/api/cli/codegen/ewbinary_min.daphne
+++ b/test/api/cli/codegen/ewbinary_min.daphne
@@ -5,29 +5,41 @@
 // f64
 X = [1.0, 2, 3, 4, 5, 6](2, 3);
 Y = [0.0, 1, 5, 11, 3, 2](2, 3);
+rowVec = [2.0, 4, 1](1,);
+colVec = [3.0, 3](,1);
 a = as.scalar(X[1:2, 0:1]); // 4
 b = as.scalar(X[0:1, 1:2]); // 2
 
-print(min(X, Y)); // mat, mat
-print(min(X, a)); // mat, scalar (broadcasting)
-print(min(a, b)); // scalar, scalar
+print(min(X, Y));       // mat, mat
+print(min(X, rowVec));  // mat, mat (broadcasting along columns)
+print(min(X, colVec));  // mat, mat (broadcasting along rows)
+print(min(X, a));       // mat, scalar (broadcasting)
+print(min(a, b));       // scalar, scalar
 
 // si64
 X = [1, 2, 3, 4, 5, 6](2, 3);
 Y = [0, 1, 5, 11, 3, 2](2, 3);
+rowVec = [2, 4, 1](1,);
+colVec = [3, 3](,1);
 a = as.scalar(X[1:2, 0:1]); // 4
 b = as.scalar(X[0:1, 1:2]); // 2
 
-print(min(X, Y)); // mat, mat
-print(min(X, a)); // mat, scalar (broadcasting)
-print(min(a, b)); // scalar, scalar
+print(min(X, Y));       // mat, mat
+print(min(X, rowVec));  // mat, mat (broadcasting along columns)
+print(min(X, colVec));  // mat, mat (broadcasting along rows)
+print(min(X, a));       // mat, scalar (broadcasting)
+print(min(a, b));       // scalar, scalar
 
 // ui64
 X = [1u, 2u, 3u, 4u, 5u, 6u](2, 3);
 Y = [0u, 1u, 5u, 11u, 3u, 2u](2, 3);
+rowVec = [2u, 4u, 1u](1,);
+colVec = [3u, 3u](,1);
 a = as.scalar(X[1:2, 0:1]); // 4
 b = as.scalar(X[0:1, 1:2]); // 2
 
-print(min(X, Y)); // mat, mat
-print(min(X, a)); // mat, scalar (broadcasting)
-print(min(a, b)); // scalar, scalar
+print(min(X, Y));       // mat, mat
+print(min(X, rowVec));  // mat, mat (broadcasting along columns)
+print(min(X, colVec));  // mat, mat (broadcasting along rows)
+print(min(X, a));       // mat, scalar (broadcasting)
+print(min(a, b));       // scalar, scalar

--- a/test/api/cli/codegen/ewbinary_mul.daphne
+++ b/test/api/cli/codegen/ewbinary_mul.daphne
@@ -4,18 +4,26 @@
 
 // f64
 X = [1.0, 2, 3, 4, 5, 6](2, 3);
+rowVec = [5.0, 4, 3](1,);
+colVec = [4.0, 3](,1);
 a = as.scalar(X[0:1, 1:2]); // 2
 b = as.scalar(X[1:2, 0:1]); // 4
 
-print(X * X); // mat * mat
-print(X * a); // mat * scalar (broadcasting)
-print(a * b); // scalar * scalar
+print(X * X);       // mat * mat
+print(X * rowVec);  // mat * mat (broadcasting along columns)
+print(X * colVec);  // mat * mat (broadcasting along rows)
+print(X * a);       // mat * scalar (broadcasting)
+print(a * b);       // scalar * scalar
 
 // si64
 X = [1, 2, 3, 4, 5, 6](2, 3);
+rowVec = [5, 4, 3](1,);
+colVec = [4, 3](,1);
 a = as.scalar(X[0:1, 1:2]); // 2
 b = as.scalar(X[1:2, 0:1]); // 4
 
-print(X * X); // mat * mat
-print(X * a); // mat * scalar (broadcasting)
-print(a * b); // scalar * scalar
+print(X * X);       // mat * mat
+print(X * rowVec);  // mat * mat (broadcasting along columns)
+print(X * colVec);  // mat * mat (broadcasting along rows)
+print(X * a);       // mat * scalar (broadcasting)
+print(a * b);       // scalar * scalar

--- a/test/api/cli/codegen/ewbinary_sub.daphne
+++ b/test/api/cli/codegen/ewbinary_sub.daphne
@@ -5,19 +5,27 @@
 // f64
 X = [1.0, 2, 3, 4, 5, 6](2, 3);
 Y = [6.0, 5, 4, 3, 2, 1](2, 3);
+rowVec = [5.0, 4, 3](1,);
+colVec = [4.0, 3](,1);
 a = as.scalar(X[0:1, 1:2]); // 2
 b = as.scalar(X[1:2, 0:1]); // 4
 
-print(X - Y); // mat - mat
-print(X - a); // mat - scalar (broadcasting)
-print(a - b); // scalar - scalar
+print(X - Y);       // mat - mat
+print(X - rowVec);  // mat - mat (broadcasting along columns)
+print(X - colVec);  // mat - mat (broadcasting along rows)
+print(X - a);       // mat - scalar (broadcasting)
+print(a - b);       // scalar - scalar
 
 // si64
 X = [1, 2, 3, 4, 5, 6](2, 3);
 Y = [6, 5, 4, 3, 2, 1](2, 3);
+rowVec = [5, 4, 3](1,);
+colVec = [4, 3](,1);
 a = as.scalar(X[0:1, 1:2]); // 2
 b = as.scalar(X[1:2, 0:1]); // 4
 
-print(X - Y); // mat - mat
-print(X - a); // mat - scalar (broadcasting)
-print(a - b); // scalar - scalar
+print(X - Y);       // mat - mat
+print(X - rowVec);  // mat - mat (broadcasting along columns)
+print(X - colVec);  // mat - mat (broadcasting along rows)
+print(X - a);       // mat - scalar (broadcasting)
+print(a - b);       // scalar - scalar


### PR DESCRIPTION
This PR adds some test cases for #920.
The existing tests have been renamed and a new test for row and column broadcasting has been added.

EwBinary codegen supports broadcasting for all functions that use the `BinaryOpLowering` template (at the point of writing this includes `EwAdd`, `EwSub`, `EwMul`, `EwDiv`, `EwMin`, `EwMax`). The operand that is broadcast is assumed to be rhs.

Singletons (1x1 dense matrices) are broadcast to the entire rhs matrix, whereas row/column vectors must have size 1 in the dimension that is broadcast and match `lhs` in the other dimension. Thus, `2x3` + `2x1` would be valid dimensions where the rows of `rhs` are broadcast along the columns of `lhs`, i.e. all values in the first row of `lhs` are respectively combined with the value in the first row of `rhs`.

```
lhsMat = [1, 2, 3, 4, 5, 6](2,);
rhsRowMat = [10, 20, 30](1,);
rhsColMat = [10, 20](,1);

print(lhsMat + rhsRowMat);    // -> [11, 22, 33, 14, 25, 36](2,3)
print(lhsMat + rhsColMat);    // -> [11, 12, 13, 24, 25, 26](2,3)
```

If dimensions do not match, a compiler error is thrown:
```
lhsMat = [1, 2, 3, 4, 5, 6](2,);
rhsRowMat = [10, 20, 30](1,);
rhsColMat = [10, 20, 30](,1);

print(rhsRowMat + lhsMat);    // -> ... lhs and rhs must have equal dimensions or allow for broadcasting but operands have dimensions (1,3) and (2,3)
print(lhsMat + rhsColMat);    // -> ... could not broadcast rhs along rows. Rhs must be a scalar value, singleton matrix or have an equal amount of rows to be broadcast but operands have dimensions (2,3) and (3,1)
```

---

Currently, the changes trigger some issue with `runDaphne` within `EwBinaryTest`. The issue seems to be unrelated to the new tests and causes the tests to run indefinitely (running `./test.sh [codegen]`). From what I can tell, execution within `test/api/cli/Utils.h` in `runProgram` gets blocked at the first `dup2` call at l.117. This might be similar to the issue described in #675 which were first fixed with https://github.com/daphne-eu/daphne/commit/c2900a39189a8e7e407082278a33f6ef3981ff76 .