### PR TITLE
[DAPHNE-#785] Fix DaphneLib file permission error on multi-user systems.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,6 @@ __pycache__/
 .clion.source.upload.marker
 
 # local test/dev scripts
-/tmpdaphne.daphne
 /*.daphne
 /*.mlir
 /*.log

--- a/src/api/python/daphne/utils/consts.py
+++ b/src/api/python/daphne/utils/consts.py
@@ -22,6 +22,7 @@
 # -------------------------------------------------------------
 from __future__ import annotations
 import os
+from pathlib import Path
 from typing import Union, TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -36,7 +37,7 @@ BINARY_OPERATIONS = ['+', '-', '/', '*', '^', '%', '<', '<=', '>', '>=', '==', '
 VALID_ARITHMETIC_TYPES = Union['DAGNode', int, float]
 VALID_COMPUTED_TYPES = Union['Matrix', 'Frame', 'Scalar']
 
-TMP_PATH = os.path.join("/tmp/", "DaphneLib")
+TMP_PATH = str(Path.home() / ".daphnelib")
 os.makedirs(TMP_PATH, exist_ok=True)
 
 _PROTOTYPE_PATH_ENV_VAR_NAME = "DAPHNELIB_DIR_PATH"


### PR DESCRIPTION
- Currently, DaphneLib stores all its temporary files (generated DaphneDSL script as well as data that is transfered from Python to DAPHNE via files) in the directory "/tmp/DaphneLib/".
- On systems used by multiple users, this directory is typically owned and only writable by the user who creates it.
- If another user uses DaphneLib afterwards (e.g., by running the test suite), they encounter file permission errors that make DaphneLib crash and the test cases fail.
- The reason why the temporary files are stored in a central place (not inside the DAPHNE source code tree) is that the source tree may not be available or writable when DAPHNE was installed as a Python package (see 25f2a3c1f34ca4e2068deb06fae01d4188b8392e for details).
- This commit fixes the problem, while keeping the temporary files in some central location, by storing the temporary files under the user's home directory; more precisely, a (hidden) directory "~/.daphnelib" is employed.
- There is no guarantee that this new directory will always be writable (so a more thorough solution could add checks and fallbacks for that case), but at least this solution avoids the current problem of a clash of permissions of multiple users on the same system, because every user has their own directory for DaphneLib's temporary files.
- Fixes #785.
- Additional little clean-up: Removed the entry "/tmpdaphne.daphne" from .gitignore, because DaphneLib's temporary DaphneDSL script file isn't created in the DAPHNE root directory anymore (hasn't been the case for a long time anymore).

-----

**If anybody sees any problems with changing the location of DaphneLib's temporary files, please speak up. In case there are no comments, I will merge this PR on May 16, 2025.**