### PR TITLE
feat: track `_vectN` functions in `--statistics`

### DIFF
--- a/src/api/cli/DaphneUserConfig.h
+++ b/src/api/cli/DaphneUserConfig.h
@@ -77,7 +77,7 @@ struct DaphneUserConfig {
     bool explain_mlir_codegen_sparsity_exploiting_op_fusion = false;
     bool explain_mlir_codegen_daphneir_to_mlir = false;
     bool explain_mlir_codegen_mlir_specific = false;
-    bool statistics = false;
+    bool enable_statistics = false;
 
     bool force_cuda = false;
 

--- a/src/api/internal/daphne_internal.cpp
+++ b/src/api/internal/daphne_internal.cpp
@@ -499,7 +499,7 @@ int startDAPHNE(int argc, const char **argv, DaphneLibResult *daphneLibRes, int 
         }
     }
 
-    user_config.statistics = enableStatistics;
+    user_config.enable_statistics = enableStatistics;
 
     if (user_config.use_distributed && distributedBackEndSetup == ALLOCATION_TYPE::DIST_MPI) {
 #ifndef USE_MPI
@@ -671,7 +671,7 @@ int startDAPHNE(int argc, const char **argv, DaphneLibResult *daphneLibRes, int 
         std::cerr << "}" << std::endl;
     }
 
-    if (user_config.statistics)
+    if (user_config.enable_statistics)
         Statistics::instance().dumpStatistics(KernelDispatchMapping::instance());
 
     // explicitly destroying the moduleOp here due to valgrind complaining about

--- a/src/compiler/lowering/LowerToLLVMPass.cpp
+++ b/src/compiler/lowering/LowerToLLVMPass.cpp
@@ -570,8 +570,7 @@ class VectorizedPipelineOpLowering : public OpConversionPattern<daphne::Vectoriz
             auto returnRef = funcBlock.addArgument(pppI1Ty, rewriter.getUnknownLoc());
             auto inputsArg = funcBlock.addArgument(ptrPtrI1Ty, rewriter.getUnknownLoc());
             auto daphneContext = funcBlock.addArgument(ptrI1Ty, rewriter.getUnknownLoc());
-            // TODO: we should not create a new daphneContext, instead pass the
-            // one created in the main function
+
             for (auto callKernelOp : funcBlock.getOps<daphne::CallKernelOp>()) {
                 callKernelOp.setOperand(callKernelOp.getNumOperands() - 1, daphneContext);
             }
@@ -603,7 +602,7 @@ class VectorizedPipelineOpLowering : public OpConversionPattern<daphne::Vectoriz
             }
 
             // Update function block to write return value by reference instead
