### PR TITLE
Unified upper and lower part of address argument in `ReceiveFromNumpyOp`

### DIFF
--- a/src/api/python/daphne/context/daphne_context.py
+++ b/src/api/python/daphne/context/daphne_context.py
@@ -96,8 +96,6 @@ class DaphneContext(object):
         if shared_memory:
             # Data transfer via shared memory.
             address = mat.ctypes.data_as(np.ctypeslib.ndpointer(dtype=mat.dtype, ndim=1, flags='C_CONTIGUOUS')).value
-            upper = (address & 0xFFFFFFFF00000000) >> 32
-            lower = (address & 0xFFFFFFFF)
 
             # Change the data type, if int16 or uint16 is handed over.
             # TODO This could change the input DataFrame.
@@ -127,7 +125,7 @@ class DaphneContext(object):
                 # TODO Raise an error here?
                 print("unsupported numpy dtype")
 
-            res = Matrix(self, 'receiveFromNumpy', [upper, lower, rows, cols, vtc], local_data=mat)
+            res = Matrix(self, 'receiveFromNumpy', [address, rows, cols, vtc], local_data=mat)
         else:
             # Data transfer via a file.
             data_path_param = "\"" + TMP_PATH + "/{file_name}.csv\""
@@ -201,8 +199,6 @@ class DaphneContext(object):
                     print(f"from_pandas(): original DataFrame column `{column}` (#{idx}) shares memory with new numpy array: {np.shares_memory(mat, df[column].values)}")
 
                 address = mat.ctypes.data_as(np.ctypeslib.ndpointer(dtype=mat.dtype, ndim=1, flags='C_CONTIGUOUS')).value
-                upper = (address & 0xFFFFFFFF00000000) >> 32
-                lower = (address & 0xFFFFFFFF)
                 d_type = mat.dtype
                 if d_type == np.double or d_type == np.float64:
                     vtc = F64
@@ -223,7 +219,7 @@ class DaphneContext(object):
                 else:
                     raise TypeError(f'Unsupported numpy dtype in column "{column}" ({idx})')
                 
-                args.append(Matrix(self, 'receiveFromNumpy', [upper, lower, len(mat), 1 , vtc], local_data=mat))
+                args.append(Matrix(self, 'receiveFromNumpy', [address, len(mat), 1 , vtc], local_data=mat))
 
                 if verbose:
                     print(f"from_pandas(): Python-side execution time for column `{column}` (#{idx}): {(time.time() - col_start_time):.10f} seconds")

--- a/src/ir/daphneir/DaphneOps.td
+++ b/src/ir/daphneir/DaphneOps.td
@@ -1436,7 +1436,7 @@ def Daphne_WriteOp : Daphne_Op<"write"> {
 }
 
 def Daphne_ReceiveFromNumpyOp: Daphne_Op<"receiveFromNumpy">{
-    let arguments = (ins UI32:$upper, UI32:$lower, SI64:$rows, SI64:$cols);
+    let arguments = (ins UI64: $address, SI64:$rows, SI64:$cols);
     let results = (outs MatrixOrU:$res);
 }
 

