### PR TITLE
fix use after free by removing instrumentation from `destroyDaphneContext`

### DIFF
--- a/src/runtime/local/kernels/genKernelInst.py
+++ b/src/runtime/local/kernels/genKernelInst.py
@@ -154,8 +154,9 @@ def generateKernelInstantiation(kernelTemplateInfo, templateValues, opCodes, out
             rp["isOutput"] = False
 
     isCreateDaphneContext = opName == "createDaphneContext"
+    isDestroyDaphneContext = opName == "destroyDaphneContext"
     def isInstrumentedOp(op :str):
-        if op in ["map", "createDaphneContext"]:
+        if op in ["map", "createDaphneContext", "destroyDaphneContext"]:
             return False
         # TODO: KernelDispatchMapping currently does not support distributed ops
         if "distributed" in op:
@@ -179,8 +180,9 @@ def generateKernelInstantiation(kernelTemplateInfo, templateValues, opCodes, out
     if typesForName != "":
         typesForName = "__" + typesForName
     params = ", ".join(
-        ["{} {}".format(rtp["type"], rtp["name"]) for rtp in
-         extendedRuntimeParams] + ([] if not isInstrumented else ["int kId"]) + ([] if isCreateDaphneContext else ["DCTX(ctx)"])
+        ["{} {}".format(rtp["type"], rtp["name"]) for rtp in extendedRuntimeParams]
+        + ([] if (not isInstrumented and not isDestroyDaphneContext) else ["int kId"])
+        + ([] if isCreateDaphneContext else ["DCTX(ctx)"])
     )
 
     def generateFunction(opCode):

--- a/src/runtime/local/kernels/genKernelInst.py
+++ b/src/runtime/local/kernels/genKernelInst.py
@@ -154,7 +154,6 @@ def generateKernelInstantiation(kernelTemplateInfo, templateValues, opCodes, out
             rp["isOutput"] = False
 
     isCreateDaphneContext = opName == "createDaphneContext"
-    isDestroyDaphneContext = opName == "destroyDaphneContext"
     def isInstrumentedOp(op :str):
         if op in ["map", "createDaphneContext", "destroyDaphneContext"]:
             return False
@@ -180,9 +179,8 @@ def generateKernelInstantiation(kernelTemplateInfo, templateValues, opCodes, out
     if typesForName != "":
         typesForName = "__" + typesForName
     params = ", ".join(
-        ["{} {}".format(rtp["type"], rtp["name"]) for rtp in extendedRuntimeParams]
-        + ([] if (not isInstrumented and not isDestroyDaphneContext) else ["int kId"])
-        + ([] if isCreateDaphneContext else ["DCTX(ctx)"])
+        ["{} {}".format(rtp["type"], rtp["name"]) for rtp in
+         extendedRuntimeParams] + ([] if not isInstrumented else ["int kId"]) + ([] if isCreateDaphneContext else ["DCTX(ctx)"])
     )
 
     def generateFunction(opCode):


### PR DESCRIPTION
Kernel instrumentation currently causes a use after free bug in  `destroyDaphneContext`.

After instrumentation, `_destroyDaphneContext` looks like this:

```c++
preKernelInstrumentation(kId, ctx);
destroyDaphneContext(ctx);
postKernelInstrumentation(kId, ctx); // <- use after free in here
```

This PR fixes this by disabling instrumentation for destroyDaphneContext.

As [`RewriteToCallKernelOpPass`](https://github.com/daphne-eu/daphne/blob/aa1fb14badc0083c2d927210b782745544260f38/src/compiler/lowering/RewriteToCallKernelOpPass.cpp#L489) assumes that the `kId` and `ctx` parameters are present for all kernels besides `createDaphneContext`, this parameter is retained in `destroyDaphneContext` to keep it simple.