-            auto oldReturn = funcBlock.getTerminator();
+            auto *oldReturn = funcBlock.getTerminator();
             rewriter.setInsertionPoint(oldReturn);
             for (auto i = 0u; i < oldReturn->getNumOperands(); ++i) {
                 auto retVal = oldReturn->getOperand(i);
@@ -677,7 +676,7 @@ class VectorizedPipelineOpLowering : public OpConversionPattern<daphne::Vectoriz
 
                 // Update function block to write return value by reference
                 // instead
-                auto oldReturn = funcBlock.getTerminator();
+                auto *oldReturn = funcBlock.getTerminator();
                 rewriter.setInsertionPoint(oldReturn);
                 for (auto i = 0u; i < oldReturn->getNumOperands(); ++i) {
                     auto retVal = oldReturn->getOperand(i);

--- a/src/compiler/lowering/RewriteToCallKernelOpPass.cpp
+++ b/src/compiler/lowering/RewriteToCallKernelOpPass.cpp
@@ -476,20 +476,19 @@ class KernelReplacement : public RewritePattern {
         // *****************************************************************************
         // Add kernel id and DAPHNE context as arguments
         // *****************************************************************************
-
         auto kId = rewriter.create<mlir::arith::ConstantOp>(
             loc, rewriter.getI32IntegerAttr(KernelDispatchMapping::instance().registerKernel(kernelFuncName, op)));
 
-        // NOTE: kId has to be added before CreateDaphneContextOp because
-        // there is an assumption that the CTX is the last argument
-        // (LowerToLLVMPass.cpp::623,702). This means the kId is expected to
-        // be the second to last argument.
-        kernelArgs.push_back(kId);
-
         // Inject the current DaphneContext as the last input parameter to
         // all kernel calls, unless it's a CreateDaphneContextOp.
-        if (!llvm::isa<daphne::CreateDaphneContextOp>(op))
+        if (!llvm::isa<daphne::CreateDaphneContextOp>(op)) {
+            // NOTE: kId has to be added before CreateDaphneContextOp because
+            // there is an assumption that the CTX is the last argument
+            // (LowerToLLVMPass.cpp::623,702). This means the kId is expected to
+            // be the second to last argument.
+            kernelArgs.push_back(kId);
             kernelArgs.push_back(dctx);
+        }
 
         // *****************************************************************************
         // Create the CallKernelOp

--- a/src/runtime/local/instrumentation/KernelInstrumentation.cpp
+++ b/src/runtime/local/instrumentation/KernelInstrumentation.cpp
@@ -1,11 +1,11 @@
 #include <runtime/local/instrumentation/KernelInstrumentation.h>
 
 void preKernelInstrumentation(int kId, DaphneContext *ctx) {
-    if (ctx->getUserConfig().statistics)
+    if (ctx->getUserConfig().enable_statistics)
         ctx->startKernelTimer(kId);
 }
 
 void postKernelInstrumentation(int kId, DaphneContext *ctx) {
-    if (ctx->getUserConfig().statistics)
+    if (ctx->getUserConfig().enable_statistics)
         ctx->stopKernelTimer(kId);
 }

--- a/src/runtime/local/kernels/genKernelInst.py
+++ b/src/runtime/local/kernels/genKernelInst.py
@@ -121,9 +121,14 @@ def generateKernelInstantiation(kernelTemplateInfo, templateValues, opCodes, out
             rp["isOutput"] = False
 
     isCreateDaphneContext = opName == "createDaphneContext"
-    # TODO: KernelDispatchMapping currently does not support
-    # vectorized/distributed ops
-    isVectorizedOrDistributed = "vectorized" in opName or "distributed" in opName
+    def isInstrumentedOp(op :str):
+        if op in ["map", "createDaphneContext"]:
+            return False
+        # TODO: KernelDispatchMapping currently does not support distributed ops
+        if "distributed" in op:
+            return False
+        return True
+    isInstrumented = isInstrumentedOp(opName)
 
     # typesForName = "__".join([("{}_{}".format(tv[0], tv[1]) if isinstance(tv, list) else tv) for tv in templateValues])
     typesForName = "__".join([
@@ -143,7 +148,7 @@ def generateKernelInstantiation(kernelTemplateInfo, templateValues, opCodes, out
         typesForName = "__" + typesForName
     params = ", ".join(
         ["{} {}".format(rtp["type"], rtp["name"]) for rtp in
-         extendedRuntimeParams] + ([] if isVectorizedOrDistributed else ["int kId"]) + ([] if isCreateDaphneContext else ["DCTX(ctx)"])
+         extendedRuntimeParams] + ([] if not isInstrumented else ["int kId"]) + ([] if isCreateDaphneContext else ["DCTX(ctx)"])
     )
 
     def generateFunction(opCode):
@@ -193,20 +198,12 @@ def generateKernelInstantiation(kernelTemplateInfo, templateValues, opCodes, out
             opCodeWord = opCodeType[:-len("OpCode")]
             callTemplateParams = ["{}::{}".format(opCodeWord if API == "CPP" else API + "::" + opCodeWord, opCode)] + callTemplateParams
 
-        nonInstrumentedOps = ["map", "createDaphneContext","destroyDaphneContext"]
         # Body of that function: delegate to the kernel instantiation.
         outFile.write(2 * INDENT)
-        if not isCreateDaphneContext:
-            # try
+        if isInstrumented:
             outFile.write(f"try{{\n")
-            if opName in nonInstrumentedOps:
-                outFile.write("")
-            elif isVectorizedOrDistributed:
-                outFile.write(3 * INDENT)
-                outFile.write(f"preKernelInstrumentation(0, ctx);\n")
-            else:
-                outFile.write(3 * INDENT)
-                outFile.write(f"preKernelInstrumentation(kId, ctx);\n")
+            outFile.write(3 * INDENT)
+            outFile.write(f"preKernelInstrumentation(kId, ctx);\n")
             outFile.write(3 * INDENT)
 
         #  import pdb;pdb.set_trace()
@@ -223,21 +220,11 @@ def generateKernelInstantiation(kernelTemplateInfo, templateValues, opCodes, out
             # Run-time parameters, possibly including DaphneContext:
             ", ".join(callParams + ([] if isCreateDaphneContext else ["ctx"])),
         ))
-        if not isCreateDaphneContext:
-
-            if opName in nonInstrumentedOps:
-                outFile.write(2 * INDENT)
-                outFile.write(f"}} catch(std::exception &e) {{\n{3*INDENT}throw ErrorHandler::runtimeError(0, e.what(), &(ctx->dispatchMapping));\n{2*INDENT}}}\n")
-            elif isVectorizedOrDistributed:
-                outFile.write(3 * INDENT)
-                outFile.write(f"postKernelInstrumentation(0, ctx);\n")
-                outFile.write(2 * INDENT)
-                outFile.write(f"}} catch(std::exception &e) {{\n{3*INDENT}throw ErrorHandler::runtimeError(-1, e.what(), &(ctx->dispatchMapping));\n{2*INDENT}}}\n")
-            else:
-                outFile.write(3 * INDENT)
-                outFile.write(f"postKernelInstrumentation(kId, ctx);\n")
-                outFile.write(2 * INDENT)
-                outFile.write(f"}} catch(std::exception &e) {{\n{3*INDENT}throw ErrorHandler::runtimeError(kId, e.what(), &(ctx->dispatchMapping));\n{2*INDENT}}}\n")
+        if isInstrumented:
+            outFile.write(3 * INDENT)
+            outFile.write(f"postKernelInstrumentation(kId, ctx);\n")
+            outFile.write(2 * INDENT)
+            outFile.write(f"}} catch(std::exception &e) {{\n{3*INDENT}throw ErrorHandler::runtimeError(kId, e.what(), &(ctx->dispatchMapping));\n{2*INDENT}}}\n")
         outFile.write(INDENT + "}\n")
 
         argTypes = [rtp["type"].replace(" **", "").replace(" *", "").replace("const ", "") for rtp in extendedRuntimeParams if not rtp["isOutput"]]

--- a/src/util/KernelDispatchMapping.cpp
+++ b/src/util/KernelDispatchMapping.cpp
@@ -24,7 +24,7 @@ KernelDispatchMapping &KernelDispatchMapping::instance() {
     return INSTANCE;
 }
 
-int KernelDispatchMapping::registerKernel(std::string name, mlir::Operation *op) {
+int KernelDispatchMapping::registerKernel(const std::string &name, mlir::Operation *op) {
     std::lock_guard<std::mutex> lg(m_dispatchMapping);
     int kId = kIdCounter++;
     if (auto flcLoc = llvm::dyn_cast<mlir::FileLineColLoc>(op->getLoc())) {

--- a/src/util/KernelDispatchMapping.cpp
+++ b/src/util/KernelDispatchMapping.cpp
@@ -39,5 +39,7 @@ int KernelDispatchMapping::registerKernel(std::string name, mlir::Operation *op)
 
 KDMInfo KernelDispatchMapping::getKernelDispatchInfo(int kId) {
     std::lock_guard<std::mutex> lg(m_dispatchMapping);
+    if (!kId)
+        return {"NonInstrumentedOp", "unknkown", 0, 0};
     return dispatchMapping.at(kId);
 }

--- a/src/util/KernelDispatchMapping.h
+++ b/src/util/KernelDispatchMapping.h
@@ -42,7 +42,7 @@ struct KDMInfo {
  */
 struct KernelDispatchMapping {
   private:
-    int kIdCounter{0};
+    int kIdCounter{1};
     std::mutex m_dispatchMapping{};
     std::unordered_map<int, KDMInfo> dispatchMapping{};
     /**

--- a/src/util/KernelDispatchMapping.h
+++ b/src/util/KernelDispatchMapping.h
@@ -64,7 +64,7 @@ struct KernelDispatchMapping {
      * \param name The symbol name of the kernel.
      * \param op The mlir::Operation being lowered to dispatch a kernel call.
      */
-    int registerKernel(std::string name, mlir::Operation *op);
+    int registerKernel(const std::string &name, mlir::Operation *op);
     //
     KDMInfo getKernelDispatchInfo(int kId);
 };

--- a/src/util/Statistics.cpp
+++ b/src/util/Statistics.cpp
@@ -36,7 +36,7 @@ void Statistics::stopKernelTimer(int kId) {
     auto const stopTime = std::chrono::high_resolution_clock::now();
     std::lock_guard<std::mutex> lg(m_times);
     std::chrono::duration<double> kernelTime = stopTime - startTimes[kId];
-    kernelExecutionTimes.push_back({kId, kernelTime});
+    kernelExecutionTimes.emplace_back(kId, kernelTime);
 }
 
 size_t getMaxKernelNameLength(KernelDispatchMapping &kdm) {


### PR DESCRIPTION
This patch adds tracking for `_vectN` functions generated when using
--vec and displays them in the output of `--statistics`.

Also contains a small commit with minor changes so it's run as part of the CI test run.