--- a/src/parser/daphnedsl/DaphneDSLBuiltins.cpp
+++ b/src/parser/daphnedsl/DaphneDSLBuiltins.cpp
@@ -1102,13 +1102,12 @@ antlrcpp::Any DaphneDSLBuiltins::build(mlir::Location loc, const std::string &fu
         return builder.create<WriteOp>(loc, arg, filename).getOperation();
     }
     if (func == "receiveFromNumpy") {
-        checkNumArgsExact(loc, func, numArgs, 5);
+        checkNumArgsExact(loc, func, numArgs, 4);
 
-        mlir::Value upper = utils.castUI32If(args[0]);
-        mlir::Value lower = utils.castUI32If(args[1]);
-        mlir::Value rows = args[2];
-        mlir::Value cols = args[3];
-        mlir::Value valueType = args[4];
+        mlir::Value address = utils.castUI64If(args[0]);
+        mlir::Value rows = args[1];
+        mlir::Value cols = args[2];
+        mlir::Value valueType = args[3];
 
         int64_t valueTypeCode = CompilerUtils::constantOrThrow<int64_t>(
             valueType, "the value type code in ReceiveFromNumpyOp must be a constant");
@@ -1136,7 +1135,7 @@ antlrcpp::Any DaphneDSLBuiltins::build(mlir::Location loc, const std::string &fu
             throw ErrorHandler::compilerError(loc, "DSLBuiltins", "invalid value type code");
 
         return static_cast<mlir::Value>(
-            builder.create<ReceiveFromNumpyOp>(loc, utils.matrixOf(vt), upper, lower, rows, cols));
+            builder.create<ReceiveFromNumpyOp>(loc, utils.matrixOf(vt), address, rows, cols));
     }
     if (func == "saveDaphneLibResult") {
         checkNumArgsExact(loc, func, numArgs, 1);

--- a/src/runtime/local/kernels/ReceiveFromNumpy.h
+++ b/src/runtime/local/kernels/ReceiveFromNumpy.h
@@ -28,7 +28,7 @@
 // ****************************************************************************
 
 template <class DTRes> struct ReceiveFromNumpy {
-    static void apply(DTRes *&res, uint32_t upper, uint32_t lower, int64_t rows, int64_t cols, DCTX(ctx)) = delete;
+    static void apply(DTRes *&res, uint64_t address, int64_t rows, int64_t cols, DCTX(ctx)) = delete;
 };
 
 // ****************************************************************************
@@ -36,8 +36,8 @@ template <class DTRes> struct ReceiveFromNumpy {
 // ****************************************************************************
 
 template <class DTRes>
-void receiveFromNumpy(DTRes *&res, uint32_t upper, int32_t lower, int64_t rows, int64_t cols, DCTX(ctx)) {
-    ReceiveFromNumpy<DTRes>::apply(res, upper, lower, rows, cols, ctx);
+void receiveFromNumpy(DTRes *&res, uint64_t address, int64_t rows, int64_t cols, DCTX(ctx)) {
+    ReceiveFromNumpy<DTRes>::apply(res, address, rows, cols, ctx);
 }
 
 // ****************************************************************************
@@ -56,9 +56,9 @@ template <typename VT> struct NoOpDeleter {
 };
 
 template <typename VT> struct ReceiveFromNumpy<DenseMatrix<VT>> {
-    static void apply(DenseMatrix<VT> *&res, uint32_t upper, uint32_t lower, int64_t rows, int64_t cols, DCTX(ctx)) {
+    static void apply(DenseMatrix<VT> *&res, uint64_t address, int64_t rows, int64_t cols, DCTX(ctx)) {
         res = DataObjectFactory::create<DenseMatrix<VT>>(
-            rows, cols, std::shared_ptr<VT[]>((VT *)(((uint64_t)upper << 32) | lower), NoOpDeleter<VT>()));
+            rows, cols, std::shared_ptr<VT[]>((VT *)(address), NoOpDeleter<VT>()));
     }
 };
 

--- a/src/runtime/local/kernels/kernels.json
+++ b/src/runtime/local/kernels/kernels.json
@@ -4171,12 +4171,8 @@
                     "name": "res"
                 },
                 {
-                    "type": "uint32_t",
-                    "name": "upper"
-                },
-                {
-                    "type": "uint32_t",
-                    "name": "lower"
+                    "type": "uint64_t",
+                    "name": "address"
                 },
                 {
                     "type": "int64_t",


### PR DESCRIPTION
This pull request fuses the unsigned 32-bit integers `upper` and `lower` arguments in the `ReceiveFromNumpy` operation into one unsigned 64-bit integer called `address`. The issue linked to this pull request is: https://github.com/daphne-eu/daphne/issues/710 