### PR TITLE
[DOC] Syntactic clean-up of the entire documentation.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-# Contributing to the DAPHNE System
+# Contributing to DAPHNE
 
-*Thank you* for your interest in contributing to the DAPHNE system.
+*Thank you* for your interest in contributing to DAPHNE.
 Our goal is to build an **open and inclusive community of developers** around the system.
 Thus, **contributions are highly welcome**, both from *within the DAPHNE project consortium* and from *external researchers/developers*.
 
@@ -25,6 +25,7 @@ In the following, you find some rough **guidelines on contributing**, which will
 ## Ways of Contributing
 
 There are **various ways of contributing** including (but not limited to):
+
 - actual implementation
 - writing test cases
 - writing documentation
@@ -36,7 +37,7 @@ That way, discussions are made *accessible and transparent* to everyone interest
 This is important to *involve people* and to *avoid repetition* in case multiple people have the same question/comment or encounter the same problem.
 So feel free to create an issue to start a discussion on a particular topic (including these contribution guidelines) or to report a bug or other problem.
 
-## Issue tracking
+## Issue Tracking
 
 All open/ongoing/completed **work is tracked as issues** on GitHub.
 These could be anything from precisely defined small tasks to requests for complex components.
@@ -65,31 +66,41 @@ That is, please try your best to make a good-quality contribution and we will he
 **The procedure is roughly as follows:**
 
 1. **Get assigned to the issue** to let others know you are going to work on it and to avoid duplicate work. Please leave a comment on the issue stating that you are going to work on it. After that, a collaborator will formally assign you.
+
 2. **Fork the repository** on GitHub and **clone your fork** (see [GitHub docs](https://docs.github.com/en/get-started/quickstart/fork-a-repo)).
-   We recommend cloning by `git clone --recursive https://github.com/<USERNAME>/daphne.git` (note the `--recursive`), as specified in [Getting Started](/doc/GettingStarted.md).
-   
-   *You may skip this step and reuse your existing fork if you have contributed before. Simply update your fork with the recent changes from the original DAPHNE repository (see [GitHub docs](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork)).*
+    <!-- TODO with containers, we don't recommend that anymore -->
+    We recommend cloning by `git clone --recursive https://github.com/<USERNAME>/daphne.git` (note the `--recursive`), as specified in [Getting Started](/doc/GettingStarted.md).
+    
+    *You may skip this step and reuse your existing fork if you have contributed before. Simply update your fork with the recent changes from the original DAPHNE repository (see [GitHub docs](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork)).*
+
 3. **Create your own local branch**: `git checkout -b BRANCH_NAME`.
-   `BRANCH_NAME` should clearly indicate what the branch is about; the recommended pattern is `123-some-short-title` (where `123` is the issue number).
+    `BRANCH_NAME` should clearly indicate what the branch is about; the recommended pattern is `123-some-short-title` (where `123` is the issue number).
+
 4. **Add as many commits as you like** to your branch, and `git push` them to your fork.
-   Use `git push --set-upstream origin BRANCH_NAME` when you push the first time.
-5. If you work longer on your contribution, make sure to **get the most recent changes from the upstream** (original DAPHNE system repository) from time to time (see [GitHub docs](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork)).
+    Use `git push --set-upstream origin BRANCH_NAME` when you push the first time.
+
+5. If you work longer on your contribution, make sure to **get the most recent changes from the upstream** (original DAPHNE repository) from time to time (see [GitHub docs](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork)).
+
 6. Once you feel ready (for integration or for discussion/feedback), **create a pull request** on GitHub (see [GitHub docs](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request)).
-   Normally, you'll want to ask for integration into `base:main`, the repo's default branch.
-   Please choose an expressive title and provide a short description of your changes.
-   Feel free to mark your pull request "WIP: " or "Draft: " in the title.
-   Note that you can add more commits to your pull request after you created it.
-   Ideally, the changes in the PR contain only the changes you made for that PR,
-   e.g, by rebasing your branch on top of the target branch. This makes it easier for others to
-   review your PR.
+    Normally, you'll want to ask for integration into `base:main`, the repo's default branch.
+    Please choose an expressive title and provide a short description of your changes.
+    Feel free to mark your pull request "WIP: " or "Draft: " in the title.
+    Note that you can add more commits to your pull request after you created it.
+    Ideally, the changes in the PR contain only the changes you made for that PR,
+    e.g, by rebasing your branch on top of the target branch. This makes it easier for others to
+    review your PR.
+    <!-- TODO link to reviewing guidelines -->
+
 7. [Resolve any open conflicts](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/addressing-merge-conflicts/about-merge-conflicts) to the target branch of the PR.
+
 8. You **receive feedback** on your proposed contribution.
-   You may be asked to apply certain changes, or we might apply straightforward adjustments ourselves before the integration.
+    You may be asked to apply certain changes, or we might apply straightforward adjustments ourselves before the integration.
+
 9. If it looks good (potentially after some help), **your contribution becomes a part of DAPHNE**.
 
 ### Experienced DAPHNE Contributors (Collaborators)
 
-We appreciate *continued commitment* to the DAPHNE system.
+We appreciate *continued commitment* to DAPHNE.
 Thus, **frequent contributors can become collaborators** on GitHub.
 Currently, this requires **at least three non-trivial contributions** to the system.
 Collaborators have *direct write access* to all branches of the repository, including the main branch.
@@ -99,25 +110,26 @@ Collaborators do not need to create a fork, and do not need to go through pull r
 At the same time, this freedom comes with certain responsibilities, which are roughly sketched here:
 
 1. Please **follow some simple guidelines when changing the code**:
-   - Feel free to directly push to the main branch, but *be mindful of what you commit*, since it will affect everyone.
-     As a guideline, commits fundamentally changing how certain things work should be announced and discussed first, whereas small changes or changes local to "your" component are not critical.
-   - But **never force push to the main branch**, since it can lead to severe inconsistencies in the Git history.
-   - Even *collaborators may still use pull requests* (just like new contributors) to suggest larger changes.
-     This is also suitable whenever you feel unsure about a change or want to get feedback first.
+    - Feel free to directly push to the main branch, but *be mindful of what you commit*, since it will affect everyone.
+      As a guideline, commits fundamentally changing how certain things work should be announced and discussed first, whereas small changes or changes local to "your" component are not critical.
+    - But **never force push to the main branch**, since it can lead to severe inconsistencies in the Git history.
+    - Even *collaborators may still use pull requests* (just like new contributors) to suggest larger changes.
+      This is also suitable whenever you feel unsure about a change or want to get feedback first.
 2. Please **engage in the [handling of pull requests](/doc/development/HandlingPRs.md)**; especially those affecting the components you are working on.
-   This includes:
-   - reading the code others suggest for integration
-   - trying if it works
-   - providing constructive and *actionable* feedback on improving the contribution prior to the integration
-   - actually merging a pull request in
-   
-   Balancing the handling of pull requests is important to *keep the development process scalable*.
+    This includes:
+    
+    - reading the code others suggest for integration
+    - trying if it works
+    - providing constructive and *actionable* feedback on improving the contribution prior to the integration
+    - actually merging a pull request in
+    
+    Balancing the handling of pull requests is important to *keep the development process scalable*.
 
 
 ### Code Style
 
 Before contributing, please make sure to run `clang-format` on your C++ (.h and
-.cpp) files. The codebase is currently formatted with `clang-format` version
+.cpp) files. The code base is currently formatted with `clang-format` version
 `18.1.3`. This is the default `clang-format` version when installing via `apt`
 on Ubuntu 24.04, and can easily be installed via `python -mpip install clang-format==18.1.3`
 on other systems.

--- a/doc/BinaryFormat.md
+++ b/doc/BinaryFormat.md
@@ -17,7 +17,7 @@ limitations under the License.
 # Binary Data Format
 
 DAPHNE defines its own binary representation for the serialization of in-memory data objects (matrices/frames).
-This representation is intended to be used by default whenever we need to transfer or persistently store these in-memory objects, e.g., for
+This representation is intended to be used by default whenever we need to transfer or persistently store these in-memory objects, e.g., for:
 
 - the data transfer in the distributed runtime
 - a custom binary file format
@@ -32,7 +32,7 @@ At the moment, we focus on the case of a single block per data object.
 
 ## Binary Representation of a Whole Data Object
 
-The binary representation of a data object (matrix/frame) starts with a header containing general and data type-specific information.
+The binary representation of a data object (matrix/frame) starts with a header containing general and data-type-specific information.
 The data object is partitioned into rectangular blocks (in the extreme case, this can mean a single block).
 All blocks are represented individually (see binary representation of a single block below) and stored along with their position in the data object.
 
@@ -76,7 +76,7 @@ We currently support the following **value types**:
 | 9 | `float` |
 | 10 | `double` |
 
-Depending on the data type, there are more information in the header:
+Depending on the data type, there is more information in the header:
 
 *For `DenseMatrix` and `CSRMatrix`*:
 
@@ -108,8 +108,8 @@ size[B]   1    1    8    8      1               1         2     len[0]          
 The body consists of a sequence of:
 
 - a pair of
-  - row index `rx` (uint64)
-  - column index `cx` (uint64)
+    - row index `rx` (uint64)
+    - column index `cx` (uint64)
 - a binary block representation
 
 For the special case of a single block, this looks as follows:
@@ -128,7 +128,7 @@ size[B]
 A single data block is a rectangular partition of a data object.
 In the extreme case, a single block can span the entire data object in both dimensions (one block per data object).
 
-General block header
+General block header:
 
 - number of rows `#r` (uint32)
 - number of columns `#c` (uint32)
@@ -143,7 +143,7 @@ addr[B]  0  3 4  7 8  8 9                        *
 size[B]    4    4    1               *
 ```
 
-## Block types
+## Block Types
 
 We define different block types to allow for a space-efficient representation depending on the data.
 When serializing a data object, the block types are not required to match the in-memory representation (e.g., the blocks of a `DenseMatrix` could use the *sparse* binary representation).
@@ -161,7 +161,7 @@ Most block types store their value type as part of the block type-specific infor
 Note that the value type used for the binary representation is not required to match the value type of the in-memory object (e.g., `DenseMatrix<uint64_t>` may be represented as a *dense* block with value type `uint8_t`, if the value range permits).
 Furthermore, each block may be represented using its individual value type.
 
-### Empty block
+### Empty Block
 
 This block type is used to represent blocks that contain only zeros of the respective value type very space-efficiently.
 
@@ -175,7 +175,7 @@ addr[B]  0  3 4  7 8 8
 size[B]    4    4   1
 ```
   
-### Dense block
+### Dense Block
 
 Block type-specific information:
 
@@ -192,17 +192,17 @@ addr[B]  0  3 4  7 8 8 9  9 10                             10+#r*#c*S
 size[B]    4    4   1    1      S         S                  S
 ```
 
-### Sparse block (compressed sparse row, CSR)
+### Sparse Block (Compressed Sparse Row, CSR)
 
 Block type-specific information:
 
 - value type `vt`  (uint8)
 - number of non-zeros in the block `#nzb` (uint64)
 - for each row
-  - number of non-zeros in the row `#nzr` (uint32)
-  - for each non-zero in the row
-    - column index `cx` (uint32)
-    - value `v` (value type `vt`)
+    - number of non-zeros in the row `#nzr` (uint32)
+    - for each non-zero in the row
+        - column index `cx` (uint32)
+        - value `v` (value type `vt`)
 
 Note that both a row and the entire block might contain no non-zeros.
 
@@ -233,20 +233,20 @@ size[B]    4    4   1    1     8              4+#nzr[i]*(4+S)
                                        4             S
 ```
 
-### Ultra-sparse block (coordinate, COO)
+### Ultra-Sparse Block (Coordinate, COO)
 
 Ultra-sparse blocks contain almost no non-zeros, so we want to keep the overhead of the meta data low.
 Thus, we distinguish blocks with a single column (where we don't need to store the column index) and blocks with more than one column.
 
-### Blocks with a single column
+### Blocks with a Single Column
 
 Block type-specific information:
 
 - value type `vt` (uint8)
 - number of non-zeros in the block `#nzb` (uint32)
 - for each non-zero
-  - row index `rx` (uint32)
-  - value `v` (value type `vt`)
+    - row index `rx` (uint32)
+    - value `v` (value type `vt`)
 
 Below, `S` denotes the size (in bytes) of a single value of type `vt`.
   
@@ -266,16 +266,16 @@ size[B]    4    4   1    1     4     4+S           4+S              4+S
                                              4          S
 ```
 
-### Blocks with more than one column
+### Blocks with More than One Column
 
 Block type-specific information:
 
 - value type `vt` (uint8)
 - number of non-zeros in the block `#nzb` (uint32)
 - for each non-zero
-  - row index `rx` (uint32)
-  - column index `cx` (uint32)
-  - value `v` (value type `vt`)
+    - row index `rx` (uint32)
+    - column index `cx` (uint32)
+    - value `v` (value type `vt`)
 
 Below, `S` denotes the size (in bytes) of a single value of type `vt`.
   

--- a/doc/BuildEnvironment.md
+++ b/doc/BuildEnvironment.md
@@ -14,22 +14,21 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-# Building in unsupported environments
+# Building in Unsupported Environments
 
 DAPHNE can also be built in environments other than the one endorsed by the DAPHNE project team. To help with that,
-there are scripts to build your own toolchain in the [``buildenv``](/buildenv) directory.
+there are scripts to build your own toolchain in the [`buildenv`](/buildenv) directory.
 These scripts can be used to build the compiler and necessary libraries to build DAPHNE in unsupported environments 
 (RHEL UBI, CentOS, ...) Besides the build scripts, there is a docker file to create a UBI image to build for Redhat 8.
 
-
 Usage:
-* Create Docker image with build-ubi8.sh
-* Run the Docker image with run-ubi8.sh
-* Run build-all.sh
-* Run source env.sh inside or outside the Docker image to set PATH and linker variables to use the created environment 
-(you need to cd into the directory containing env.sh as this uses $PWD)
 
+* Create the Docker image with `build-ubi8.sh`
+* Run the Docker image with `run-ubi8.sh`
+* Run `build-all.sh`
+* Run `source env.sh` inside or outside the Docker image to set `PATH` and linker variables to use the created environment 
+(you need to cd into the directory containing `env.sh` as this uses `$PWD`)
 
 Beware that this procedure needs ~50GB of free disk space. Also, the provided CUDA SDK expects a recent driver (550+) 
 version. That will most likely be an issue on large installations - exchange the relevant version and file names for 
-another CUDA version in env.sh to build another version.
+another CUDA version in `env.sh` to build another version.

--- a/doc/Codegen.md
+++ b/doc/Codegen.md
@@ -1,3 +1,19 @@
+<!--
+Copyright 2025 The DAPHNE Consortium
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 # Code Generation with MLIR
 
 This document describes the process of directly generating code with the MLIR
@@ -5,9 +21,9 @@ framework.
 
 ## Motivation
 
-DAPHNE provides a kernel for (almost) every DaphneIR operation which reside in
-`src/runtime/local/kernels/`. These are precompiled as a shared library and
-linked during compile-time. Even though these kernels can be highly optimized
+DAPHNE provides a kernel for (almost) every DaphneIR operation. The kernels reside in
+`src/runtime/local/kernels/`. These are pre-compiled as a shared library during the DAPHNE build and
+linked at DaphneDSL compile-time. Even though these kernels can be highly optimized
 and thus achieve great runtime characteristics, they may not provide a desired
 level of extensibility for custom value types. They may also be lacking
 information only available at compile-time that could enable further
@@ -16,13 +32,13 @@ input IR, the code generation pipeline may enable more optimization
 possibilities such as operator or loop fusion.
 
 
-As an alternative way to implement our operators we provide the code generation
+As an alternative way to implement our operators, we provide the code generation
 pipeline which progressively lowers the DaphneIR available after parsing the
 DaphneDSL script to operations in either the same dialect or operations from
 other dialects. With that, we can optionally replace certain kernels by
 generating code directly, and also perform a hybrid compilation approach where
 we mix kernel calls with code generation in order to exploit advantages of
-both, precompiled kernel libraries and code generation. Code generation passes
+both, pre-compiled kernel libraries and code generation. Code generation passes
 are found in `src/compiler/lowering/`.
 
 
@@ -32,14 +48,14 @@ Currently, the code generation pipeline is enabled with the CLI flag
 `--mlir-codegen`. This adds the following passes that perform transformations and
 lowerings:
 
-- [DenseMatrixOptPass](src/compiler/lowering/DaphneOptPass.cpp)
-- [MatMulOpLoweringPass](src/compiler/lowering/MatMulOpLowering.cpp)
-- [AggAllLoweringPass](src/compiler/lowering/AggAllOpLowering.cpp)
-- [MapOpLoweringPass](src/compiler/lowering/MapOpLowering.cpp)
+- [DenseMatrixOptPass](/src/compiler/lowering/DaphneOptPass.cpp)
+- [MatMulOpLoweringPass](/src/compiler/lowering/MatMulOpLowering.cpp)
+- [AggAllLoweringPass](/src/compiler/lowering/AggAllOpLowering.cpp)
+- [MapOpLoweringPass](/src/compiler/lowering/MapOpLowering.cpp)
 - InlinerPass
-- [LowerEwOpPass](src/compiler/lowering/EwOpsLowering.cpp)
+- [LowerEwOpPass](/src/compiler/lowering/EwOpsLowering.cpp)
 - ConvertMathToLLVMPass
-- [ModOpLoweringPass](src/compiler/lowering/ModOpLowering.cpp)
+- [ModOpLoweringPass](/src/compiler/lowering/ModOpLowering.cpp)
 - Canonicalizer
 - CSE
 - LoopFusion
@@ -75,12 +91,11 @@ multiple passes) on the IR. `daphne-opt` provides all the functionality of the
 debug information.
 
 
-
 #### Testing
 
 To test the generated code, there currently are two different approaches.
 
-End-to-end tests can be found under `test/api/cli/codegen/` and are part of the
+Script-level tests can be found under `test/api/cli/codegen/` and are part of the
 existing Catch2 test-suite with the its own tag, `TAG_CODEGEN`.
 
 Additionally, there are tests that check the generated IR by running the
@@ -95,6 +110,5 @@ the comments in the `.mlir` file to check for certain conditions, e.g., `//
 CHECK-NOT: daphne.ewAdd` looks through the IR and fails if `daphne.ewAdd` can be
 found. These `llvm-lit` tests are all run by the `codegen` testcase in
 `test/codegen/Codegen.cpp`.
-
 
 All codegen tests can be executed by running `bin/run_tests '[codegen]'`.

--- a/doc/Config.md
+++ b/doc/Config.md
@@ -16,7 +16,7 @@ limitations under the License.
 
 # Configuration - Getting Information from the User
 
-The behavior of the DAPHNE system can be influenced by the user by means of a cascading configuration mechanism.
+The behavior of DAPHNE can be influenced by the user by means of a cascading configuration mechanism.
 There is a set of options that can be passed from the user to the system.
 These options are collected in the `DaphneUserConfig` ([src/api/cli/DaphneUserConfig.h](/src/api/cli/DaphneUserConfig.h)).
 The cascade consists of the following steps:
@@ -34,7 +34,7 @@ The `DaphneUserConfig` is available to all parts of the code, including:
 Hence, information provided by the user can be used to influence both, the compiler and the runtime.
 *The use of environment variables to pass information into the system is discouraged.*
 
-## How to extend the configuration?
+## How to Extend the Configuration?
 
 If you need to add additional information from the user, you must take roughly the following steps:
 

--- a/doc/DaphneDSL/Builtins.md
+++ b/doc/DaphneDSL/Builtins.md
@@ -30,7 +30,7 @@ We use the following notation (deviating from the DaphneDSL function syntax):
 - `...` stands for an arbitrary repetition of the previous parameter (including zero).
 - `/` means alternative options, e.g., `matrix/frame` means the parameter could be a matrix or a frame
 
-## List of categories
+## List of Categories
 
 DaphneDSL's built-in functions can be categorized as follows:
 
@@ -51,7 +51,7 @@ DaphneDSL's built-in functions can be categorized as follows:
 - Measurements
 - List operations
 
-## Data generation
+## Data Generation
 
 - **`fill`**`(value:scalar, numRows:size, numCols:size)`
 
@@ -86,7 +86,7 @@ DaphneDSL's built-in functions can be categorized as follows:
     Note that `from` may be greater than `to`, and `inc` may be negative.
     The scalar `inc` is an optional argument and defaults to `1`.
 
-## Matrix/frame meta data
+## Matrix/Frame Meta Data
 
 The following built-in functions allow to find out meta data of matrices and frames.
 
@@ -119,7 +119,7 @@ The following built-in functions allow to find out meta data of matrices and fra
     Returns `true` if and only if the given *(n x n)* matrix is symmetric, i.e., for any *i in {0, 1, ..., n-1}* and *j in {0, 1, ..., n-1}*, the value at position *(i, j)* is the same as the value at position *(j, i)*.
     The given matrix must be a square matrix.
 
-## Elementwise unary
+## Elementwise Unary
 
 The following built-in functions all follow the same scheme:
 
@@ -127,7 +127,7 @@ The following built-in functions all follow the same scheme:
   
     Applies the respective unary function (see table below) to the given scalar `arg` or to each element of the given matrix `arg`.
 
-### Arithmetic/general math
+### Arithmetic/General Math
 
 | function | meaning |
 | ----- | ----- |
@@ -167,7 +167,7 @@ The following built-in functions all follow the same scheme:
 | ----- | ----- |
 | **`isNan`** | `1` if argument is NaN, `0` otherwise |
 
-## Elementwise binary
+## Elementwise Binary
 
 DaphneDSL supports various elementwise binary operations.
 Some of those can be used through *operators in infix notation*, e.g., `+`; and some through *built-in functions*, e.g., `log()`.
@@ -192,7 +192,7 @@ The built-in functions all follow the same scheme:
 | **`log`** | | logarithm (logarithm of `lhs` to the base of `rhs`) |
 | **`mod`** | **`%`** | modulo |
 
-### Min/max
+### Min/Max
 
 | function | operator | meaning |
 | ----- | ----- | ----- |
@@ -223,23 +223,24 @@ The built-in functions all follow the same scheme:
 | | **`>`** | greater than |
 | | **`>=`** | greater or equal |
 
-## Outer binary (generalized outer product)
+## Outer Binary (Generalized Outer Product)
 
 The following built-in functions all follow the same scheme:
 
 - ***`outerBinaryFunc`***`(lhs:matrix, rhs:matrix)`
   
-  The argument `lhs` is expected to be a column *(m x 1)* matrix, and the argument `rhs` is expected to be a row *(1 x n)* matrix.
-  The result is a *(m x n)* matrix, whereby the element at position *(i, j)* is calculated by applying the respective binary function (see the table below) to the *i*-th element in `lhs` and the *j*-th element in `rhs`.
-  Schematically, this looks as follows (where `∘` is some binary operation):
-  ```
-         |    b0    b1 ...    bn rhs
-      ---+----------------------
-  lhs a0 | a0∘b0 a0∘b1 ... a0∘bn res
-      a1 | a1∘b0 a1∘b1 ... a1∘bn
-      .. | ..... .....     .....
-      am | am∘b0 am∘b1 ... am∘bn
-  ```
+    The argument `lhs` is expected to be a column *(m x 1)* matrix, and the argument `rhs` is expected to be a row *(1 x n)* matrix.
+    The result is a *(m x n)* matrix, whereby the element at position *(i, j)* is calculated by applying the respective binary function (see the table below) to the *i*-th element in `lhs` and the *j*-th element in `rhs`.
+    Schematically, this looks as follows (where `∘` is some binary operation):
+
+    ```text
+           |    b0    b1 ...    bn rhs
+        ---+----------------------
+    lhs a0 | a0∘b0 a0∘b1 ... a0∘bn res
+        a1 | a1∘b0 a1∘b1 ... a1∘bn
+        .. | ..... .....     .....
+        am | am∘b0 am∘b1 ... am∘bn
+    ```
   
 ### Arithmetic
 
@@ -253,7 +254,7 @@ The following built-in functions all follow the same scheme:
 | **`outerLog`** | logarithm (logarithm of `lhs` to the base of `rhs`) |
 | **`outerMod`** | modulo |
 
-### Min/max
+### Min/Max
 
 | function | meaning |
 | ----- | ----- |
@@ -285,9 +286,9 @@ The following built-in functions all follow the same scheme:
 | **`outerGt`** | greater than |
 | **`outerGe`** | greater or equal |
 
-## Aggregation and statistical
+## Aggregation and Statistical
 
-### Full/row/column aggregation
+### Full/Row/Column Aggregation
 
 The following built-in functions all follow the same scheme:
 
@@ -314,7 +315,7 @@ The following built-in functions all follow the same scheme:
 | `idxMin` | argmin (the index of the minimum value, only for row/column-wise aggregation) |
 | `idxMax` | argmax (the index of the maximum value, only for row/column-wise aggregation) |
 
-### Cumulative aggregation
+### Cumulative Aggregation
 
 The following built-in functions all follow the same scheme:
 
@@ -363,7 +364,7 @@ The following built-in functions all follow the same scheme:
     The provided number of columns and sort orders must match.
     The parameter `returnIndexes` determines whether to return the sorted data (`false`) or a column-matrix of positions representing the permutation applied by the sorting (`true`).
 
-## Matrix decomposition & co
+## Matrix Decomposition & Co
 
 - **`eigen`**`(arg:matrix)`
 
@@ -372,7 +373,7 @@ The following built-in functions all follow the same scheme:
 
 We plan to support additional matrix decompositions like **`lu`**, **`qr`**, and **`svd`** in the future.
 
-## Deep neural network
+## Deep Neural Network
 
 Note that most of these operations only have a CUDNN-based kernel for GPU execution at the moment.
 
@@ -402,7 +403,7 @@ Note that most of these operations only have a CUDNN-based kernel for GPU execut
 
 - **`softmax`**`(inputData:matrix)`
 
-## Other matrix operations
+## Other Matrix Operations
 
 - **`diagVector`**`(arg:matrix)`
 
@@ -443,7 +444,7 @@ Note that most of these operations only have a CUDNN-based kernel for GPU execut
     The weight also determines the value type of the result.
 
     Moreover, optionally, the result shape in terms of the number of rows and columns can be specified.
-    If omited, it defaults to the smallest numbers required to accommodate all given `y`/`x`-coordinates, as expressed above.
+    If omitted, it defaults to the smallest numbers required to accommodate all given `y`/`x`-coordinates, as expressed above.
     If specified, the result can be either cropped or padded with zeros to the desired shape.
     If a value less than zero is provided as the number of rows/columns, the respective dimension will also be determined from the input data.
 
@@ -457,14 +458,14 @@ Note that most of these operations only have a CUDNN-based kernel for GPU execut
 
     Calcuates `t(A) @ x` for the given *(n x m)* matrix `A` and *(n x 1)* column-matrix `x`.
 
-## Extended relational algebra
+## Extended Relational Algebra
 
 DaphneDSL supports relational algebra on frames in two ways:
 On the one hand, entire SQL queries can be executed over previously registered *views*.
 This aspect is described in detail in a [separate tutorial](/doc/tutorial/sqlTutorial.md).
 On the other hand, built-in functions for individual operations of extended relational algebra can be used on frames in DaphneDSL.
 
-### Entire SQL query
+### Entire SQL Query
 
 - **`registerView`**`(viewName:str, arg:frame)`
 
@@ -491,7 +492,7 @@ We will support set operations such as **`intersect`**, **`merge`**, and **`exce
   Returns the tuples in `lhs`, which are not in `rhs` (in set or bag semantics, tbd).
 -->
 
-### Cartesian product and joins
+### Cartesian Product and Joins
 
 - **`cartesian`**`(lhs:frame, rhs:frame)`
 
@@ -520,7 +521,7 @@ We will support set operations such as **`intersect`**, **`merge`**, and **`exce
   
 We will support more variants of joins, including (left/right) outer joins, theta joins, anti-joins, etc.
 
-### Grouping and aggregation
+### Grouping and Aggregation
 
 - **`groupSum`**`(arg:frame, grpColNames:str[, grpColNames, ...], sumColName:str)`
 
@@ -528,7 +529,7 @@ We will support more variants of joins, including (left/right) outer joins, thet
 
     *This built-in function is currently limited in terms of functionality (aggregation only on a single column, sum as the only aggregation function). It will be extended in the future. Meanwhile, consider using DAPHNE's `sql()` built-in function for more comprehensive grouping and aggregation support.*
 
-### Frame label manipulation
+### Frame Label Manipulation
 
 - **`setColLabels`**`(arg:frame, labels:str, ...)`
 
@@ -539,7 +540,7 @@ We will support more variants of joins, including (left/right) outer joins, thet
 
     Prepends the given `prefix` to the labels of all columns in `arg`.
 
-## Conversions and casts
+## Conversions and Casts
 
 Note that DaphneDSL offers casts in form of the `as.()`-expression.
 See the [DaphneDSL Language Reference](/doc/DaphneDSL/LanguageRef.md) for details.
@@ -549,7 +550,7 @@ See the [DaphneDSL Language Reference](/doc/DaphneDSL/LanguageRef.md) for detail
     Performs a `min`/`max` quantization of the values in `arg`.
     The result matrix is of value type `ui8`.
 
-## Input/output
+## Input/Output
 
 DAPHNE supports local file I/O for various file formats.
 The format is determined by the specified file name extension.
@@ -591,7 +592,7 @@ These must be provided in a separate [`.meta`-file](/doc/FileMetaDataFormat.md).
 
     Terminates the DaphneDSL script execution with the given optional message.
 
-## Data preprocessing
+## Data Preprocessing
 
 - **`oneHot`**`(arg:matrix, info:matrix<si64>)`
 
@@ -624,7 +625,7 @@ These must be provided in a separate [`.meta`-file](/doc/FileMetaDataFormat.md).
 
     Example:
 
-    ```
+    ```r
     data = [10, 5, 20, 5, 20];
     codes, dict = recode(data, false);
     print(codes);
@@ -633,7 +634,7 @@ These must be provided in a separate [`.meta`-file](/doc/FileMetaDataFormat.md).
     print(decoded);
     ```
 
-    ```
+    ```text
     DenseMatrix(5x1, int64_t)
     0
     1
@@ -661,13 +662,13 @@ These must be provided in a separate [`.meta`-file](/doc/FileMetaDataFormat.md).
 
     Example:
 
-    ```
+    ```r
     print(bin(t([10, 20, 30, 40, 50, 60, 70]), 3));
     print(bin(t([10, 20, 30, 40, 50, 60, 70]), 3, 10, 70));
     print(bin(t([5.0, 20.0, nan, 40.0, inf, 60.0, 100.0]), 3, 10.0, 70.0));
     ```
 
-    ```
+    ```text
     DenseMatrix(1x7, int64_t)
     0 0 0 1 1 2 2
     DenseMatrix(1x7, int64_t)
@@ -680,9 +681,9 @@ These must be provided in a separate [`.meta`-file](/doc/FileMetaDataFormat.md).
 
 - **`now`**`()`
 
-    Returns the current time since the epoch in nano seconds.
+    Returns the current time since the epoch in nanoseconds.
 
-## List operations
+## List Operations
 
 - **`createList`**`(elm:matrix, ...)`
 

--- a/doc/DaphneDSL/Imports.md
+++ b/doc/DaphneDSL/Imports.md
@@ -16,9 +16,9 @@ limitations under the License.
 
 # Imports
 
-How to import functions from other Daphne scripts
+DaphneDSL supports importing functions from other DaphneDSL scripts.
 
-Example usage:
+*Example:*
 
 ```cpp
 import "bar.daphne";
@@ -30,7 +30,7 @@ print(utils.x);
 
 ---
 
-`UserConfig.json` now has a new field `daphnedsl_import_paths`, which maps e.g., library names to a list of paths, see example:
+`UserConfig.json` has a field `daphnedsl_import_paths`, which maps, e.g., library names to a list of paths, see example:
 
 ```json
     "daphnedsl_import_paths": 
@@ -40,11 +40,11 @@ print(utils.x);
     }
 ```
 
-NOTE: to use a user config, the json file path needs to be passed as CLI arg to the DAPHNE binary `daphne --config=<filename>`
+**Note:** To use a custom configuration, the JSON file path needs to be passed as a command-line argument to the DAPHNE binary `bin/daphne --config=<filename>`
 
-NOTE: `default_dirs` can hold many paths and it will look for the **one** specified file in each, whereas any other library names have a list consisting of **one** directory,  from which **all** files will be imported (can be easily extended to multiple directories).
+**Note:** The parameter `default_dirs` can hold many paths and it will look for the **one** specified file in each, whereas any other library names have a list consisting of **one** directory,  from which **all** files will be imported (can be easily extended to multiple directories).
 
-Example:
+*Example:*
 
 ```cpp
 import "a.daphne";
@@ -62,9 +62,9 @@ Paths from `UserConfig` get to `DaphneDSLVisitor` from `daphne.cpp` via `DaphneU
 ---
 
 Variable name collision resolution:
-Whenever we stumble upon equal prefixes (e.g., files with the same name in different directories), a parent directory of the file where conflict is detected is prepended before prefix.
+Whenever we stumble upon equal prefixes (e.g., files with the same name in different directories), a parent directory of the file where the conflict is detected is prepended before the prefix.
 
-Example:
+*Example:*
 
 ```cpp
 import "somedir/a.daphne";
@@ -74,9 +74,9 @@ print(a.x);
 print(otherdir.a.x);
 ```
 
-NOTE: the parent directory may be prepended even though you never specified it (e.g., the import script is in the same directory as the original script).
+**Note:** The parent directory may be prepended even though you never specified it (e.g., the import script is in the same directory as the original script).
 
-Example:
+*Example:*
 
 ```cpp
 import "somedir/a.daphne";
@@ -97,7 +97,7 @@ print(algorithms.x);
 print(algorithms.kmeans1.someVar);
 ```
 
-Even though both prefixes will begin with `algorithms.`, the entire library content's prefix is extended with filenames. It is up to user to not confuse yourself.
+Even though both prefixes will begin with `algorithms.`, the entire library content's prefix is extended with filenames. It is up to the user to not confuse yourself.
 
 ---
 

--- a/doc/DaphneDSL/LanguageRef.md
+++ b/doc/DaphneDSL/LanguageRef.md
@@ -106,7 +106,7 @@ Simple expressions constitute the basis of all expressions, and DaphneDSL offers
 
 Literals represent hard-coded values and can be of various data and value types:
 
-##### Scalar literals
+##### Scalar Literals
 
 **Integer literals** are specified in decimal digits.
 By default, they have the type `si64`, but if the optional suffix `u` is appended, the type is `ui64`.
@@ -142,7 +142,7 @@ Special characters must be escaped using a backslash:
 "This is \"hello.daphne\"."
 ```
 
-##### Matrix literals
+##### Matrix Literals
 
 A matrix literal consists of a comma-separated list of elements enclosed in square brackets,
 optionally followed by parentheses with a comma separated pair of dimensions (number of rows and/or columns).
@@ -160,7 +160,7 @@ Note that the [built-in function](/doc/DaphneDSL/Builtins.md) `reshape` can also
 [1, 2, 3, sum([4, 5])](2, 2)    # matrix<si64> with shape (2 x 2)
 ```
 
-##### Frame literals
+##### Frame Literals
 
 Frame literals can be defined using either columns or rows and are enclosed in curly brackets.
 
@@ -200,7 +200,7 @@ Variables are referenced by their name.
 x
 ```
 
-#### Script arguments
+#### Script Arguments
 
 Script arguments are named *literals* that can be passed to a DaphneDSL script.
 They are referenced by a dollar sign `$` followed by the argument's name.
@@ -281,7 +281,7 @@ The result is always a data object of the same data type as the input (even *1 x
 
 The rows and columns to extract can be specified independently in any of the following ways:
 
-##### Omit indexing
+##### Omit Indexing
 
 Omitting the specification of rows/columns means extracting all rows/columns.
 
@@ -291,51 +291,51 @@ Omitting the specification of rows/columns means extracting all rows/columns.
 X[, ] # same as X (all rows and columns)
 ```
 
-##### Indexing by position
+##### Indexing by Position
 
 This is supported for addressing rows and columns in matrices and frames.
 
 - *Single row/column position:*
-  Extracts only the specified row/column.
+    Extracts only the specified row/column.
 
-  *Examples:*
+    *Examples:*
 
-  ```r
-  X[2, 3] # extracts the cell in row 2, column 3 as a 1 x 1 matrix
-  ```
+    ```r
+    X[2, 3] # extracts the cell in row 2, column 3 as a 1 x 1 matrix
+    ```
 
 - *Row/column range:*
-  Extracts all rows/columns between a lower bound (inclusive) and an upper bound (exclusive).
-  The lower and upper bounds can be omitted independently of each other.
-  In that case, they are replaced by zero and the number of rows/columns, respectively.
-  
-  *Examples:*
+    Extracts all rows/columns between a lower bound (inclusive) and an upper bound (exclusive).
+    The lower and upper bounds can be omitted independently of each other.
+    In that case, they are replaced by zero and the number of rows/columns, respectively.
 
-  ```r
-  X[2:5, 3] # extracts rows 2, 3, 4 of column 3
-  X[2, 3:]  # extracts row 2 of all columns from column 3 onward
-  X[:5, 3]  # extracts rows 0, 1, 2, 3, 4 of column 3
-  X[:, 3]   # extracts all rows of column 3, same as X[, 3]
-  ```
+    *Examples:*
+
+    ```r
+    X[2:5, 3] # extracts rows 2, 3, 4 of column 3
+    X[2, 3:]  # extracts row 2 of all columns from column 3 onward
+    X[:5, 3]  # extracts rows 0, 1, 2, 3, 4 of column 3
+    X[:, 3]   # extracts all rows of column 3, same as X[, 3]
+    ```
 
 - *Arbitrary sequence of row/column positions:*
-  Expects a sequence of row/column positions *as a column (n x 1) matrix*.
-  There are no restrictions on these positions, except that they must be in bounds.
-  In particular, they do *not* need to be contiguous, sorted, or unique.
+    Expects a sequence of row/column positions *as a column (n x 1) matrix*.
+    There are no restrictions on these positions, except that they must be in bounds.
+    In particular, they do *not* need to be contiguous, sorted, or unique.
 
-  *Examples:*
+    *Examples:*
 
-  ```r
-  X[ [5, 1, 3], ] # extracts rows 5, 1, and 3
-  X[, [2, 2, 2] ] # extracts column 2 three times
-  ```
+    ```r
+    X[ [5, 1, 3], ] # extracts rows 5, 1, and 3
+    X[, [2, 2, 2] ] # extracts column 2 three times
+    ```
 
-  Note that, when using matrix literals to specify the positions, a space must be left between the opening/closing bracket `[`/`]` of the indexing and that of the matrix literal, in order to avoid confusion with the indexing by bit vector.
+    Note that, when using matrix literals to specify the positions, a space must be left between the opening/closing bracket `[`/`]` of the indexing and that of the matrix literal, in order to avoid confusion with the indexing by bit vector.
 
 A few remarks on positions:
 
 - Counting starts at zero.
-  For instance, a 5 x 3 matrix has row positions 0, 1, 2, 3, and 4, and column positions 0, 1, and 2.
+    For instance, a 5 x 3 matrix has row positions 0, 1, 2, 3, and 4, and column positions 0, 1, and 2.
 - They must be non-negative.
 - They can be provided as integers or floating-point numbers (the latter are rounded down to integers).
 - They can be given as literals or as any expression evaluating to a suitable value.
@@ -348,21 +348,21 @@ X[1.9, ]              # same as X[1, ]
 X[i, (j + 2*sum(Y)):] # expressions
 ```
 
-##### Indexing by label
+##### Indexing by Label
 
 So far, this is only supported for addressing columns of frames.
 
 - *Single column label:*
-  Extracts only the column with the given label.
+    Extracts only the column with the given label.
 
-  *Examples:*
+    *Examples:*
 
-  ```r
-  X[, "revenue"]        # extracts the column labeled "revenue"
-  X[100:200, "revenue"] # extracts rows 100 through 199 of the column labeled "revenue"
-  ```
+    ```r
+    X[, "revenue"]        # extracts the column labeled "revenue"
+    X[100:200, "revenue"] # extracts rows 100 through 199 of the column labeled "revenue"
+    ```
 
-##### Indexing by bit vector
+##### Indexing by Bit Vector
 
 This is not supported for addressing columns of frames yet.
 
@@ -415,7 +415,7 @@ as.ui8(x) # casts x to the same data type as x, but with value type ui8
 
 Note that casting to frames does not support changing the value/column type yet, i.e., expressions like `as.frame<f64, si32, f32>(x)` and `as.f64(x)` (on a frame `x`) do not work yet.
 
-#### Function calls
+#### Function Calls
 
 Function calls can address [*built-in* functions](/doc/DaphneDSL/Builtins.md) as well as [*user-defined* functions](#user-defined-functions-udfs), but the syntax is the same in both cases:
 The name of the function followed by a comma-separated list of positional parameters in parentheses.
@@ -428,7 +428,7 @@ t(myMatrix);
 seq(0, 10, 2);
 ```
 
-#### Conditional expression
+#### Conditional Expression
 
 DaphneDSL supports the conditional expression with the general syntax:
 
@@ -439,15 +439,15 @@ condition ? then-value : else-value
 The condition can be either a scalar or a matrix.
 
 - *Condition is a scalar:*
-  If the condition is `true` (when casted to boolean), then the result is the `then-value`.
-  Otherwise, the result is the `else-value`.
-  The `then-value` and the `else-value` must have the same type.
+    If the condition is `true` (when casted to boolean), then the result is the `then-value`.
+    Otherwise, the result is the `else-value`.
+    The `then-value` and the `else-value` must have the same type.
 - *Condition is a matrix (elementwise application):*
-  In this case, the condition matrix can be of any value type, but must only contain 0 or 1 values of that type (for all other values, the behavior is unspecified).
-  The `then-value` and `else-value` must be matrices of the same shape as the condition and must have the same value type as each other.
-  The `?:`-operator is applied in an elementwise fashion, i.e., individually for each triple of corresponding elements in condition/`then-value`/`else-value`.
-  The `then-value` and `else-value` may also be scalars, in which case they are treated like matrices with a constant value.
-  The result is a matrix of the same shape as the condition and the same value type as the `then-value`/`else-value`.
+    In this case, the condition matrix can be of any value type, but must only contain 0 or 1 values of that type (for all other values, the behavior is unspecified).
+    The `then-value` and `else-value` must be matrices of the same shape as the condition and must have the same value type as each other.
+    The `?:`-operator is applied in an elementwise fashion, i.e., individually for each triple of corresponding elements in condition/`then-value`/`else-value`.
+    The `then-value` and `else-value` may also be scalars, in which case they are treated like matrices with a constant value.
+    The result is a matrix of the same shape as the condition and the same value type as the `then-value`/`else-value`.
 
 *Examples:*
 
@@ -461,7 +461,7 @@ The condition can be either a scalar or a matrix.
 At the highest level, a DaphneDSL script is a sequence of statements.
 Statements comprise assignments, various forms of control flow, and declarations of user-defined functions.
 
-### Expression statement
+### Expression Statement
 
 Every expression followed by a semicolon `;` can be used as a statement.
 This is useful for expressions (especially function calls) which do not return a value.
@@ -476,7 +476,7 @@ doSomething();  # possible return values are ignored, but the execution
                 # of the user-defined function could have side effects
 ```
 
-### Assignment statement
+### Assignment Statement
 
 The return value(s) of an expression can be assigned to one (or more) variable(s).
 
@@ -545,13 +545,13 @@ B[..., ...] = ...; # copy-on-write: changes B, but no effect on A
 A[..., ...] = ...; # copy-on-write: changes A, but no effect on B
 ```
 
-### Control Flow statements
+### Control Flow Statements
 
 DaphneDSL supports block statements, conditional branching, and various kinds of loops.
 These control flow constructs can be nested arbitrarily.
 Besides that, the [`stop()` built-in function](/doc/DaphneDSL/Builtins.md) can be used to terminate the DaphneDSL script execution.
 
-#### Block statement
+#### Block Statement
 
 A block statement allows to view an enclosed sequence of statements like a single statement.
 This is very useful in combination with the control flow statements described below.
@@ -582,7 +582,7 @@ print(x);     # prints 2
 print(y);     # error
 ```
 
-#### If-then-else
+#### If-Then-Else
 
 The syntax of an if-then-else statement is as follows:
 
@@ -767,7 +767,7 @@ def fib(n: si64) -> si64 {
     return fib(n - 1) + fib(n - 2);
 }
 ```
-```
+```csharp
 def nextTwo(a: si64) -> si64, si64 {
     return a + 1, a + 2;
 }
@@ -784,7 +784,7 @@ x = 2 * fib(5) + 123;
 y, z = nextTwo(123);
 ```
 
-### Typed and Untyped Functions (experimental)
+### Typed and Untyped Functions (Experimental)
 
 DaphneDSL supports both typed and untyped functions.
 
@@ -795,7 +795,7 @@ A typed function is compiled exactly once and specialized to the specified param
 In contrast to that, the definition of an *untyped function* leaves the data and value type, or just the value type, of one or more parameters and/or return values unspecified.
 At call sites, a value of any type, or any value type, can be passed to an untyped parameter.
 As a consequence, an untyped function is compiled and specialized on demand according to the types at a call site.
-Consistently, the types of untyped return values are infered from the parameter types and operations.
+Consistently, the types of untyped return values are inferred from the parameter types and operations.
 
 ## Compiler Hints
 

--- a/doc/DaphneLib/APIRef.md
+++ b/doc/DaphneLib/APIRef.md
@@ -20,7 +20,7 @@ This document is a hand-crafted reference of the DaphneLib API.
 A general introduction to [DaphneLib (DAPHNE's Python API)](/doc/DaphneLib/Overview.md) can be found in a separate document.
 DaphneLib offers numerous methods for *obtaining DAPHNE matrices and frames* as well as for *building complex computations* based on them, including complex control flow with if-then-else, loops, and user-defined functions.
 Ultimately, DaphneLib will support all [DaphneDSL built-in functions](/doc/DaphneDSL/Builtins.md) on matrices and frames.
-Futhermore, **we also plan to create a library of higher-level primitives** allowing users to productively implement integrated data analysis pipelines at a much higher level of abstraction.
+Furthermore, **we also plan to create a library of higher-level primitives** allowing users to productively implement integrated data analysis pipelines at a much higher level of abstraction.
 
 At the moment, the documentation is still rather incomplete.
 However, as the methods largely map to DaphneDSL built-in functions, you can find some more information in the [List of DaphneDSL built-in functions](/doc/DaphneDSL/Builtins.md), for the time being.
@@ -258,7 +258,7 @@ Logical *and* (`&&`) and *or* (`||`) operators can be used for the conditions fo
 ## Building Complex Control Structures
 
 Complex control structures like if-then-else, for-loops, while-loops and do-while-loops can be built using methods of the `DaphneContext`.
-These control structures can be used to manipulate matrices, frames, and scalars, and are lazily evaluated. Futhermore, user-defined functions can be created to build reusable code which can then be again lazily evaluated.
+These control structures can be used to manipulate matrices, frames, and scalars, and are lazily evaluated. Furthermore, user-defined functions can be created to build reusable code which can then be again lazily evaluated.
 User-defined functions can manipulate matrices, frames, and scalars, too.
 
 ### `DaphneContext` API Reference
@@ -297,7 +297,7 @@ User-defined functions can manipulate matrices, frames, and scalars, too.
 - **`@function`**, **`function`**`(callback)`
     * callback: Callable
         - This function requires adding typing hints in case the arguments are supposed to be handled as `Scalar` or `Frame`, all arguments without hints are handled as `Matrix` objects.
-          Hinting `Matrix` is optional.
-          Wrong or missing typing hints can trigger errors before and during computing (lazy evaluation).
+            Hinting `Matrix` is optional.
+            Wrong or missing typing hints can trigger errors before and during computing (lazy evaluation).
     * returns: Tuple[VALID_COMPUTED_TYPES]  *(length equals the return values of callback)*
     * if the decorator `@function` is used the *callback* is defined right below it like regular Python method

--- a/doc/DaphneLib/Overview.md
+++ b/doc/DaphneLib/Overview.md
@@ -27,16 +27,16 @@ Users can easily mix and match DAPHNE computations with other Python libraries a
 **Provide DAPHNE:**
 
 - `libdaphnelib.so` and `libAllKernels.so` must be present
-  - Building the project with `./build.sh --target daphnelib` achieves this (this creates a `lib` dir in the `daphne` project root)
-  - OR use the `lib/` dir of a release
+    - Building the project with `./build.sh --target daphnelib` achieves this (this creates a `lib` dir in the `daphne` project root)
+    - OR use the `lib/` dir of a release
 - `LD_LIBRARY_PATH` must be set (e.g., executed from `daphne/`: `export LD_LIBRARY_PATH=$PWD/lib:$LD_LIBRARY_PATH`)
 - Set the environment variable `DAPHNELIB_DIR_PATH` to the path were the libraries (`*.so` files) are placed, e.g., `path/to/daphne/lib/`
 
 ## Installation
 
 - There are two options to install the Python package `daphne` (DaphneLib)
-  - Via github url: `pip install git+https://github.com/daphne-eu/daphne.git@main#subdirectory=src/api/python`
-  - OR clone the DAPHNE repository and install from source files: `pip install daphne/src/api/python`
+    - Via GitHub url: `pip install git+https://github.com/daphne-eu/daphne.git@main#subdirectory=src/api/python`
+    - OR clone the DAPHNE repository and install from source files: `pip install daphne/src/api/python`
 - *Recommendation:* Use a virtual environment
 
     ```shell
@@ -83,7 +83,7 @@ Here, we generate some random data in numpy and import it to DAPHNE **(3)**.
 Based on DAPHNE matrices/frames/scalars (and Python scalars), complex expressions can be defined **(4)** using Python operators (such as `-` and `/` above) and methods on the DAPHNE matrices/frames/scalars (such as `mean()` and `stddev()` above).
 The results of these expressions again represent DAPHNE matrices/frames/scalars.
 
-Up until here, no acutal computations are performed.
+Up until here, no actual computations are performed.
 Instead, an internal DAG (directed acyclic graph) representation of the computation is built.
 When calling `compute()` on the result **(5)**, the DAG is automatically optimized and executed by DAPHNE.
 This principle is known as *lazy evaluation*.
@@ -231,7 +231,7 @@ X.sqrt()
 X.cbind(Y)
 ```
 
-## Data Exchange with other Python Libraries
+## Data Exchange with Other Python Libraries
 
 DaphneLib supports efficient data exchange with other well-known Python libraries, in both directions.
 The data transfer from other Python libraries to DaphneLib can be triggered through the `from_...()` methods of the `DaphneContext` (e.g., `from_numpy()`).

--- a/doc/Deploy.md
+++ b/doc/Deploy.md
@@ -16,43 +16,41 @@ limitations under the License.
 
 # Deploying
 
-DAPHNE Packaging, Distributed Deployment, and Management
-
 ## Overview
 
-This file explains the deployment of the **Daphne system**, on HPC with SLURM or manually through SSH, and highlights the excerpts from descriptions of functionalities in [deploy/](/deploy/) directory (mostly [deploy-distributed-on-slurm.sh](/deploy/deploy-distributed-on-slurm.sh)):
+This file explains the deployment of **DAPHNE**, on HPC with Slurm or manually through SSH, and highlights the excerpts from descriptions of functionalities in the [deploy/](/deploy/) directory (mostly [deploy-distributed-on-slurm.sh](/deploy/deploy-distributed-on-slurm.sh)):
 
-- compilation of the Singularity image,
-- compilation of Daphne (and the Daphne DistributedWorker) within the Singularity image,
-- packaging compiled Daphne,
-- packaging compiled Daphne with user payload as a payload package,
-- uploading the payload package to an HPC platform,
-- starting and managing DAPHNE workers on HPC platforms using SLURM,
-- executing DAPHNE on HPC using SLURM,
-- collection of logs from daphne execution, and
-- cleanup of worker environments and payload deployment.
+- compilation of the Singularity image
+- compilation of DAPHNE (and the DAPHNE DistributedWorker) within the Singularity image
+- packaging compiled DAPHNE
+- packaging compiled DAPHNE with user payload as a payload package
+- uploading the payload package to an HPC platform
+- starting and managing DAPHNE workers on HPC platforms using Slurm
+- executing DAPHNE on HPC using Slurm
+- collection of logs from DAPHNE execution
+- cleanup of worker environments and payload deployment
 
 ## Background
 
-Daphne's distributed system consists of a single coordinator and multiple DistributedWorkers (you can read more about Distributed DAPHNE [here](DistributedRuntime.md#Background)).  For now, in order to execute Daphne in a distributed fashion, we need to deploy DistributedWorkers manually. Coordinator gets the worker's addresses
-through an environmental variable.
+DAPHNE's distributed runtime consists of a single coordinator and multiple DistributedWorkers (see the documentation of the [distributed runtime](/doc/DistributedRuntime.md#Background) for more information). For now, in order to execute DAPHNE in a distributed fashion, we need to deploy DistributedWorkers manually. The coordinator gets the worker's addresses
+through an environment variable.
 
-`deployDistributed.sh` manually connects to machines with SSH and starts up DistributedWorker processes. On the other hand the [deploy-distributed-on-slurm.sh](/deploy/deploy-distributed-on-slurm.sh) packages and starts Daphne on a target HPC platform, and is tailored to the communication required with Slurm and the target HPC platform.
+`deployDistributed.sh` manually connects to machines with SSH and starts up DistributedWorker processes. On the other hand, the script [deploy-distributed-on-slurm.sh](/deploy/deploy-distributed-on-slurm.sh) packages and starts DAPHNE on a target HPC platform, and is tailored to the communication required with Slurm and the target HPC platform.
 
-## Deploying without Slurm support
+## Deploying without Slurm Support
 
-**`deployDistributed.sh`** can be used to manually connect to a list of machines and remotely start up workers, get status of running workers or terminate distributed worker processes. This script depends only on an SSH client/server and does not require any use of a resource management tool (e.g. SLURM). With this script you can:
+**`deployDistributed.sh`** can be used to manually connect to a list of machines and remotely start up workers, get status of running workers or terminate distributed worker processes. This script depends only on an SSH client/server and does not require any use of a resource management tool (e.g. Slurm). With this script you can:
 
 - build and deploy DistributedWorkers to remote machines
 - start workers
 - check status of running workers
 - kill workers
 
-Workers' own IPs and ports to listen to, can be specified inside the script, or with `--peers [IP[:PORT]],[IP[:PORT]],...`. Default port for all workers is 50000, but this can also be specified inside the script or with `-p,--port PORT`. If running on same machine (e.g. localhost), different ports must be specified.
+Workers' own IPs and ports to listen to, can be specified inside the script, or with `--peers [IP[:PORT]],[IP[:PORT]],...`. The default port for all workers is 50000, but this can also be specified inside the script or with `-p,--port PORT`. If running on the same machine (e.g., localhost), different ports must be specified.
 
-With `--deploy` the script builds `DistributedWorker` executable (`./build.sh --target DistributedWorker`), compresses `build`, `lib` and `bin` folders and uses `scp` and `ssh` to send and decompress at remote machines, inside the directory specified by `--pathToBuild` (default `~/DaphneDistributedWorker/`). If running workers on localhost, `PATH_TO_BUILD` can be set `/path/to/daphne` and provided `DistributedWorker` is built, `--deploy` is not nessecary.
+With `--deploy` the script builds the `DistributedWorker` executable (`./build.sh --target DistributedWorker`), compresses the `build`, `lib` and `bin` folders and uses `scp` and `ssh` to send to and decompress at remote machines, inside the directory specified by `--pathToBuild` (default `~/DaphneDistributedWorker/`). If running workers on localhost, `PATH_TO_BUILD` can be set `/path/to/daphne` and provided `DistributedWorker` is built, `--deploy` is not nessecary.
 
-Ssh username must be specified inside the script. For now the script assumes all remote machines can be accessed with the same `username`, `id_rsa` key and ssh port (default 22).
+The SSH username must be specified inside the script. For now the script assumes all remote machines can be accessed with the same `username`, `id_rsa` key and SSH port (default 22).
 
 Usage example:
 
@@ -63,13 +61,13 @@ $ ./deployDistributed.sh --deploy --pathToBuild /path/to/dir --peers localhost:5
 $ ./deployDistributed.sh -r # (Uses default peers and path/to/build/ to start workers)
 ```  
 
-## Deploying with Slurm support
+## Deploying with Slurm Support
 
-Building the Daphne system (to be later deployed on distributed nodes) can be done with a Singularity container. The Singularity container can be built on the utilized HPC. [deployDistributed.sh](/deploy/deployDistributed.sh) sends executables on each node, assuming there are different storages for each node. This might cause unnecessary overwrites if the workers use same mounted user storage (e.g. HPC environments with distributed storages). Instead [deploy-distributed-on-slurm.sh](/deploy/deploy-distributed-on-slurm.sh) should be used for such cases. The latter also automatically generates the environmental variable `PEERS` from Slurm.
+Building DAPHNE (to be later deployed on distributed nodes) can be done with a Singularity container. The Singularity container can be built on the utilized HPC. [deployDistributed.sh](/deploy/deployDistributed.sh) sends executables to each node, assuming there are different storages for each node. This might cause unnecessary overwrites if the workers use the same mounted user storage (e.g. HPC environments with distributed storages). Instead, [deploy-distributed-on-slurm.sh](/deploy/deploy-distributed-on-slurm.sh) should be used for such cases. The latter also automatically generates the environment variable `PEERS` from Slurm.
 
-### How to use `deploy-distributed-on-slurm.sh` for DAPHNE Packaging, Distributed Deployment, and Management using Slurm
+### How to Use `deploy-distributed-on-slurm.sh` for DAPHNE Packaging, Distributed Deployment, and Management Using Slurm
 
-This explains how to set up the Distributed Workers on a HPC platform, and it also briefly comments on what to do afterwards (how to run, manage, stop, and clean it).
+This section explains how to set up the DistributedWorkers on a HPC platform and briefly comments on what to do afterwards (how to run, manage, stop, and clean it).
 Commands, with their parameters and arguments, are hence described below for deployment with [deploy-distributed-on-slurm.sh](/deploy/deploy-distributed-on-slurm.sh).
 
 ```shell
@@ -119,7 +117,7 @@ Logs can be found at [pathToBuild]/logs.
 
 ### Short Examples
 
-The following list presents few examples about how to use the [deploy-distributed-on-slurm.sh](/deploy/deploy-distributed-on-slurm.sh) command.
+The following list presents a few examples about how to use the [deploy-distributed-on-slurm.sh](/deploy/deploy-distributed-on-slurm.sh) command.
 
 These comprise more hands-on documentation about deployment, including tutorial-like explanation examples about how to package, distributively deploy, manage, and execute workloads using DAPHNE.
 
@@ -129,43 +127,43 @@ These comprise more hands-on documentation about deployment, including tutorial-
     ./deploy-distributed-on-slurm.sh singularity && ./deploy-distributed-on-slurm.sh build && ./deploy-distributed-on-slurm.sh package
     ```
 
-1. Transfers a package to the target platform through OpenSSH, using login node HPC, user hpc, and identify key hpc.pub.
+1. Transfers a package to the target platform through OpenSSH, using login node `HPC`, user `hpc`, and identify key `hpc.pub`.
 
     ```shell
     ./deploy-distributed-on-slurm.sh --login HPC --user hpc -i ~/.ssh/hpc.pub transfer
     ```
 
-1. Using login node HPC, accesses the target platform and starts workers on remote machines.
+1. Using login node `HPC`, accesses the target platform and starts workers on remote machines.
 
     ```shell
     ./deploy-distributed-on-slurm.sh -l HPC start
     ```
 
-1. Runs one request (script called example-time.daphne) on the deployment using 1024 cores, login node HPC, and default OpenSSH configuration.
+1. Runs one request (script called `example-time.daphne`) on the deployment using `1024` cores, login node `HPC`, and the default OpenSSH configuration.
 
     ```shell
     ./deploy-distributed-on-slurm.sh -l HPC -n 1024 run example-time.daphne
     ```
 
-1. Executes one request (DaphneDSL script input from standard input) at a running deployed platform, using default singularity/srun configurations.
+1. Executes one request (DaphneDSL script input from standard input) at a running deployed platform, using default `singularity`/`srun` configurations.
 
     ```shell
     ./deploy-distributed-on-slurm.sh run
     ```
 
-1. Deploys once at the target platform through OpenSSH using default login node (localhost), then cleans.
+1. Deploys once at the target platform through OpenSSH using the default login node (localhost), then cleans.
 
     ```shell
     ./deploy-distributed-on-slurm.sh deploy -n 10
     ```
 
-1. Starts workers at a running deployed platform using custom srun arguments (2 hours dual-core with 10G memory).
+1. Starts workers at a running deployed platform using custom `srun` arguments (2 hours dual-core with 10G memory).
 
     ```shell
     ./deploy-distributed-on-slurm.sh workers -R="-t 120 --mem-per-cpu=10G --cpu-bind=cores --cpus-per-task=2"
     ```
 
-1. Executes a request with custom srun arguments (30 minutes single-core).
+1. Executes a request with custom `srun` arguments (30 minutes single-core).
 
     ```shell
     ./deploy-distributed-on-slurm.sh run -R="--time=30 --cpu-bind=cores --nodes=1 --ntasks-per-node=1 --cpus-per-task=1"
@@ -188,7 +186,7 @@ Here is a scenario usage as a longer example demo.
       git clone --recursive git@github.com:daphne-eu/daphne.git 2>&1 | tee daphne-$(date +%F-%T).log
       cd daphne/deploy
       ./deploy-distributed-on-slurm.sh singularity # creates the Singularity container image
-      ./deploy-distributed-on-slurm.sh build   # Builds the daphne codes using the container
+      ./deploy-distributed-on-slurm.sh build       # Builds the daphne codes using the container
     }
     compile
     ```

--- a/doc/DistributedRuntime.md
+++ b/doc/DistributedRuntime.md
@@ -16,56 +16,53 @@ limitations under the License.
 
 # Distributed Runtime
 
-Running DAPHNE on the Distributed Runtime
-
 ## Background
 
-Daphne supports execution in a distributed fashion. Utilizing the Daphne Distributed Runtime does not require any changes to the DaphneDSL script.
+DAPHNE supports execution in a distributed fashion. Utilizing the DAPHNE distributed runtime does not require any changes to the DaphneDSL script.
 Similar to the local vectorized engine ([here, section 4](https://daphne-eu.eu/wp-content/uploads/2022/08/D2.2-Refined-System-Architecture.pdf)), the compiler automatically fuses operations and creates pipelines for the distributed runtime, which then uses multiple distributed nodes (workers) that work on their local data, while a main node, the coordinator, is responsible for transferring the data and code to be executed.
-As mentioned above, changes at DaphneDSL code are not needed, however the user is required to start the workers, either manually or using an HPC tool as SLURM (scripts that start the workers locally or remotely, natively or not, can be found [here](/deploy)).
-<!-- TODO: add link to documentation. -->
+As mentioned above, changes to the DaphneDSL code are not needed, however the user is required to start the workers, either manually or using an HPC tool such as Slurm (see the documentation on [deployment](/deploy) for scripts that start the workers locally or remotely, natively or not).
 
 ## Scope
 
 This document focuses on:
 
 - how to start distributed workers
-- executing Daphne scripts on the distributed runtime
+- executing DaphneDSL scripts on the distributed runtime
 - DAPHNE's distributed runtime has two different backends. This page explains how things work with the **gRPC backend**.
 A brief introduction to the other backend using **OpenMPI** can be viewed in [this document](MPI-Usage.md).
 
-## Build the Daphne prototype
+## Build DAPHNE
 
-First you need to build the Daphne prototype. This doc assumes that you already built Daphne and can run it locally. If you need help building or running Daphne see [here](/doc/GettingStarted.md).
+First you need to build DAPHNE. This document assumes that you have already built DAPHNE and can run it locally. If you need help building or running DAPHNE see the guidelines for [getting started](/doc/GettingStarted.md).
 
 ## Building the Distributed Worker
 
-The Daphne distributed worker is a different executable which can be build using the build-script and providing the `--target` argument:
+The DAPHNE distributed worker is a different executable which can be built using the build script by providing the `--target` argument:
 
 ```bash
 ./build.sh --target DistributedWorker
 ```
 
-## Start distributed workers
+## Start Distributed Workers
 
-Before executing Daphne on the distributed runtime, worker nodes must first be up and running. You can start a distributed worker within the Daphne prototype directory as follows:
+Before executing DAPHNE on the distributed runtime, worker nodes must first be up and running. You can start a distributed worker within the DAPHNE directory as follows:
 
 ```bash
 # IP:PORT is the IP and PORT the worker server will be listening too
-./bin/DistributedWorker IP:PORT 
+bin/DistributedWorker IP:PORT 
 ```
 
-There are [scripts](/deploy) that automate this task and can help running multiple workers at once locally or even utilizing tools (like SLURM) in HPC environments.
+There are [scripts](/deploy) that automate this task and can help running multiple workers at once locally or even utilizing tools (like Slurm) in HPC environments.
 
 Each worker can be left running and reused for multiple scripts and pipeline executions (however, for now they might run into memory issues, see **Limitations** section below).
 
 Each worker can be terminated by sending a `SIGINT` (Ctrl+C) or by using the scripts mentioned above.
 
-## Set up environmental variables
+## Set up Environment Variables
 
-After setting up the workers, before we run Daphne we need to specify which IPs
-and ports the workers are listening too. For now we use an environmental variable called
-`DISTRIBUTED_WORKERS` where we list IPs and ports of the workers separated by a comma.
+After setting up the workers, before we run DAPHNE we need to specify which IPs
+and ports the workers listen to. For now, we use an environment variable called
+`DISTRIBUTED_WORKERS` where we list IPs and ports of the workers separated by comma.
 
 ```bash
 # Example for 2 workers.
@@ -74,51 +71,43 @@ and ports the workers are listening too. For now we use an environmental variabl
 export DISTRIBUTED_WORKERS=localhost:5000,localhost:5001
 ```
 
-## Run DAPHNE using the distributed runtime
+## Run DAPHNE Using the Distributed Runtime
 
-Now that we have all workers up and running and the environmental variable is set we can run Daphne. We enable the distributed runtime by specifying the flag argument `--distributed`.
+Now that we have all workers up and running and the environment variable is set, we can run DAPHNE. We enable the distributed runtime by specifying the flag `--distributed`.
 
-**(*)** Note that we execute Daphne from the same bash shell we've set up the environmental variable  `DISTRIBUTED_WORKERS`.
+**(*)** Note that we execute DAPHNE from the same bash shell we've set up the environment variable  `DISTRIBUTED_WORKERS`.
 
 ```bash
-./bin/daphne --distributed ./example.script
+bin/daphne --distributed ./example.script
 ```
 
-For now only asynchronous-gRPC is implemented as a distributed backend and selection is hardcoded [here](/src/runtime/distributed/coordinator/kernels/DistributedWrapper.h#L73).
+For now, only asynchronous gRPC is implemented as a distributed backend and the backend selection is hardcoded in `/src/runtime/distributed/coordinator/kernels/DistributedWrapper.h`.
 <!-- 
 TODO: PR #436 provides support for MPI and implements a cli argument for selecting a distributed backend. This section will be updated once #436 is merged.
  -->
 
 ## Example
 
-On one terminal with start up a Distributed Worker:
+On one terminal we start up a distributed worker:
 
 ```bash
-$./bin/DistributedWorker localhost:5000
+$ bin/DistributedWorker localhost:5000
 Started Distributed Worker on `localhost:5000`
 ```
 
-On another terminal we set the environment variable and execute script [`distributed.daph`](/scripts/examples/distributed.daph):
+On another terminal we set the environment variable and execute the script [`distributed.daph`](/scripts/examples/distributed.daph):
 
 ```bash
 $ export DISTRIBUTED_WORKERS=localhost:5000
-$ ./bin/daphne --distributed ./scripts/example/distributed.daph
+$ bin/daphne --distributed ./scripts/example/distributed.daph
 ```
 
-## Current limitations
+## Current Limitations
 
-Distributed Runtime is still under development and currently there are various limitations. Most of these limitations will be fixed in the future.
+The distributed runtime is still under development and currently there are various limitations. Most of these limitations will be fixed in the future.
 
-- Distributed runtime for now heavily depends on the vectorized engine of Daphne and how pipelines are
-created and multiple operations are fused together (more [here - section 4](https://daphne-eu.eu/wp-content/uploads/2022/08/D2.2-Refined-System-Architecture.pdf)). This causes some limitations related to pipeline creation (e.g. [not supporting pipelines with different result outputs](/issues/397) or pipelines with no outputs).
-- For now distributed runtime only supports `DenseMatrix` types and value types `double` - `DenseMatrix<double>` (issue [#194](/issues/194)).
-- A Daphne pipeline input might exist multiple times in the input array. For now this is not supported. In the future similar pipelines will simply omit multiple pipeline inputs and each one will be provided only once.
+- Distributed runtime for now heavily depends on the vectorized engine and how pipelines are
+created and multiple operations are fused together (more [here - section 4](https://daphne-eu.eu/wp-content/uploads/2022/08/D2.2-Refined-System-Architecture.pdf)). This causes some limitations related to pipeline creation (e.g. [not supporting pipelines with different result outputs](https://github.com/daphne-eu/daphne/tree/main/issues/397) or pipelines with no outputs).
+- For now, the distributed runtime only supports the `DenseMatrix` data type and the `double` value type, i.e., `DenseMatrix<double>` (issue [#194](https://github.com/daphne-eu/daphne/tree/main/issues/194)).
+- A DAPHNE pipeline input might exist multiple times in the input array. For now, this is not supported. In the future, similar pipelines will simply omit multiple pipeline inputs and each one will be provided only once.
 - Garbage collection at worker (node) level is not implemented yet. This means that after some time the workers can fill up their memory completely, requiring a restart.
-
-## What Next?
-
-You might want to have a look at
-
-- the [distributed runtime development guideline](/doc/development/ExtendingDistributedRuntime.md)
-- the [contribution guidelines](/CONTRIBUTING.md)
-- the [open distributed related issues](https://github.com/daphne-eu/daphne/issues?q=is%3Aopen+is%3Aissue+label%3ADistributed)

--- a/doc/Extensions.md
+++ b/doc/Extensions.md
@@ -40,11 +40,11 @@ All files shown below can be found in `/scripts/examples/extensions/myKernels/`.
 A kernel extension consists at least of the following:
 
 - A *C++ source file*, which includes some essential DAPHNE headers and defines one or multiple kernel functions.
-  The kernel functions have to follow a certain interface **(*)** and have `extern "C"` linkage.
-  Within the kernel functions, extension developers have a lot of freedom.
-  Nevertheless, we also plan to provide some best practices and helpers to make extension development more productive.
+    The kernel functions have to follow a certain interface **(*)** and have `extern "C"` linkage.
+    Within the kernel functions, extension developers have a lot of freedom.
+    Nevertheless, we also plan to provide some best practices and helpers to make extension development more productive.
 - A *kernel catalog JSON file*, which provides some essential information on the kernels provided in the extension, such that DAPHNE knows how to use them.
-  This information includes: the mnemonic of the DaphneIR operation **(*)**, the name of the kernel function, the list of result/argument types, the backend (e.g. CPU or a specific hardware accelerator), and the path to the shared library of the extension (relative to this JSON file).
+    This information includes: the mnemonic of the DaphneIR operation **(*)**, the name of the kernel function, the list of result/argument types, the backend (e.g. CPU or a specific hardware accelerator), and the path to the shared library of the extension (relative to this JSON file).
 - To build the extension, it is recommendable (but not required) to include a Makefile or similar as well.
 
 **(*)** *We will add a concrete list of DaphneIR operations for which custom kernels can be added later.

--- a/doc/FPGAconfiguration.md
+++ b/doc/FPGAconfiguration.md
@@ -16,44 +16,52 @@ limitations under the License.
 
 # FPGA Configuration
 
-FPGA configuration for usage in DAPHNE
+## System Requirements
 
-## System requirments
+Using DAPHNE's build script with FPGA kernels support requires the additional `QUARTUSDIR` environment variable to be defined.
+An example command is presented in `fpga-build-env.sh` or in the following command:
 
-Daphne build script for FPGA kernels support requires additional QUARTUSDIR system variable definition.
-Example command is presented in fpga-build-env.sh or in the following command:
+```bash
+export QUARTUSDIR=/opt/intel/intelFPGA_pro/21.4
+```
 
-`export QUARTUSDIR=/opt/intel/intelFPGA_pro/21.4`
+To build DAPHNE with FPGA kernels support, the flag `--fpgaopencl` has to be used:
 
-To build the Daphne with the FPGA support `-fpgaopencl` flag has to be used:
+```bash
+./build.sh --fpgaopencl
+```
 
-`./build.sh --fpgaopenc`
+To run the pre-compiled FPGA OpenCL kernels included in the DAPHNE repository, an installed and configured FPGA device is required.
+Our example kernels have been tested using an [Intel(R) PAC D5005 card](https://www.intel.com/content/www/us/en/products/sku/193921/intel-fpga-pac-d5005/specifications.html).
 
-To run developed or precompiled, included in Daphne repository FPGA OpenCL kernels an installedand configured  FPGA device is required.
-Our example kernels have been tested using [Intel(R) PAC D5005 card](https://www.intel.com/content/www/us/en/products/sku/193921/intel-fpga-pac-d5005/specifications.html)
-
-DAPHNE contains some example linear algebra kernels developed using [T2SP framework](https://github.com/IntelLabs/t2sp/blob/master/README.md).
-Example precompiled FPGA kernels can be usedon  DAPHNE DSL description level.
-To prepare the system for the precompiled FPGA kernels some FPGA and OpenCL system variables are required.
-The easiest way to set up required varables is to use the init_opencl.sh script from installed Intel(R) Quartus sowtware or from the
+DAPHNE contains some example linear algebra kernels developed using the [T2SP framework](https://github.com/IntelLabs/t2sp/blob/master/README.md).
+The example pre-compiled FPGA kernels can be used at DaphneDSL level.
+To prepare the system for the pre-compiled FPGA kernels, some FPGA and OpenCL environment variables are required.
+The easiest way to set up the required variables is to use the `init_opencl.sh` script from installed Intel(R) Quartus software or from the
 Intel(R) OpenCL RTE or Intel(R) OpenCL SDK packages.
 
 Example script usage:
-`source /opt/intel/intelFPGA_pro/21.4/hld/init_opencl.sh`
 
-For additional details please look into the [Intel guide](https://www.intel.com/content/www/us/en/docs/programmable/683550/18-1/standard-edition-getting-started-guide.html)
-or [SDK for openCL](https://www.intel.com/content/www/us/en/software/programmable/sdk-for-opencl/overview.html).
+```bash
+source /opt/intel/intelFPGA_pro/21.4/hld/init_opencl.sh
+```
 
-### Precompiled FPGA Kernels
+For additional details, see the [Intel guide](https://www.intel.com/content/www/us/en/docs/programmable/683550/18-1/standard-edition-getting-started-guide.html)
+or the [SDK for OpenCL](https://www.intel.com/content/www/us/en/software/programmable/sdk-for-opencl/overview.html).
 
-To use a precompiled FPGA kernel a FPGA image is required (*.aocx). FPGA device has to programmed with particular image which contains required kernel implementation.
-Example FPGA programming command using example FPGA image:
+### Pre-compiled FPGA Kernels
 
-`aocl program acl0 src/runtime/local/kernels/FPGAOPENCL/bitstreams/sgemm.aocx`
+To use a pre-compiled FPGA kernel, an FPGA image is required (`*.aocx`). The FPGA device has to be programmed with a particular image which contains the required kernel implementation.
+An example FPGA programming command using example FPGA image:
 
-Additionally the BITSTREAM variable has to be defind in the system.
-Please look into the following example:
+```bash
+aocl program acl0 src/runtime/local/kernels/FPGAOPENCL/bitstreams/sgemm.aocx
+```
 
-`export BITSTREAM=src/runtime/local/kernels/FPGAOPENCL/bitstreams/sgemm.aocx`
+Additionally, the `BITSTREAM` environment variable has to be defind in the system as follows:
 
-When another FPGA image contains implementation for another required computational kernel then FPGA device has to be reprogrammed and BITSTREAM variable value has to be changed.
+```bash
+export BITSTREAM=src/runtime/local/kernels/FPGAOPENCL/bitstreams/sgemm.aocx
+```
+
+When another FPGA image contains an implementation for another required computational kernel, then the FPGA device has to be reprogrammed and the `BITSTREAM` environment variable has to be changed.

--- a/doc/FileMetaDataFormat.md
+++ b/doc/FileMetaDataFormat.md
@@ -16,32 +16,30 @@ limitations under the License.
 
 # Read and Write Data
 
-Reading and writing (meta) data in Daphne.
-
-When loading data with ``read()`` in a DaphneDSL script, the system expects a file with the same file name in the same
-directory as the data file with an additional extension ``.meta``. This file contains a description of meta data stored
+When loading data with `read()` in a DaphneDSL script, the system expects a file with the same file name in the same
+directory as the data file with an additional extension `.meta`. This file contains a description of meta data stored
 in JSON format.
 
 There are two slightly varying ways of specifying meta data depending on whether there is a schema for the columns (e.g.,
-a data frame - the corresponding C++ type is the Frame class) or not (this data can currently (as of version 0.1) be
+a data frame - the corresponding C++ type is the `Frame` class) or not (this data can currently be
 loaded as `DenseMatrix<VT>` or `CSRMatrix<VT>` where `VT` is the value type template parameter).
 
-If data is written from a DaphneDSL script via ``write()``, the meta data file will be written to the corresponding ``filename.meta``.
+If data is written from a DaphneDSL script via `write()`, the meta data file will be written to the corresponding `filename.meta`.
 
-## Currently supported JSON fields
+## Currently Supported JSON Fields
 
 | Name        | Expected Data | Allowed values                                                                                                                                                                                                                                                                                                                               |
 |-------------|---------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| numRows     | Integer       | # number of rows                                                                                                                                                                                                                                                                                                                             |
-| numCols     | Integer       | # number of columns                                                                                                                                                                                                                                                                                                                          |
-| valueType   | String        | ``si8, si32, si64, // signed integers (intX_t)``<br />``ui8, ui32, ui64, // unsigned integers (uintx_t)``<br />``f32, f64, // floating point (float, double)``<br /><br/>Contained within schema this may be an empty string. In this case all columns of a data frame will have the same valueType defined outside of the schema data field |
-| numNonZeros | Integer       | # number of non-zeros (optional)                                                                                                                                                                                                                                                                                                             |
+| numRows     | Integer       | number of rows                                                                                                                                                                                                                                                                                                                             |
+| numCols     | Integer       | number of columns                                                                                                                                                                                                                                                                                                                          |
+| valueType   | String        | `si8, si32, si64, // signed integers (intX_t)`<br />`ui8, ui32, ui64, // unsigned integers (uintx_t)`<br />`f32, f64, // floating point (float, double)`<br /><br/>Contained within schema this may be an empty string. In this case all columns of a data frame will have the same valueType defined outside of the schema data field |
+| numNonZeros | Integer       | number of non-zeros (optional)                                                                                                                                                                                                                                                                                                             |
 | schema      | JSON          | nested elements of "label" and "valueType" fields                                                                                                                                                                                                                                                                                            |
 | label       | String        | column name/header (optional, may be empty string "")                                                                                                                                                                                                                                                                                        |
 
 ## Matrix Example
 
-The example below describes a 2 by 4 dense matrix of double precision values.
+The example below describes a *2x4* matrix of double-precision values.
 
 ### Matrix CSV
 
@@ -63,7 +61,7 @@ The example below describes a 2 by 4 dense matrix of double precision values.
 
 ## Data Frame Example
 
-The example below describes a 2 by 2 Frame with signed integers in the first columns named foo and double precision 
+The example below describes a *2x2* frame with signed integers in the first column named foo and double-precision 
 values in the second column named bar.
 
 ### Data Frame CSV

--- a/doc/GPG-signing-keys.md
+++ b/doc/GPG-signing-keys.md
@@ -1,22 +1,37 @@
-## Providing information about GPG signing keys
+<!--
+Copyright 2025 The DAPHNE Consortium
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Providing Information about GPG Signing Keys
 
 In general see the [GitHub documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification) about generating and maintaining your GPG keys for signing commits and releases. There are also tons of how-tos and tutorials out there about GPG and its best practices (which might change over time).
 
-Here are a few pointers how to deal with your GPG keys in the context of DAPHNE. <br/>Keys need to be:
+Here are a few pointers how to deal with your GPG keys in the context of DAPHNE. Keys need to be:
+
 1. entered in your GitHub profile ([see GitHub documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)).
 2. kept up to date (remove and add again in GitHub after prolonging the expiry date).
-3. kept up to date in the ``KEYS.txt`` file in the DAPHNE repo root directory.
+3. kept up to date in the `KEYS.txt` file in the DAPHNE repo root directory.
 4. updated on third party key servers you might have used.
 
 Keyserver recommendation: As of February 2024 we recommend keyserver.ubuntu.com, keys.openpgp.org and keys.mailvelope.com. The latter two are recommended as they perform email verification. 
 
-* To export your key information to ``KEYS.txt`` use these two commands (replace ``<your-email>`` with the email address associated with your GPG key:
+* To export your key information to `KEYS.txt` use these two commands (replace `<your-email>` with the email address associated with your GPG key:
 
-``` bash
-gpg --keyid-format=0xshort --list-key --with-fingerprint <your-email> | tee -a KEYS.txt
-gpg --armor --export <your-email> | tee -a KEYS.txt
-```
+    ``` bash
+    gpg --keyid-format=0xshort --list-key --with-fingerprint <your-email> | tee -a KEYS.txt
+    gpg --armor --export <your-email> | tee -a KEYS.txt
+    ```
 
-* If you are updating your key information in ``KEYS.txt``, open that file with a text editor to remove the old key after appending the new one.
-
-
+* If you are updating your key information in `KEYS.txt`, open that file with a text editor to remove the old key after appending the new one.

--- a/doc/GettingStarted.md
+++ b/doc/GettingStarted.md
@@ -123,8 +123,6 @@ git clone https://github.com/daphne-eu/daphne.git
 
 ### 2. Download the DAPHNE Development Container Image
 
-<!-- TODO assumes X86-64 is correct -->
-
 The development container image already contains all necessary (¹) dependencies of a DAPHNE development environment as well as a useful initialization of environment variables etc., such that you don't need to worry about these things and can have a productive start.
 
 **Get the container image**
@@ -151,7 +149,7 @@ docker pull daphneeu/daphne-dev:latest_AArch64
 cd daphne
 ./containers/run-docker-example.sh
 ```
-```
+```text
 Use xyz with password Docker!0147 for SSH login
 Docker Container IP address(es):
 172.17.0.2
@@ -240,7 +238,7 @@ launching DAPHNE via Docker (see below) should work the same way as in a native 
 | gfortran                             | 9.3.0                        |                                                                                                                                         |
 | git                                  | 2.25.1                       |                                                                                                                                         |
 | java (e.g. openjdk)                  | 11 (1.7 should be fine)      |                                                                                                                                         |
-| jq                                   |                              | json commandline processor used in docker image generation scripts.                                                                     |
+| jq                                   |                              | JSON command-line processor used in docker image generation scripts.                                                                     |
 | libpfm4-dev                          | 4.10                         | This dependency is needed for profiling support [DAPHNE-#479]                                                                           |
 | gRPC                                 | 1.38.0                       |                                                                                                                                         |
 | libssl-dev                           | 1.1.1                        | Dependency introduced while optimizing grpc build (which used to build ssl unnecessarily)                                               |
@@ -266,13 +264,13 @@ launching DAPHNE via Docker (see below) should work the same way as in a native 
 
 - about 7.5 GB of free disk space to build from source (mostly due to dependencies)
 - Optional:
-  - NVidia GPU for CUDA ops (tested on Pascal and newer architectures); 8GB for CUDA SDK
-  - Intel GPU for OneAPI ops (tested on Coffeelake graphics); 23 GB for OneAPI
-  - Intel FPGA for FPGAOPENCL ops (tested on PAC D5005 accelerator); 23 GB for OneAPI
+    - NVidia GPU for CUDA ops (tested on Pascal and newer architectures); 8GB for CUDA SDK
+    - Intel GPU for OneAPI ops (tested on Coffeelake graphics); 23 GB for OneAPI
+    - Intel FPGA for FPGAOPENCL ops (tested on PAC D5005 accelerator); 23 GB for OneAPI
 
 ### Obtaining the Source Code
 
-The DAPHNE system is based on MLIR, which is a part of the LLVM monorepo.
+DAPHNE is based on MLIR, which is a part of the LLVM monorepo.
 The LLVM monorepo is included in this repository as a submodule.
 Thus, clone this repository as follows to also clone the submodule:
 
@@ -294,7 +292,7 @@ git pull && git submodule update --init --recursive
 ./pull.sh
 ```
 
-### Building the DAPHNE system
+### Building DAPHNE
 
 Simply build the system using the build-script without any arguments:
 
@@ -327,7 +325,7 @@ For convenience, you can call the following to remove them all.
 
 See [this page](/doc/development/BuildingDaphne.md) for more information.
 
-### Setting up the environment
+### Setting up the Environment
 
 As DAPHNE uses shared libraries, these need to be found by the operating system's loader to link them at runtime.
 Since most DAPHNE setups will not end up in one of the standard directories (e.g., `/usr/local/lib`), environment variables
@@ -364,9 +362,9 @@ print("Hello World!");
 ... and execute it as follows: `bin/daphne scripts/examples/hello-world.daph` (This command works if `daphne` is run
 after building from source. Omit `bin/` in the path to the DAPHNE binary if executed from the binary distribution).
 
-Optionally flags like ``--cuda`` can be added after the daphne command and before the script file to activate support
+Optionally flags like `--cuda` can be added after the `daphne` command and before the script file to activate support
 for accelerated ops (see [software requirements](#software) above and [build instructions](development/BuildingDaphne.md)).
-For further flags that can be set at runtime to activate additional functionality, run ``daphne --help``.
+For further flags that can be set at runtime to activate additional functionality, run `daphne --help`.
 
 ### Building and Running with Containers
 
@@ -406,7 +404,7 @@ On the top-level, there are the following directories:
 - `bin`: after compilation, generated binaries will be placed here (e.g., daphne)
 - `build`: temporary build output
 - [`containers`:](/containers) scripts and configuration files to get/build/run with Docker or Singularity containers
-- [`deploy`:](/deploy) shell scripts to ease deployment in SLURM clusters
+- [`deploy`:](/deploy) shell scripts to ease deployment in Slurm clusters
 - [`doc`:](/doc) documentation written in markdown (e.g., what you are reading at the moment)
 - `lib`: after compilation, generated library files will be placed here (e.g., libAllKernels.so, libCUDAKernels.so, ...)
 - [`scripts`:](/scripts) a collection of algorithms and examples written in DAPHNE's own domain specific language ([DaphneDSL](/doc/DaphneDSL/LanguageRef.md))

--- a/doc/MPI-Usage.md
+++ b/doc/MPI-Usage.md
@@ -18,30 +18,28 @@ limitations under the License.
 
 About employing MPI as a distributed runtime backend.
 
-The DAPHNE runtime system is designed with the goal of supporting various distributed runtime that relies on various technologies, e.g. MPI and RPC.
+The DAPHNE runtime is designed with the goal of supporting various distributed backends that rely on various technologies, e.g. MPI and RPC.
 
-This document shows how a DAPHNE user can execute DAPHNE scripts on a distributed computing environment with the MPI backend implementation of the DAPHNE runtime system.
-This document assumes that the DAPHNE was build with the `--mpi` options, if this is not the case please rebuild DAPHNE with the `--mpi` option
-```./build.sh --mpi```
+This document shows how a DAPHNE user can execute DaphneDSL scripts on a distributed computing environment with the MPI backend of the DAPHNE runtime.
+This document assumes that DAPHNE was built with the `--mpi` option, i.e., by `./build.sh --mpi`.
 
-The DAPHNE build script uses [Open MPI](https://www.open-mpi.org/).
-The DAPHNE build script does not configure the Open MPI installation with the SLURM support option.
-For users who want to add the SLURM, please visit the [Open MPI](https://www.open-mpi.org/) documentation (adding ```--with-slurm``` to the build command of the Open MPI libbrary) and edit the DAPHNE build script.
-Also, users who wants to use other MPI implementations e.g., Intel MPI may edit the corresponding part in the DAPHNE build script.
+DAPHNE's build script uses [Open MPI](https://www.open-mpi.org/).
+It does not configure the Open MPI installation with the Slurm support option.
+For users who want to add Slurm, please visit the [Open MPI](https://www.open-mpi.org/) documentation (adding `--with-slurm` to the build command of the Open MPI library) and edit the DAPHNE build script.
+Also, users who want to use other MPI implementations, e.g., Intel MPI may edit the corresponding part in the DAPHNE build script.
 
 ## When DAPHNE is Installed Natively (w/o Container)
 
-1. Ensure that your system knows about the installed MPI  
-    -- The ```PATH``` and ```LD_LIBRARY_PATH```environment variable has to be updated as follows  
+1. Ensure that your system knows about the installed MPI: The `PATH` and `LD_LIBRARY_PATH`environment variables have to be updated as follows:
 
     ```bash
     export PATH=$PATH:<DAPHNE_INSTALLATION>/thirdparty/installed/bin/
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:<DAPHNE_INSTALLATION>//thirdparty/installed/lib/ 
     ```
 
-    Please do not forget to replace `<DAPHNE_INSTALLATION>` with the actual path
+    Please do not forget to replace `<DAPHNE_INSTALLATION>` with the actual path.
 
-1. Run basic example @ ```/examples/matrix_addition_for_mpi.daph``` as follows
+1. Run the basic example `scripts/examples/matrix_addition_for_mpi.daph` as follows:
 
     ```bash
     mpirun -np 10 ./bin/daphne --distributed --dist_backend=MPI scripts/examples/matrix_addition_for_mpi.daph
@@ -49,25 +47,25 @@ Also, users who wants to use other MPI implementations e.g., Intel MPI may edit 
 
 The command above executes 10 processes **locally** on one machine.
 
-In order to run on **a distributed system**, you need to provide the machine names or the machinefile which contains the machine names.
-For instance assuming that ```my_hostfile``` is a text file that contains machine names
+In order to run on **a distributed system**, you need to provide the machine names or the file which contains the machine names.
+For instance, assuming that `my_hostfile` is a text file that contains machine names, execute the following command:
 
 ```bash
-mpirun -np 10 --hostfile my_hostfile  ./bin/daphne --distributed --dist_backend=MPI scripts/examples/matrix_addition_for_mpi.daph
+mpirun -np 10 --hostfile my_hostfile ./bin/daphne --distributed --dist_backend=MPI scripts/examples/matrix_addition_for_mpi.daph
 ```
 
-The command above starts 10 processes distributed on following the hosts in the my_hostfile.
-For more options, please check the [Open MPI documentation](https://www.open-mpi.org/faq/?category=running#mpirun-hostfile).
+The command above starts 10 processes distributed on the hosts specified in the file `my_hostfile`.
+For more options, please see the [Open MPI documentation](https://www.open-mpi.org/faq/?category=running#mpirun-hostfile).
 
-From a DAPHNE runtime point of view, the ```--distributed``` option tells the DAPHNE runtime system to utilize the distributed backend, while the ```--dist_backend=MPI```
-indicate the type of the backend implementation.
+From a DAPHNE runtime point of view, the `--distributed` option tells the DAPHNE runtime to utilize the distributed backend, while the option `--dist_backend=MPI`
+indicates the type of the backend implementation.
 
-## When DAPHNE is Installed with Containers (e.g. singularity)
+## When DAPHNE is Installed with Containers (e.g. Singularity)
 
-The main difference is that the mpirun command is called at the level of the container as follows
+The main difference is that the `mpirun` command is called at the level of the container as follows:
 
 ```bash
-mpirun -np 10 singularity exec <singularity-image> daphne/bin/daphne --distributed   --dist_backend=MPI --vec --num-threads=2 daphne/scripts/examples/matrix_addition_for_mpi.daph
+mpirun -np 10 singularity exec <singularity-image> daphne/bin/daphne --distributed --dist_backend=MPI --vec --num-threads=2 daphne/scripts/examples/matrix_addition_for_mpi.daph
 ```
 
-Please do not forget to replace `<singularity-image>` with the actual singularity image.
+Please do not forget to replace `<singularity-image>` with the actual Singularity image.

--- a/doc/Profiling.md
+++ b/doc/Profiling.md
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-# Profiling DAPHNE using PAPI
+# Profiling DAPHNE Using PAPI
 
-You can profile your DAPHNE script by using the ```--enable-profiling``` CLI
+You can profile your DaphneDSL script by using the `--enable-profiling` CLI
 switch.
 Note that profiling is only available if DAPHNE was built *without* the `--no-papi` flag.
 
@@ -26,17 +26,17 @@ profiling library, specifically the
 
 When run with profiling enabled, the DAPHNE compiler will generate code that
 automatically starts and stops profiling (via PAPI) at the start and end of the
-DAPHNE script.
+DaphneDSL script.
 
 You can configure which events to profile via the `PAPI_EVENTS`
-environmental variable, e.g.:
+environment variable, e.g.:
 
 ```bash
-$ PAPI_EVENTS="perf::CYCLES,perf::INSTRUCTIONS,perf::CACHE-REFERENCES,perf::CACHE MISSES,perf::BRANCHES,perf::BRANCH-MI SSES" PAPI_REPORT=1 ./daphne --enable-profiling script.daph
+$ PAPI_EVENTS="perf::CYCLES,perf::INSTRUCTIONS,perf::CACHE-REFERENCES,perf::CACHE MISSES,perf::BRANCHES,perf::BRANCH-MI SSES" PAPI_REPORT=1 bin/daphne --enable-profiling script.daph
 ```
 
 For more details about the supported events as well as other PAPI-HL configuration
-options you can check the
+options you can read the
 [PAPI HL API documentation](https://github.com/icl-utk-edu/papi/wiki/PAPI-HL#overview-of-environment-variables).
 You can also get a list of the supported events on your machine via the
 `papi_native_avail` PAPI utility (included in the `papi-tools` package

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,3 +1,19 @@
+<!--
+Copyright 2025 The DAPHNE Consortium
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 # Overview
 
 - [Getting Started](/doc/GettingStarted.md)

--- a/doc/ReleaseScripts.md
+++ b/doc/ReleaseScripts.md
@@ -16,27 +16,33 @@ limitations under the License.
 
 # Release Scripts
 
-How to use the release scripts to create binary artifacts
-
 This is a quick write-up of how the scripts to create a binary release artifact are meant to be used.
 
-The release.sh script will call pack.sh which will call build.sh and test.sh. Only if testing completes successfully, the artifact, a gzipped tar archive (format open for discussion) is created. The command after ``--githash`` fetches the git hash of the current commit. The script checks out this git hash and restores the current commit after successful completion. This is a bit of a shortcoming as you have to issue a manual ``git checkout -`` if the script fails and terminates early.
+The `release.sh` script calls `pack.sh` which calls `build.sh` and `test.sh`. Only if testing completes successfully, the artifact, a gzipped tar archive (format open for discussion) is created. The command after `--githash` fetches the git hash of the current commit. The script checks out this git hash and restores the current commit after successful completion. This is a bit of a shortcoming as you have to issue a manual `git checkout -` if the script fails and terminates early.
 
 ## Signing
 
 The release manager will have to sign the artifacts to verify that the provided software has been created by that person.
 To create an appropriate GPG key, [these instructions](GPG-signing-keys.md) can be adapted to our needs. The
-keys of Daphne release managers will be provided in [this file](/KEYS.txt). Ideally, future release managers sign each others keys. Key signing is a form of showing
+keys of DAPHNE release managers will be provided in [KEYS.txt](/KEYS.txt). Ideally, future release managers sign each other's keys. Key signing is a form of showing
 that the one key owner trusts the other.
 
 ## The Procedure (Preliminary for v0.1)
 
-1. Get into a bash shell and change to your working copy (aka daphne root) directory.
-1. **Create the artifacts (plain Daphne):** ``./release.sh --version 0.1 --githash `git rev-parse HEAD` ``
-1. **Create additional artifacts with extra features compiled in:**<br /> ``./release.sh --version 0.1 --githash `git rev-parse HEAD` --feature cuda``
-<br />Note that this adds additional constraints on the binaries (e.g., if CUDA support is compiled in, the executable will fail to load on a system without the CUDA SDK properly installed)_
-1. **Copy the artifacts** to a machine where you have your top secret signing key installed (can be skipped if this is the build machine):<br />
-   ``rsync -vuPah <hostname>:path/to/daphne/artifacts .``
+1. Get into a bash shell and change to your working copy (aka DAPHNE root) directory.
+
+1. **Create the artifacts (plain DAPHNE):** ``./release.sh --version 0.1 --githash `git rev-parse HEAD` ``
+
+1. **Create additional artifacts with extra features compiled in:** ``./release.sh --version 0.1 --githash `git rev-parse HEAD` --feature cuda``
+    
+    Note that this adds additional constraints on the binaries (e.g., if CUDA support is compiled in, the executable will fail to load on a system without the CUDA SDK properly installed).
+
+1. **Copy the artifacts** to a machine where you have your secret signing key installed (can be skipped if this is the build machine):
+    
+    ```bash
+    rsync -vuPah <hostname>:path/to/daphne/artifacts .
+    ```
+
 1. **Signing and checksumming:**
 
     ``` bash
@@ -44,8 +50,9 @@ that the one key owner trusts the other.
     ~/path/to/daphne/release.sh --version 0.1 --artifact ./daphne-0.1-bin.tgz --gpgkey <GPG_KEY_ID> --githash `cat daphne-0.1-bin.githash` 
     ```
 
-   * repeat for other feature artifacts
-1. **Tag & push** The previous signing command will provide you with two more git commands to tag the commit that the artfiacts were made from and to push these tags to github.
+    Repeat for other feature artifacts
+
+1. **Tag & push** The previous signing command will provide you with two more git commands to tag the commit that the artifacts were made from and to push these tags to GitHub.
     This should look something like this:
 
     ``` bash
@@ -54,6 +61,6 @@ that the one key owner trusts the other.
     ```
 
 1. **Upload & release**:
-    * Click the "create new release" link on the front page of the Daphne github repository (right column under "Releases").
+    * Click the "create new release" link on the front page of the DAPHNE GitHub repository (right column under "Releases").
     * Select the tag for the release, create a title, add release notes (highlights of this release, list of contributors, maybe a detailed change log at the end)
-    * Upload the artifacts: All the ``<filename>.{tgz,tgz.asc,tgz.sha512sum}`` files before either saving as draft for further polishing or finally release the new version.
+    * Upload the artifacts: All the `<filename>.{tgz,tgz.asc,tgz.sha512sum}` files before either saving as draft for further polishing or finally release the new version.

--- a/doc/RunningDaphneLocally.md
+++ b/doc/RunningDaphneLocally.md
@@ -16,13 +16,11 @@ limitations under the License.
 
 # Running DAPHNE Locally
 
-Running DAPHNE in a local environment.
-
 This document explains how to run DAPHNE on a local machine.
 For more details on running DAPHNE in a distributed setup, please see the documentation on the [distributed runtime](/doc/DistributedRuntime.md) and [distributed deployment](/doc/Deploy.md).
 
 Before DAPHNE can be executed, the system must be built using `./build.sh` (for more details see [Getting Started](/doc/GettingStarted.md)).
-The main executable of the DAPHNE system is `bin/daphne`.
+The main executable of DAPHNE is `bin/daphne`.
 The general scheme of an invocation of DAPHNE looks as follows:
 
 ```bash
@@ -95,7 +93,7 @@ If `daphne` terminates normally, one of the following status codes is returned:
 
 ### `Parser error: ...`/`Pass error: ...`/`Execution error: ...`
 
-One of the three types of errors mentioned above occured.
+One of the three types of errors mentioned above occurred.
 In many (but not yet all) cases, there will be an error message indicating what went wrong.
 
 *Examples:*

--- a/doc/SchedulingOptions.md
+++ b/doc/SchedulingOptions.md
@@ -16,27 +16,27 @@ limitations under the License.
 
 # DAPHNE Scheduling
 
-This document describes the use of the pipeline and task scheduling mechanisms currently supported in the DAPHNE system.
+This document describes the use of the pipeline and task scheduling mechanisms currently supported in DAPHNE.
 
 ## Scheduling Decisions
 
-The DAPHNE system considers four types of scheduling decisions: work partitioning, assignment, ordering and timing.
+DAPHNE considers four types of scheduling decisions: work partitioning, assignment, ordering, and timing.
 
 - Work partitioning refers to the partitioning of the work into units of work (or tasks) according to a certain granularity (fine or coarse, equal or variable).
 - Work assignment refers to mapping (or placing) the units of work (or tasks) onto individual units of execution (processes or threads).
 - Work ordering refers to the order in which the tasks are executed. We rely on the vectorized execution engine, therefore, tasks within a vectorized pipeline have no dependencies and can be executed in any order.
 - Work timing refers to the times at which the units of work are set to begin execution on the assigned units of execution.
   
-**Work Partitioning**: The the DAPHNE prototype supports twelve partitioning schemes: Static (STATIC), Self-scheduling (SS), Guided self-scheduling (GSS), Trapezoid self-scheduling (TSS), Trapezoid Factoring self-scheduling (TFSS), Fixed-increase self-scheduling (FISS), Variable-increase self-scheduling (VISS), Performance loop-based self-scheduling (PLS), Modified version of Static (MSTATIC), Modified version of fixed size chunk self-scheduling (MFSC), and Probabilistic self-scheduling (PSS). The granularity of the tasks generated and scheduled by the DAPHNE system follows one of these partitioning schemes (See Section 4.1.1.1 in Deliverable 5.1 [D5.1].
+**Work Partitioning**: DAPHNE supports twelve partitioning schemes: Static (STATIC), Self-scheduling (SS), Guided self-scheduling (GSS), Trapezoid self-scheduling (TSS), Trapezoid Factoring self-scheduling (TFSS), Fixed-increase self-scheduling (FISS), Variable-increase self-scheduling (VISS), Performance loop-based self-scheduling (PLS), Modified version of Static (MSTATIC), Modified version of fixed size chunk self-scheduling (MFSC), and Probabilistic self-scheduling (PSS). The granularity of the tasks generated and scheduled by DAPHNE follows one of these partitioning schemes (see Section 4.1.1.1 in [Deliverable 5.1](https://daphne-eu.eu/wp-content/uploads/2021/11/Deliverable-5.1-fin.pdf)).
 
-**Work Assignment**: The current snapshot of the DAPHNE prototype supports two main assignment mechanisms: Single centralized work queue and Multiple work queues.  When work assignment relies on a centralized work queue (CENTRALIZED), workers follow the self-scheduling principle, i.e., whenever a worker is free and idle, it obtains a task from a central queue. When work assignment relies on multiple work queues, workers follow the work-stealing principle, i.e., whenever workers are free, idle, and have no tasks in their queues, they steal tasks from the work queue of each other. Work queues can be per worker (PERCPU) or per group of workers (PERGROUP).  In work-stealing, workers need to apply a victim selection mechanism to find a queue and steal work from it. The currently supported victim selection mechanisms are SEQ (steal from the next adjacent worker), SEQPRI (Steal from the next adjacent worker, but prioritize same NUMA domain), RANDOM (Steal from a random worker), RANDOMPRI (Steal from a random worker, but prioritize same NUMA domain).
+**Work Assignment**: Currently, DAPHNE supports two main assignment mechanisms: *single centralized work queue* and *multiple work queues*. When work assignment relies on a centralized work queue (CENTRALIZED), workers follow the self-scheduling principle, i.e., whenever a worker is free and idle, it obtains a task from a central queue. When work assignment relies on multiple work queues, workers follow the work-stealing principle, i.e., whenever workers are free, idle, and have no tasks in their queues, they steal tasks from the work queue of each other. Work queues can be per worker (PERCPU) or per group of workers (PERGROUP).  In work-stealing, workers need to apply a victim selection mechanism to find a queue and steal work from it. The currently supported victim selection mechanisms are SEQ (steal from the next adjacent worker), SEQPRI (steal from the next adjacent worker, but prioritize the same NUMA domain), RANDOM (steal from a random worker), RANDOMPRI (steal from a random worker, but prioritize the same NUMA domain).
 
 ## Scheduling Options
 
-To list all possible execution options of the DAPHNE system, one needs to execute the following
+To list all possible execution options of DAPHNE, one needs to execute the following:
 
 ```shell
-$ ./bin/daphne --help
+$ bin/daphne --help
 ```
 
 The output of this command shows all DAPHNE compilation and execution parameters including the scheduling options that are currently support. The output below shows only the scheduling options that we will cover in this document.
@@ -71,7 +71,7 @@ Advanced Scheduling Knobs:
   --debug-mt            - Prints debug information about the Multithreading Wrapper
   --grain-size=<int>    - Define the minimum grain size of a task (default is 1)
   --hyperthreading      - Utilize multiple logical CPUs located on the same physical CPU
-  --num-threads=<int>   - Define the number of the CPU threads used by the vectorized execution engine (default is equal to the number of physcial cores on the target node that executes the code)
+  --num-threads=<int>   - Define the number of the CPU threads used by the vectorized execution engine (default is equal to the number of physical cores on the target node that executes the code)
   --pin-workers         - Pin workers to CPU cores
   --pre-partition       - Partition rows into the number of queues before applying scheduling technique
   --vec                 - Enable vectorized execution engine
@@ -103,38 +103,38 @@ EXAMPLES:
 ```
 
 **_NOTE:_**
-the DAPHNE system relies on the vectorized (tile) execution engine to support parallelism at the node level. The vectorized execution engine takes decision concerning work partition and assignment during applications’ execution. Therefore, one needs always to use the option --vec with any of the scheduling options that we present in this document.
+DAPHNE relies on its vectorized execution engine to support parallelism at the node level. The vectorized execution engine makes decisions concerning work partitioning and assignment during the execution of a DaphneDSL script. Therefore, one always needs to use the option `--vec` with any of the scheduling options that we present in this document.
 
 ### Multithreading Options
 
-- **Number of threads**: A DAPHNE user can control the total number of threads spawn by the DAPHNE runtime system use the following parameter **--num-threads**. This parameter should be non-zero positive value. Illegal integer values will be ignored by the system and the default value will be used.  The default value of --num-threads is equal to the total number of physical cores of the host machine. The option can be used as below, e.g., the DAPHNE system spawns only 4 threads.
+- **Number of threads**: A DAPHNE user can control the total number of threads spawned by the DAPHNE runtime using the parameter **`--num-threads`**. This parameter should be a non-zero positive value. Illegal integer values will be ignored by the system and the default value will be used. The default value of `--num-threads` is equal to the total number of physical cores of the host machine. The option can be used as below, e.g., DAPHNE spawns only 4 threads.
 
     ```shell
-    ./bin/daphne --vec --num-threads=4 some_daphne_script.daphne
+    bin/daphne --vec --num-threads=4 some_daphne_script.daphne
     ```
 
-- **Thread Pinning**: A DAPHNE user can decide if the DAPHNE system pins its threads to the physical cores. Currently, the DAPHNE system supports one simple pining strategy, namely, round-robin strategy.  By default, the DAPHNE system does not pin its threads. The option **--pin-workers** can be used to activate thread pinning as follows
+- **Thread Pinning**: A DAPHNE user can decide if DAPHNE pins its threads to the physical cores. Currently, DAPHNE supports one simple pinning strategy: round-robin. By default, DAPHNE does not pin its threads. The option **`--pin-workers`** can be used to activate thread pinning as follows:
 
     ```shell
-    ./bin/daphne --vec --pin-threads some_daphne_script.daphne
+    bin/daphne --vec --pin-threads some_daphne_script.daphne
     ```
 
-- **Hyperthreading**: if a host machine supports hyperthreading, a DAPHNE user can decide to use logical cores, i.e., if the –num-threads is not specified, the DAPHNE system sets the total number of threads to the count of the physical cores. However, when the user specify the following parameter **--hyperthreading**, the DAPHNE system sets the number of threads to the count of the logical cores.
+- **Hyperthreading**: If a host machine supports hyperthreading, a DAPHNE user can decide to use logical cores, i.e., if `--num-threads` is not specified, DAPHNE sets the total number of threads to the number of the physical cores. However, when the user specifies the parameter **`--hyperthreading`**, DAPHNE sets the number of threads to the number of the logical cores.
 
     ```shell
-    ./bin/daphne --vec --hyperthreading some_daphne_script.daphne
+    bin/daphne --vec --hyperthreading some_daphne_script.daphne
     ```
 
 ### Work Partitioning Options
 
-- **Partition Scheme**: A DAPHNE user selects the partition scheme by passing the name of the partition scheme as an argument to the DAPHNE system. If the user does not specify a partition scheme, the default partition scheme (STATIC) will be used. As an example, the following command uses GSS as a partition scheme.
+- **Partition Scheme**: A DAPHNE user selects the partition scheme by passing the name of the partition scheme as an argument to DAPHNE. If the user does not specify a partition scheme, the default partition scheme (STATIC) will be used. As an example, the following command uses GSS as a partition scheme.
 
     ```shell
     ./bin/daphne --vec --GSS some_daphne_script.daphne
     ```
 
-- **Task granularity**: The DAPHNE user can exploit the **--grain-size** parameter to set the minimum size of the tasks generated by the DAPHNE system. This parameter should be non-zero positive value. Illegal integer values will be ignored by the system and the default value will be used.  The default value of **--grain-size** is 1, i.e., the data associated with a task represents 1 row of the input matrix.
-As an example, the following command uses SS as a partition scheme with minimum task size of 100
+- **Task granularity**: The DAPHNE user can exploit the **`--grain-size`** parameter to set the minimum size of the tasks generated by DAPHNE. This parameter should be a non-zero positive value. Illegal integer values will be ignored by the system and the default value will be used.  The default value of **`--grain-size`** is 1, i.e., the data associated with a task represents 1 row of the input matrix.
+As an example, the following command uses SS as a partition scheme with minimum task size of 100:
 
     ```shell
     ./bin/daphne --vec --SS --grain-size=100 some_daphne_script.daphne
@@ -142,40 +142,39 @@ As an example, the following command uses SS as a partition scheme with minimum 
 
 ### Work Assignment Options
 
-- **Single centralized work queue**: By default, the DAPHNE system uses a single centralized work queue. However, the user may explicitly use the following parameter **--CENTRALIZED** to ensure the use of single centralized work queue.
+- **Single centralized work queue**: By default, DAPHNE uses a single centralized work queue. However, the user may explicitly use the parameter **`--CENTRALIZED`** to ensure the use of a single centralized work queue.
 
     ```shell
     ./bin/daphne --vec --GSS --CENTRALIZED some_daphne_script.daphne
     ```
 
-- **Multiple work queues**: a DAPHNE user can exploit the use of multiple work queues by passing one of the following parameters **--PERCPU** or **--PERGROUP**. The two parameters cannot be used together, and if **--CENTRALIZED** is used with any of them, --CENTRALIZED will be ignored by the system.
-- parameter **--PERGROUP** ensures that the DAPHNE system creates a number of groups equals to the number of NUMA domains on the target host machine. The DAPHNE system assigns equal number of workers (threads) to each of the groups. Workers within the same group share one work queue. The **–-PERGROUP** can be used as follows
+- **Multiple work queues**: A DAPHNE user can exploit the use of multiple work queues by passing any one of the parameters **`--PERCPU`** or **`--PERGROUP`**. The two parameters cannot be used together, and if **`--CENTRALIZED`** is used with any of them, `--CENTRALIZED` will be ignored by the system.
+    - The parameter **`--PERGROUP`** ensures that DAPHNE creates a number of groups equal to the number of NUMA domains on the target host machine. DAPHNE assigns an equal number of workers (threads) to each of the groups. Workers within the same group share one work queue. The parameter `--PERGROUP` can be used as follows:
 
     ```shell
     ./bin/daphne --vec --PERGROUP some_daphne_script.daphne
     ```
 
-- The parameter **--PERCPU** ensures that the DAPHNE system creates a number of queues equal to the total number of workers (threads), i.e., each worker is assigned to a single work queue. The parameter **--PERCPU** can be used as follows
+    - The parameter **`--PERCPU`** ensures that DAPHNE creates a number of queues equal to the total number of workers (threads), i.e., each worker is assigned to a single work queue. The parameter `--PERCPU` can be used as follows:
 
     ```shell
     ./bin/daphne --vec --PERCPU some_daphne_script.daphne
     ```
 
-- **Victim Selection**: A DAPHNE user can choose a victim selection strategy by passing one of the following parameters --SEQ, --SEQPRI, --RANDOM, and --RANDOMPRI. These parameters activate different victim selection strategies as follows
-    - **--SEQ** activates a sequential victim selection strategy, i.e., the ith worker steals form the (i+1)th  worker. The last worker steals from the first worker.
-    - **--SEQPRI** is similar to --SEQ except that --SEQPRI priorities workers assigned to the same NUMA domain. When the host machine has one NUMA domain,
-    - --SEQ and --SEQPRI have no difference.
-    - **--RANDOM** activates a random victim selection strategy, i.e., the ith worker steals form a randomly chosen worker.
-    - **--RANDOMPRI** is similar to --RANDOM except that --RANDOM priorities workers assigned to the same NUMA domain. When the host machine has one NUMA domain, --RANDOMPRI and --RANDOMPRI have no difference.
-  
-**_NOTE:_**  
-When the user does not choose one of these parameters, the DAPHNE system considers --SEQ as a default victim selection strategy.
+- **Victim Selection**: A DAPHNE user can choose a victim selection strategy by passing one of the following parameters `--SEQ`, `--SEQPRI`, `--RANDOM`, and `--RANDOMPRI`. These parameters activate different victim selection strategies as follows:
+    - **`--SEQ`** activates a sequential victim selection strategy, i.e., the *i*-th worker steals form the *(i+1)*-th  worker. The last worker steals from the first worker.
+    - **`--SEQPRI`** is similar to `--SEQ` except that `--SEQPRI` prioritizes workers assigned to the same NUMA domain. When the host machine has one NUMA domain `--SEQ` and `--SEQPRI` have no difference.
+    - **`--RANDOM`** activates a random victim selection strategy, i.e., the *i*-th worker steals form a randomly chosen worker.
+    - **`--RANDOMPRI`** is similar to `--RANDOM` except that `--RANDOMPRI` prioritizes workers assigned to the same NUMA domain. When the host machine has one NUMA domain, `--RANDOM` and `--RANDOMPRI` have no difference.
 
-As an example, the following command uses --SEQPRI as a victim selection strategy.
+    **NOTE:**
+    When the user does not choose one of these parameters, DAPHNE considers `--SEQ` as a default victim selection strategy.
 
-```shell
-./bin/daphne --vec --PERGROUP --SEQPRI some_daphne_script.daphne
-```
+    As an example, the following command uses `--SEQPRI` as a victim selection strategy.
+
+    ```shell
+    ./bin/daphne --vec --PERGROUP --SEQPRI some_daphne_script.daphne
+    ```
 
 ## References
 

--- a/doc/development/BuildingDaphne.md
+++ b/doc/development/BuildingDaphne.md
@@ -19,13 +19,13 @@ limitations under the License.
 The DAPHNE project provides a full-fledged build script. After cloning, it does everything from dependency setup to
 generation of the executable.
 
-## What does the build script do? (simplified)
+## What Does the Build Script Do? (Simplified)
 
 - Download & build all code dependencies
-- Build Daphne
+- Build DAPHNE
 - Clean Project
 
-## How long does a build take?
+## How Long Does a Build Take?
 
 The first run will take a while, due to long compilation times of the dependencies (~1 hour on a 16 vcore desktop, ~10 minutes on a 128 vcore cluster node). But they only have to be compiled once (except updates).
 Following builds only take a few seconds/minutes.
@@ -37,19 +37,19 @@ Contents:
 
 ---
 
-## Usage of the build script
+## Usage of the Build Script
 
 This section shows the possibilities of the build script.
 
 ### Build
 
-The default command to build the default target **daphne**.
+The default command to build the default target **`daphne`**.
 
 ```bash
 ./build.sh
 ```
 
-Print the cli build help page. This also shows all the following options.
+Print the CLI build help page. This also shows all the following options.
 
 ```bash
 ./build.sh --help
@@ -69,28 +69,28 @@ For example the following builds the main test target.
 
 ### Clean
 
-Clean all build directories, i.e., the daphne build dir `<project_root>/build` and the build output in
-`<project_root>/bin` and `<project_root>/lib`
+Clean all build directories, i.e., the DAPHNE build dir `<project_root>/build` and the build output in
+`<project_root>/bin` and `<project_root>/lib`:
 
 ```bash
 ./build.sh --clean
 ```
 
-Clean all downloads and extracted archive directories, i.e., `<thirdparty_dir>`/download-cache, `<thirdparty_dir>`/sources
-and `<thirdparty_dir>`/*.download.success files:
+Clean all downloads and extracted archive directories, i.e., `<thirdparty_dir>/download-cache`, `<thirdparty_dir>/sources`
+and `<thirdparty_dir>/*.download.success` files:
 
 ```bash
 ./build.sh --cleanCache
 ```
 
-Clean third party build output, i.e., `<thirdparty_dir>/installed`, `<thirdparty_dir>/build` and
-`<thirdparty_dir>`/*.install.success files:
+Clean third-party build output, i.e., `<thirdparty_dir>/installed`, `<thirdparty_dir>/build` and
+`<thirdparty_dir>/*.install.success` files:
 
 ```bash
 ./build.sh --cleanDeps
 ```
 
-Clean everything (DAPHNE build output and third party directory)
+Clean everything (DAPHNE build output and third-party directory):
 
 ```bash
 ./build.sh --cleanAll
@@ -98,15 +98,15 @@ Clean everything (DAPHNE build output and third party directory)
 
 ### Minimize Compile Times of Dependencies
 
-The most time-consuming part of getting DAPHNE compiled is building the third party dependencies.
+The most time-consuming part of getting DAPHNE compiled is building the third-party dependencies.
 To avoid this, one can either use a prebuilt container image (in combination with some parameters to the build script
-see below) or at least build the dependencies once and subsequently point to the directory where the third party
-dependencies get installed. The bulid script must be invoked with the following two parameters to achieve this:
+see below) or at least build the dependencies once and subsequently point to the directory where the third-party
+dependencies get installed. The build script must be invoked with the following two parameters to achieve this:
 
 `./build.sh --no-deps --installPrefix path/to/installed/deps`
 
 If you have built DAPHNE and **change the installPrefix directory**, it is required to clean up and build again:
-`./build.sh --clean`
+`./build.sh --clean`.
 
 ### Options
 
@@ -115,17 +115,17 @@ All possible options for the build script:
 | Option                  | Effect                                                                                     |
 |-------------------------|--------------------------------------------------------------------------------------------|
 | -h, --help              | Print the help page                                                                        |
-| --installPrefix <path\> | Install third party dependencies in `<path>` (default: `<project_root>/thirdparty/installed`) |
+| --installPrefix <path\> | Install third-party dependencies in `<path>` (default: `<project_root>/thirdparty/installed`) |
 | --clean                 | Clean DAPHNE build output (`<project_root>/{bin,build,lib}`)                                 |
-| --cleanCache            | Clean downloaded and extracted third party artifacts                                       |
-| --cleanDeps             | Clean third party dependency build output and installed files                              |
-| --cleanAll              | Clean DAPHNE build output and reset the third party directory to the state in the git repo |
+| --cleanCache            | Clean downloaded and extracted third-party artifacts                                       |
+| --cleanDeps             | Clean third-party dependency build output and installed files                              |
+| --cleanAll              | Clean DAPHNE build output and reset the third-party directory to the state in the git repo |
 | --target <target\>      | Build specific target                                                                      |
 | -nf, --no-fancy         | Disable colorized output                                                                   |
-| --no-deps               | Avoid building third party dependencies                                                    |
+| --no-deps               | Avoid building third-party dependencies                                                    |
 | -y, --yes               | Accept prompt (e.g., when executing the clean command)                                     |
+| --debug                 | Compile the `daphne` binary with debug symbols                                               |
 | --cuda                  | Compile with support for GPU operations using the CUDA SDK                                 |
-| --debug                 | Compile the daphne binary with debug symbols                                               |
 | --oneapi                | Compile with support for accelerated operations using the OneAPI SDK                       |
 | --fpgaopencl            | Compile with support for FPGA operations using the Intel FPGA SDK or OneAPI+FPGA Add-On    |
 | --no-papi               | Compile without support for PAPI-based profiling                                       |
@@ -138,7 +138,7 @@ When using Windows Subsystems for Linux (WSL), the default memory limit for WSL 
 
 ## Extension
 
-### Overview over the build script
+### Overview of the Build Script
 
 The build script is divided into sections, visualized by
 
@@ -150,57 +150,57 @@ The build script is divided into sections, visualized by
 
 Each section should only contain functionality related to the section name.
 
-The following list contains a rough overview over the sections and the concrete functions or functionality done here.
+The following list contains a rough overview of the sections and the concrete functions or functionality done here.
 
 1. Help message
-   1. **printHelp()** // prints help message
+    1. **printHelp()** // prints help message
 2. Build message helper
-   1. **daphne_msg(** <message\> **)** // prints a status message in DAPHNE style
-   2. **printableTimestamp(** <timestamp\> **)** // converts a unix epoch timestamp into a human readable string (e.g., 5min 20s 100ms)
-   3. **printLogo()** // prints a DAPHNE logo to the console
+    1. **daphne_msg(** <message\> **)** // prints a status message in DAPHNE style
+    2. **printableTimestamp(** <timestamp\> **)** // converts a unix epoch timestamp into a human readable string (e.g., 5min 20s 100ms)
+    3. **printLogo()** // prints a DAPHNE logo to the console
 3. Clean build directories
-   1. **clean(** <array ref dirs\> <array ref files\> **)** // removes all given directories (1. parameter) and all given files (2. parameter) from disk
-   2. **cleanBuildDirs()** // cleans build dirs (daphne and dependency build dirs)
-   3. **cleanAll()** // cleans daphne build dir and wipes all dependencies from disk (resetting the third party directory)
-   4. **cleanDeps()** // removes third party build output
-   5. **cleanCache()** // removes downloaded third party artifacts (but leaving git submodules (only LLVM/MLIR at the time of writing)
+    1. **clean(** <array ref dirs\> <array ref files\> **)** // removes all given directories (1. parameter) and all given files (2. parameter) from disk
+    2. **cleanBuildDirs()** // cleans build dirs (DAPHNE and dependency build dirs)
+    3. **cleanAll()** // cleans DAPHNE build dir and wipes all dependencies from disk (resetting the third-party directory)
+    4. **cleanDeps()** // removes third-party build output
+    5. **cleanCache()** // removes downloaded third-party artifacts (but leaving git submodules (only LLVM/MLIR at the time of writing)
 4. Create / Check Indicator-files
-   1. **dependency_install_success(** <dep\> **)** // used after successful build of a dependency; creates related indicator file
-   2. dependency_download_success(<dep\>) // used after successful download of a dependency; creates related indicator file
-   3. **is_dependency_installed(** <dep\> **)** // checks if dependency is already installed/built successfully
-   4. **is_dependency_downloaded(** <dep\> **)** // checks if dependency is already downloaded successfully
-5. Versions of third party dependencies
-   1. Versions of the software dependencies are configured here
+    1. **dependency_install_success(** <dep\> **)** // used after successful build of a dependency; creates related indicator file
+    2. dependency_download_success(<dep\>) // used after successful download of a dependency; creates related indicator file
+    3. **is_dependency_installed(** <dep\> **)** // checks if dependency is already installed/built successfully
+    4. **is_dependency_downloaded(** <dep\> **)** // checks if dependency is already downloaded successfully
+5. Versions of third-party dependencies
+    1. Versions of the software dependencies are configured here
 6. Set some prefixes, paths and dirs
-   1. Definition of project related paths
-   2. Configuration of path prefixes. For example all build directories are prefixed with `buildPrefix`. If fast storage
-      is available on the system, build directories could be redirected with this central configuration.
+    1. Definition of project related paths
+    2. Configuration of path prefixes. For example all build directories are prefixed with `buildPrefix`. If fast storage
+        is available on the system, build directories could be redirected with this central configuration.
 7. Parse arguments
-   1. Parsing
-   2. Updating git submodules
+    1. Parsing
+    2. Updating git submodules
 8. Download and install third-party dependencies if requested (default is yes, omit with --no-deps))
-   1. Antlr
-   2. catch2
-   3. OpenBLAS
-   4. nlohmannjson
-   5. abseil-cpp - Required by gRPC. Compiled separately to apply a patch.
-   6. MPI (Default is MPI library is OpenMPI but cut can be any)
-   7. gRPC
-   8. Arrow / Parquet
-   9. MLIR
+    1. Antlr
+    2. catch2
+    3. OpenBLAS
+    4. nlohmannjson
+    5. abseil-cpp - Required by gRPC. Compiled separately to apply a patch.
+    6. MPI (Default is MPI library is OpenMPI but cut can be any)
+    7. gRPC
+    8. Arrow / Parquet
+    9. MLIR
 9. Build DAPHNE target
-   1. Compilation of the DAPHNE-target ('daphne' is default)
+    1. Compilation of the DAPHNE-target (`daphne` is the default)
 
-### Adding a dependency
+### Adding a Dependency
 
 1. If the dependency is fixed to a specific version, add it to the dependency versions section (section 5).
 1. Create a new segment in section 8 for the new dependency.
 1. Define needed dependency variables:
-   1. Directory Name (which is used by the script to locate the dependency in different stages)
-   1. Create an internal version variable in form of an array with two entries. Those are used for internal versioning and updating of the dependency without rebuilding each time.
-      1. First: Name and version of the dependency as a string of the form `<dep_name>_v${dep_version}` (This one is updated, if a new version of the dependency is choosen.)
-      1. Second: Thirdparty Version of the dependency as a string of the form `v1` (This one is incremented each time by hand, if something changes on the path system of the dependency or DAPHNE itself. This way already existing projects are updated automatically, if something changes.)
-   1. Optionals: Dep-specific paths, Dep-specific files, etc.
+    1. Directory name (which is used by the script to locate the dependency in different stages)
+    1. Create an internal version variable in form of an array with two entries. Those are used for internal versioning and updating of the dependency without rebuilding each time.
+        1. First: Name and version of the dependency as a string of the form `<dep_name>_v${dep_version}` (This one is updated, if a new version of the dependency is chosen.)
+        1. Second: Third-party Version of the dependency as a string of the form `v1` (This one is incremented each time by hand, if something changes on the path system of the dependency or DAPHNE itself. This way already existing projects are updated automatically, if something changes.)
+    1. Optional: Dep-specific paths, Dep-specific files, etc.
 1. Download the dependency, encased by:
 
     ```bash
@@ -222,7 +222,7 @@ The following list contains a rough overview over the sections and the concrete 
     fi
     ```
 
-    **Hint:** It is recommended to use the paths defined in section 6 for dependency downloads and installations. There are predefined paths like 'cacheDir', 'sourcePrefix', 'buildPrefix' and 'installPrefix'. Take a look at other dependencies to see how to use them.
+    **Hint:** It is recommended to use the paths defined in section 6 for dependency downloads and installations. There are predefined paths like `cacheDir`, `sourcePrefix`, `buildPrefix` and `installPrefix`. Take a look at other dependencies to see how to use them.
 1. Install the dependency (if necessary), encased by:
 
     ```bash
@@ -235,6 +235,6 @@ The following list contains a rough overview over the sections and the concrete 
     ```
 
 1. Define a flag for the build script if your dependency is optional or poses unnecessary
-   overhead for users (e.g., CUDA is optional as the CUDA SDK is a considerably sized package that only owners of Nvidia hardware would want to install).
+    overhead for users (e.g., CUDA is optional as the CUDA SDK is a considerably-sized package that only owners of Nvidia hardware would want to install).
 
-   See section 7 about argument parsing. Quick guide: define a variable and its default value and add an item to the argument handling loop.
+    See section 7 about argument parsing. Quick guide: define a variable and its default value and add an item to the argument handling loop.

--- a/doc/development/Contributing.md
+++ b/doc/development/Contributing.md
@@ -1,3 +1,19 @@
+<!--
+Copyright 2025 The DAPHNE Consortium
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 # Contributing
 
 See [CONTRIBUTING.md](/CONTRIBUTING.md)

--- a/doc/development/ExtendingSchedulingKnobs.md
+++ b/doc/development/ExtendingSchedulingKnobs.md
@@ -16,14 +16,14 @@ limitations under the License.
 
 # Extending DAPHNE with More Scheduling Knobs
 
-This document focuses on how a daphne developer may extend the DAPHNE system by adding new scheduling techniques
+This document focuses on how a DAPHNE developer may extend DAPHNE by adding new scheduling techniques.
 
 ## Guidelines
 
-The daphne developer should consider the following files for adding a new scheduling technique
+The DAPHNE developer should consider the following files for adding a new scheduling technique:
 
-1. src/runtime/local/vectorized/LoadPartitioning.h
-1. src/api/cli/daphne.cpp
+1. `src/runtime/local/vectorized/LoadPartitioning.h`
+1. `src/api/cli/daphne.cpp`
 
 **Adding the actual code of the technique:**
 
@@ -32,34 +32,34 @@ For more details, please visit [Scheduler design for tasks and pipelines](https:
 
 In this file, the developer should change two things:
 
-1. The enumeration that is called `SelfSchedulingScheme`. The developer will have to add a name for the new technique, e.g., `MYTECH`
+1. The enumeration `SelfSchedulingScheme`. The developer will have to add a name for the new technique, e.g., `MYTECH`
 
     ```cpp
     enum SelfSchedulingScheme { STATIC=0, SS, GSS, TSS, FAC2, TFSS, FISS, VISS, PLS, MSTATIC, MFSC, PSS, MYTECH };
     ```
 
-1. The function that is called `getNextChunk()`. This function has a switch case that selects the mathematical formula that corresponds to the chosen scheduling method. The developer has to add a new case to handle the new technique.
+1. The function `getNextChunk()`. This function has a switch-case-statement that selects the mathematical formula that corresponds to the chosen scheduling method. The developer has to add a new case to handle the new technique.
 
     ```cpp
     uint64_t getNextChunk(){
-       //...
+       // ...
        switch (schedulingMethod){
-           //...
-           //Only the following part is what the developer has to add. The rest remains the same
+           // ...
+           // only the following part is what the developer has to add. The rest remains the same
            case MYTECH:{ // the new technique
-               chunkSize= FORMULA;//Some Formula to calculate the chunksize (partition size)
+               chunkSize= FORMULA; // some formula to calculate the chunk size (partition size)
                break; 
            }
-           //...
+           // ...
        }
-       //...
+       // ...
        return chunkSize;
     }
     ```
 
 **Enabling the selection of the newly added technique:**
 
-The second file `daphne.cpp` contains the code that parses the command line arguments and passes them to the DAPHNE compiler and runtime. The developer has to add the new technique as a vaild option. Otherwise, the developer will not be able to use the newly added technique.
+The second file `daphne.cpp` contains the code that parses the command-line arguments and passes them to the DAPHNE compiler and runtime. The developer has to add the new technique as a valid option. Otherwise, the developer will not be able to use the newly added technique.
 There is a variable called `taskPartitioningScheme` and it is of type `opt<SelfSchedulingScheme>`.
 The developer should extend the declaration of `opt<SelfSchedulingScheme>` as follows:
 
@@ -86,13 +86,13 @@ opt<SelfSchedulingScheme> taskPartitioningScheme(
 
 **Usage of the new technique:**
 
-Daphne developers may now pass the new technique as an option when they execute a DaphneDSL script.
+DAPHNE developers may now pass the new technique as an option when they execute a DaphneDSL script.
 
 ```bash
 daphne --vec --MYTECH --grain-size 10 --num-threads 4 --PERCPU --SEQPRI --hyperthreading --debug-mt my_script.daphne
 ```
 
-In this example, the daphne system will execute `my_script.daphne`  with the following configuration:
+In this example, DAPHNE will execute `my_script.daphne`  with the following configuration:
 
 1. the vectorized engine is enabled due to `--vec`
 1. the DAPHNE runtime will use MYTECH for task partitioning due to `--MYTECH`

--- a/doc/development/HandlingPRs.md
+++ b/doc/development/HandlingPRs.md
@@ -37,35 +37,35 @@ However, they could also be interesting for *contributors* to (a) understand how
 
 ## PR Review/Merging Procedure
 
-### PR creation
+### PR Creation
 
 The contributor creates the PR.
 
 - if the PR is marked as a draft, it is handled by an informal discussion depending on concrete questions by the contributor; if there are none, the PR is left alone for now
 - if the PR is not marked as a draft, the review/merge procedure continues
 
-### Initial response and reviewer assignment
+### Initial Response and Reviewer Assignment
 
 The DAPHNE collaborators provide an *initial response* and *assign one (or multiple) reviewers* (usually from among themselves, but can also be non-collaborators).
 
 - **Initial response**
-  - ideally within a few working days after the PR was opened
-  - thank contributor for the contribution
-  - have a quick glance to decide if the contribution is relevant (default: yes)
+    - ideally within a few working days after the PR was opened
+    - thank contributor for the contribution
+    - have a quick glance to decide if the contribution is relevant (default: yes)
 - **Reviewer selection**
-  - any collaborator (or non-collaborator) may volunteer
-  - collaborators may select reviewer in a discussion (use @mentions)
-  - who qualifies as a reviewer
-    - collaborator experienced with the respective part of the code
-    - collaborator mentoring the contributor (e.g., in case of undergrad students)
-    - collaborator who wants to learn more about the respective part of the code base
-    - any other collaborator to balance the reviewing load among collaborators
-  - there may be multiple reviewers
+    - any collaborator (or non-collaborator) may volunteer
+    - collaborators may select reviewer in a discussion (use @mentions)
+    - who qualifies as a reviewer
+        - collaborator experienced with the respective part of the code
+        - collaborator mentoring the contributor (e.g., in case of undergrad students)
+        - collaborator who wants to learn more about the respective part of the code base
+        - any other collaborator to balance the reviewing load among collaborators
+    - there may be multiple reviewers
 - **Assignment of the reviewer(s)**
-  - on GitHub
-  - ideally, reviewer(s) should *communicate when review can be expected* (based on their availability and urgency of the PR)
+    - on GitHub
+    - ideally, reviewer(s) should *communicate when the review can be expected* (based on their availability and urgency of the PR)
 
-### Rounds of feedback and response
+### Rounds of Feedback and Response
 
 If necessary, the reviewer(s) and the contributor prepare the contribution for a merge by multiple (but ideally not more than one) rounds of feedback and response.
 
@@ -81,7 +81,7 @@ If necessary, the reviewer(s) and the contributor prepare the contribution for a
         - if PR states to address an issue, check if it really does so
         - it can be okay if a PR addresses just a part of a complex issue (if contribution still makes sense)
         - briefly check if PR addresses further issues (if so, also mention that in feedback and commit message later)
-        - PR does not need to address an issue, but if it doesn't, check if contribution really belongs to the DAPHNE system itself (there might be useful contributions which should better reside in a separate repo, e.g., for the usage of DAPHNE, tools around DAPHNE, experiments/reproducibility, ...)
+        - PR does not need to address an issue, but if it doesn't, check if contribution really belongs to DAPHNE itself (there might be useful contributions which should better reside in a separate repo, e.g., for the usage of DAPHNE, tools around DAPHNE, experiments/reproducibility, ...)
     - *contribution DOs*
         - readable code
         - necessary API changes should be reflected in the documentation (e.g., DaphneDSL/DaphneLib, command line arguments, environment variables, ...)
@@ -114,7 +114,7 @@ If necessary, the reviewer(s) and the contributor prepare the contribution for a
             - lots of commented out lines (especially artifacts from development/debugging)
 - **try out the code**
     - check out the branch
-        - If the contribution originates from a github fork, these steps will help to clone the PR's state into a branch of your working copy (example taken from PR #415):
+        - If the contribution originates from a GitHub fork, these steps will help to clone the PR's state into a branch of your working copy (example taken from PR #415):
             - Make sure your local copy of the main branch is up to date
 
                 ```bash
@@ -193,7 +193,7 @@ If necessary, the reviewer(s) and the contributor prepare the contribution for a
 - ideally, the contributor is willing to do this
 - otherwise (and especially for new contributors, for whom we want to lower the barrier of entry), the reviewer or someone else should take charge of this, if possible
 
-### Once the contribution is ready, a collaborator merges the PR
+### Once the Contribution is Ready, a Collaborator Merges the PR
 
 - can be done by the reviewer or any collaborator
 - we want to keep a clean history on the main branch (and remember never to force-push to main)
@@ -230,15 +230,15 @@ If necessary, the reviewer(s) and the contributor prepare the contribution for a
         - if multiple authors edited the branch: choose one of them as the main author (after squashing in GitHub it should be the person who opened the PR); more authors can be added by adding [`Co-authored-by:  NAME NAME@EXAMPLE.COM`](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) after two blank lines at the end of the commit message (one for each co-author).
         - very often, reviewers may have made minor fixes, but should refrain from adding themselves as co-authors (prefer to give full credit for the contribution to the initial contributor, unless the reviewer's contribution was significant)
 
-### Creation of follow-up issues (optional)
+### Creation of Follow-up Issues (Optional)
 
 - things that were left out
 - nice-to-haves
 - functional, non-functional, documentation, tests
 
-### Inviting the contributor as a collaborator (conditional)
+### Inviting the Contributor as a Collaborator (Conditional)
 
-If this contributor has made enough non-trivial contributions of good quality (currently, we require three), he/she should be invited as a collaborator on GitHub.
+If this contributor has made enough non-trivial contributions of good quality (currently, we require three), they should be invited as a collaborator on GitHub.
 
 ## More Hints
 

--- a/doc/development/ImplementBuiltinKernel.md
+++ b/doc/development/ImplementBuiltinKernel.md
@@ -19,7 +19,7 @@ limitations under the License.
 ## Background
 
 (Almost) every DaphneIR operation will be backed by a kernel (= physical operator) at run-time.
-Extensibility w.r.t. kernels is one on the core goals of the DAPHNE system.
+Extensibility w.r.t. kernels is one on the core goals of DAPHNE.
 It shall be easy for a user to add a custom kernel.
 However, the system will offer a full set of built-in kernels so that all DaphneIR operations can be used out-of-the-box.
 
@@ -51,20 +51,20 @@ At least, we should rather not mix kernels of different DaphneIR operations in o
 **Interfaces:**
 
 Technically, a kernel is a C++ function taking one or more data objects (matrices, frames) and/or scalars as input and returning one or more data objects and/or scalars as output.
-As a central idea, (almost) all DaphneIR operations should be able to process (almost) all kinds of Daphne data structures, whereby these could have any Daphne value type.
+As a central idea, (almost) all DaphneIR operations should be able to process (almost) all kinds of DAPHNE data structures, whereby these could have any DAPHNE value type.
 For example, elementwise binary operations (`+`, `*`, ...) should be applicable to `DenseMatrix` of `double`, `uint32_t`, etc. as well as to `CSRMatrix` of `double`, `uint32_t`, etc. and so on.
 This type flexibility motivates the use of C++ template metaprogramming.
 
 Thus, a kernel is a template function with:
 
 - *template parameters*
-  - one for the type of each input/output data object (and scalar, if necessary)
+    - one for the type of each input/output data object (and scalar, if necessary)
 - *inputs*
-  - of type `const DT *` for data objects (whereby `DT` is a particular C++ type such as `DenseMatrix<double>`)
-  - of type `VT` for scalars of some value type `VT`
+    - of type `const DT *` for data objects (whereby `DT` is a particular C++ type such as `DenseMatrix<double>`)
+    - of type `VT` for scalars of some value type `VT`
 - *outputs*
-  - as a return value, in case of a single scalar
-  - as a parameter of type `DT *&` in case of data objects (all output parameters *before* all input parameters)
+    - as a return value, in case of a single scalar
+    - as a parameter of type `DT *&` in case of data objects (all output parameters *before* all input parameters)
 
 The reason for passing output data objects as parameters is that this mechanism could be used for efficient update-in-place operations.
 
@@ -155,21 +155,21 @@ Of course, that depends on what the kernel is supposed to do, but there some rec
 
 - *Obtaining an output data object*
 
-  Data objects like matrices and frames cannot be obtained using the `new`-operator, but must be obtained from the `DataObjectFactory`, e.g., as follows:
+    Data objects like matrices and frames cannot be obtained using the `new`-operator, but must be obtained from the `DataObjectFactory`, e.g., as follows:
 
-  ```cpp
-  auto res = DataObjectFactory::create<CSRMatrix<double>>(3, 4, 6, false);
-  ```
+    ```cpp
+    auto res = DataObjectFactory::create<CSRMatrix<double>>(3, 4, 6, false);
+    ```
 
-  Internally, this `create`-function calls a private constructor of the specified data type implementation; so please have a look at these.
+    Internally, this `create`-function calls a private constructor of the specified data type implementation; so please have a look at these.
 - *Accessing the input and output data objects*
 
-  For efficiency reasons, accessing the data in way specific to the data type implementation is preferred to generic access method of the super-classes.
-  That is, if possible, rather use `getValues()` (for `DenseMatrix`) or `getValues()`/`colColIdxs()`/`getRowOffsets()` (for `CSRMatrix`) rather than `get()`/`set()`/`append()` from the super-class `Matrix`.
-  The reason is that these generic access methods can incur a lot of unnecessary effort, depending on the data type implementation.
-  However, in the end it is always a trade-off between performance and code complexity.
-  For kernels that are rarely used or typically used on small data objects, a simple but inefficient implementation might be okay.
-  Nevertheless, since the DAPHNE system should be able to handle unexpected scripts efficiently, we should not get too much used to sacrificing efficiency.
+    For efficiency reasons, accessing the data in way specific to the data type implementation is preferred to generic access method of the super-classes.
+    That is, if possible, rather use `getValues()` (for `DenseMatrix`) or `getValues()`/`colColIdxs()`/`getRowOffsets()` (for `CSRMatrix`) rather than `get()`/`set()`/`append()` from the super-class `Matrix`.
+    The reason is that these generic access methods can incur a lot of unnecessary effort, depending on the data type implementation.
+    However, in the end it is always a trade-off between performance and code complexity.
+    For kernels that are rarely used or typically used on small data objects, a simple but inefficient implementation might be okay.
+    Nevertheless, since DAPHNE should be able to handle unexpected scripts efficiently, we should not get too much used to sacrificing efficiency.
 
 ### Concrete Examples
 
@@ -189,7 +189,7 @@ Please have a look at test cases for existing kernel implementations in [test/ru
 
 ### Error Handling
 
-It is recommended to exceptions such as `throw std::runtime_error` in a kernel
+It is recommended to throw exceptions such as `throw std::runtime_error` in a kernel
 in case the code runs into an unresolvable issue. We catch these exceptions in
 our surrounding code to the kernel and provide, whenever possible, additional
 information about the source of the error in the DaphneDSL script.
@@ -198,9 +198,9 @@ information about the source of the error in the DaphneDSL script.
 ### Experimental Kernels
 
 As an alternative to implementing a new kernel that is directly integrated into
-DAPHNE, one can also work on kernel implementations using the [kernel catalog](doc/Extensions.md).
-These should reside in [experimental/op/](src/runtime/local/kernels/experimental/op/) where `op` is
-the mnemonic of the DaphneIR operation that the kernel is implementing.
+DAPHNE, one can also work on kernel implementations using the [kernel catalog](/doc/Extensions.md).
+These should reside in [experimental/op/](/src/runtime/local/kernels/experimental/op/) where `op` is
+the mnemonic of the DaphneIR operation that the kernel implements.
 
 Experimental kernels are not directly integrated into DAPHNE and are neither
 compiled nor executed by default. They can be used to test new ideas and
@@ -215,5 +215,5 @@ free to introduce new dependencies that are handled by the accompanying
 resolved before the experimental kernel is integrated into DAPHNE as a built-in
 kernel.
 
-Check out [Extensions.md](doc/Extensions.md) for more information on how to
+Check out [Extensions.md](/doc/Extensions.md) for more information on how to
 implement experimental kernels.

--- a/doc/development/Logging.md
+++ b/doc/development/Logging.md
@@ -19,46 +19,46 @@ limitations under the License.
 ## General
 
 To write out messages of any kind from DAPHNE internals we use the [spdlog](https://github.com/gabime/spdlog/) library.
-E.g., not from a user's print() statement but when ``std::cout << "my value: " << value << std::endl;`` is needed. With
-spdlog, the previous std::cout example would read like this: ```spdlog::info("my value: {}", value);```. The only
+E.g., not from a user's `print()` statement but when `std::cout << "my value: " << value << std::endl;` is needed. With
+spdlog, the previous `std::cout` example would read like this: `spdlog::info("my value: {}", value);`. The only
 difference being that we now need to choose a log level (which is arbitrarily chosen to be *info* in this case).
 
 ## Usage
 
 1. Before using the logging functionality, the loggers need to be created and registered. Due to the nature of how
-singletons work in C++, this has to be done once per binary (e.g., daphne, run_tests, libAllKernels.so, libCUDAKernels.so, etc).
-For the mentioned binaries this has already been taken care of (either somewhere near the main program entrypoint or
-via context creation in case of the libs). All setup is handled by the class DaphneLogger (with some extras in ConfigParser).
+singletons work in C++, this has to be done once per binary (e.g., `daphne`, `run_tests`, `libAllKernels.so`, `libCUDAKernels.so`, etc).
+For the mentioned binaries this has already been taken care of (either somewhere near the main program entry point or
+via context creation in case of the libs). All setup is handled by the class `DaphneLogger` (with some extras in `ConfigParser`).
 1. Log messages can be submitted in two forms:
-    - ``spdlog::warn("my warning");``
-    - ``spdlog::get("default")->warn("my warning");``
+    - `spdlog::warn("my warning");`
+    - `spdlog::get("default")->warn("my warning");`
 
     The two statements have the same effect. But while the former is a short form for using the default logger, the latter
-    explicitly chooses the logger via the static ``get()`` method. This ``get()`` method is to be used with **caution** as 
+    explicitly chooses the logger via the static `get()` method. This `get()` method is to be used with **caution** as 
     it involves acquiring a lock, which is to be avoided **in performance critical sections** of the code. In the initial 
     implementation there is a logger for runtime kernels provided by the context object to work around this limitation.
-    See the matrix multiplication kernel in ``src/runtime/local/kernels/MatMult.cpp`` for example usage. 
+    See the matrix multiplication kernel in `src/runtime/local/kernels/MatMult.cpp` for example usage. 
 
 1. We can have several loggers, which can be configured differently. For example, to control how messages are logged
-in the CUDA compiler pass ``MarkCUDAOpsPass``, a logger named "compiler::cuda" is used. Additionally, avoiding the use of
-``spdlog::get()`` is demonstrated there. For each used logger, an entry
-in ``fallback_loggers`` (see DaphneLogger.cpp) must exist to prevent crashing when using an unconfigured logger.
-1. To configure log levels, formatting and output options, the DaphneUserConfig and ConfigParser have been extended.
-See an example of this in the ``UserConfig.json`` in the root directory of the DAPHNE code base.
+in the CUDA compiler pass `MarkCUDAOpsPass`, a logger named "compiler::cuda" is used. Additionally, avoiding the use of
+`spdlog::get()` is demonstrated there. For each used logger, an entry
+in `fallback_loggers` (see `DaphneLogger.cpp`) must exist to prevent crashing when using an unconfigured logger.
+1. To configure log levels, formatting and output options, the `DaphneUserConfig` and `ConfigParser` have been extended.
+See an example of this in the `UserConfig.json` in the root directory of the DAPHNE code base.
 1. At the moment, the output options of our logging infrastructure are a bit limited (initial version). A logger currently
-always emits messages to the console's std-out and optionally to a file if a file name is given in the config.
-1. The format of log messages can be customized. See the examples in ``UserConfig.json`` and the
+always emits messages to the console's `stdout` and optionally to a file if a file name is given in the configuration.
+1. The format of log messages can be customized. See the examples in `UserConfig.json` and the
 [spdlog documentation](https://github.com/gabime/spdlog/).
-1. If a logger is called while running unit tests (run_tests executable), make sure to ```#include <run_tests.h>``` and
-call ```auto dctx = setupContextAndLogger();``` somewhere before calling the kernel to be tested.
+1. If a logger is called while running unit tests (`run_tests` executable), make sure to `#include <run_tests.h>` and
+call `auto dctx = setupContextAndLogger();` somewhere before calling the kernel to be tested.
 1. Logging can be set to only work from a certain log level and above. This mechanism also serves as a global toggle.
-To set the log level limit, set ```{ "log-level-limit": "OFF" },```. In this example, taken from ``UserConfig.json``,
+To set the log level limit, set `{ "log-level-limit": "OFF" },`. In this example, taken from `UserConfig.json`,
 all logging is switched off, regardless of configuration.
 
 ## Log Levels
 
-These are the available log levels (taken from ```<spdlog/common.h>```). Since it's an enum, their numeric value
-start from 0 for TRACE to 6 for OFF.
+These are the available log levels (taken from `<spdlog/common.h>`). Since it's an enum, their numeric values
+start from `0` for `TRACE` to `6` for `OFF`.
 
 ```cpp
 namespace level {

--- a/doc/development/Profiling.md
+++ b/doc/development/Profiling.md
@@ -20,18 +20,18 @@ For a general overview of the profiling support in DAPHNE see the [user
 profiling documentation](/doc/Profiling.md).
 
 Profiling is implemented via an instrumentation pass that injects calls to the
-```StartProfiling``` and ```StopProfiling``` kernels at the start and end of
+`StartProfiling` and `StopProfiling` kernels at the start and end of
 each block. In turn, the kernels call the PAPI-HL API start and stop functions.
 
 ## Known Issues / TODO
 
 * For scripts with multiple blocks (e.g. UDFs), the compiler will generate
-  profiling passes for each block separately instead of a single script-wide
-  profiling pass.
-* The profiling kernels should be exposed at the DSL / IR level, so that users
-  can instrument / profile specific parts of their script. This will also need
-  compiler cooperation, to make sure that the profiled bock is not rearranged /
-  fused with other operations.
+    profiling passes for each block separately instead of a single script-wide
+    profiling pass.
+* The profiling kernels should be exposed at the DSL/IR level, so that users
+    can instrument/profile specific parts of their script. This will also need
+    compiler cooperation, to make sure that the profiled bock is not rearranged/
+    fused with other operations.
 * To aid with the development and regression tracking of the runtime, the
-  profiling kernels could also be extended to support profiling specific
-  kernels or parts of kernels.
+    profiling kernels could also be extended to support profiling specific
+    kernels or parts of kernels.

--- a/doc/development/Testing.md
+++ b/doc/development/Testing.md
@@ -117,7 +117,7 @@ See the [catch2 documentation](https://github.com/catchorg/Catch2/blob/devel/doc
 
 #### DAPHNE-specific Flags
 
-The test script has several flags that control how the DAPHNE system and the test executable are built through the build script `build.sh`.
+The test script has several flags that control how DAPHNE and the test executable are built through the build script `build.sh`.
 
 - `--cuda`, `--fpgaopencl`, and `--mpi` switch on the respective feature of DAPHNE.
 - `--no-papi` switch off the respective feature of DAPHNE.
@@ -140,7 +140,7 @@ Some suggestions in the context of DAPHNE:
 - Use [DAPHNE's logger](/doc/development/Logging.md) or custom print-outs to generate more debug output.
 - Use a debugger.
 
-#### Tests Fail in the CI Workflow (even though they pass in your local development environment)
+#### Tests Fail in the CI Workflow (Even Though They Pass in Your Local Development Environment)
 
 Unfortunately, this can happen.
 **Possible reasons** include:
@@ -265,7 +265,7 @@ In the following, we list just the most important ones, see the mentioned file f
 
 - The `.cpp`-files of the DaphneDSL script-level test cases often define macros like `MAKE_TEST_CASE` and `MAKE_FAILURE_TEST_CASE`. These wrap the test case creation such that we can easily create families of similar test cases.
 - Many of the script-level test cases have no highly descriptive names as that would be cumbersome. Instead, they are typically numbered. In that context, several of the utility functions mentioned above have a variant suffixed with `Simple` (e.g., `compareDaphneToRefSimple()`), which assumes a certain naming scheme of the test cases.
-- Please put a comment line at the top of each DaphneDSL/DaphneLib script used in a script-level test case that briefly explains what is being tested. Note that the purpose of the test is otherwise not always obvious. Putting a comment helps to keep the test case up-to-date when the DAPHNE system changes.
+- Please put a comment line at the top of each DaphneDSL/DaphneLib script used in a script-level test case that briefly explains what is being tested. Note that the purpose of the test is otherwise not always obvious. Putting a comment helps to keep the test case up-to-date when DAPHNE changes.
 - When using hand-written reference text files (e.g., with `compareDaphneToRef()`), note that there usually needs to be a newline at the end of the text file, as the DAPHNE output typically also ends with a newline. Otherwise, the test case fails even though the actual and expected outputs look quite similar at first glance.
 
 ### Writing Unit Test Cases

--- a/doc/development/WriteDocs.md
+++ b/doc/development/WriteDocs.md
@@ -18,30 +18,30 @@ limitations under the License.
 
 At the moment the collection of markdown files in the `doc` directory is rendered to HTML and deployed via GitHub Pages.
 
-If you insert a new markdown file, you have to add it into the html docs tree in [mkdocs.yml](/mkdocs.yml) at a suitable position under the `nav` section.
+If you insert a new markdown file, you have to add it into the HTML docs tree in [mkdocs.yml](/mkdocs.yml) at a suitable position under the `nav` section.
 
 ## Markdown Guideline
 
-Please write clean markdown code to ensure a proper parsing by the tools used to render HTML. It is very recommended to use an IDE like *VS Code*. Code offers the feature to directly render markdown pages while you work on them. The extension [markdownlint](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint) directly highlights syntax violations / problems.
+Please write clean markdown code to ensure a proper parsing by the tools used to render HTML. It is very recommended to use an IDE like *VS Code*. Code offers the feature to directly render markdown pages while you work on them. The extension [markdownlint](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint) directly highlights syntax violations/problems.
 
 ### Links
 
 * With `[<link-name>](<link-url/path>)` you can link to other files in the repo
-* Write links to other markdown files or source code files/directories so that they work locally / in the github repository
+* Write links to other markdown files or source code files/directories so that they work locally / in the GitHub repository
 * Do not use relative links like `../BuildingDaphne.md`
 * Always use absolute paths relative to the repo root like `/doc/development/BuildingDaphne.md`
 * The Links/URLs will be altered in order to work on the rendered HTML page as well
-* Reference to issues with `[<description>](/issues/123)`. This won't work on github itself but will be rendered in the html page then
+* Refer to issues with `[<description>](/issues/123)`. This won't work on GitHub itself but will be rendered in the HTML page then
 
 ### Additional Syntax
 
 While some markdown renderers are much more relaxed and render as wished, some points have to be considered so that mkdocs renders correctly as well.
 
 * 4 spaces indentation for nested lists (ordered/unordered) and code blocks within lists to ensure proper rendering for HTML
-* Using <\>: To use angle brackets use `<\>` notation outside an codeblock
+* Using <\>: To use angle brackets use `<\>` notation outside a code block
     * Example: `<nicer dicer\>` renders to <nicer dicer\>
 
-## Toolstack
+## Tool Stack
 
-* [MkDocs](https://www.mkdocs.org/) to build html from markdown files
+* [MkDocs](https://www.mkdocs.org/) to build HTML from markdown files
 * [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/) as HTML theme

--- a/doc/tutorial/sqlTutorial.md
+++ b/doc/tutorial/sqlTutorial.md
@@ -17,61 +17,59 @@ limitations under the License.
 # Using SQL in DaphneDSL
 
 DAPHNE supports a rudimentary version of SQL. At any point in a DaphneDSL script, we can execute a SQL query on frames.
-We need two operations to achieve this: ```registerView(...)``` and ```sql(...)```
+We need two DaphneDSL built-in functions to achieve this: `registerView(...)` and `sql(...)`.
 
-For the following examples we assume we already have a DaphneDSL script which includes calculations on a frame "x" that has the columns "a", "b" and "c".
+For the following examples, we assume we already have a DaphneDSL script which includes calculations on a frame `x` that has the columns `"a"`, `"b"`, and `"c"`.
 
 ## General Procedure
 
-### registerView(...)
+### `registerView(...)`
 
-RegisterView registers a frame for the sql operation.
-If we want to execute a SQL query on a frame, we *need* to register it before that.
+The built-in function `registerView()` registers a frame for use with the `sql()` built-in function.
+If we want to execute a SQL query on a frame, we *need* to register it first.
 The operation has two inputs: the name of the table, as a string, and the frame which shall be associated with the given name.
 
-For example, we can register the frame "x", from previous calculations, under the name "Table1". The DaphneDSL script for this would look like this:
+For example, we can register the frame `x`, from previous calculations, by the name `"Table1"`. The DaphneDSL script for this would look as follows:
 
-```cpp
+```R
 registerView("Table1", x);
 ```
 
-### sql(...)
+### `sql(...)`
 
-Now that we have registered the tables, that we need for our SQL query, we can go ahead and execute our query. The SQL operation takes one input: the SQL query, as a string. In it, we will reference the table names we previously have registered via registerView(...). As a result of this operation, we get back a frame. The columns of the frame are named after the projection arguments inside the SQL query.
+Now that we have registered the tables we need for our SQL query, we can go ahead and execute our query. The SQL operation takes one input: the SQL query, as a string. The SQL query can reference the table names we previously have registered via `registerView(...)`. As a result of this operation, we get back a frame. The columns of the frame are named according to the `SELECT`-clause of the SQL query.
 
-For example, we want to return all the rows of the frame x, which we have previously registered under the name "Table1", where the column "a" is greater than 5 and save it in a new frame named "y". The DaphneDSL script for this would look like this:
+For example, we want to return all the rows of the frame `x`, which we have previously registered by the name `"Table1"`, where the column `"a"` is greater than `5` and save it in a new frame named `y`. The DaphneDSL script for this would look as follows:
 
-```cpp
+```R
 y = sql("SELECT t.a as a, t.b as b, t.c as c FROM Table1 as t WHERE t.a > 5;");
 ```
 
-This results in a frame "y" that has three columns "a", "b" and "c".
-On the frame y we can continue to build our DaphneDSL script.
+This results in a frame `y` that has three columns `"a"`, `"b"`, and `"c"`.
+On the frame `y` we can continue to build our DaphneDSL script.
 
 ## Features
 
-We don't support the complete SQL standard at the moment. For instance, we need to fully specify on which columns we want to operate. In the example above, we see "t.a" instead of simply "a".
-Also, not supported are DDL and DCL Queries. Our goal for DML queries is to only support SELECT-statements.
+We don't support the complete SQL standard at the moment. For instance, we need to fully specify on which columns we want to operate. In the example above, we see `t.a` instead of simply `a`.
+Also, not supported are DDL and DCL Queries. Our goal for DML queries is to only support `SELECT`-statements.
 Other features we do and don't support right now can be found below.
 
 ### Supported Features
 
-* SQL Cross Product (Cartesian Product)
-* Complex Where Clauses
-* Inner Join with single and multiple join conditions separated by an "AND" Operator
-* Group By Clauses
-* Having Clauses
-* Order By Clauses
-* As
-* Distinct
+* `SELECT`-clause including `AS` and `DISTINCT`
+* `FROM`-clause: cross product (Cartesian product) as well as `INNER JOIN` with a single and multiple join conditions separated by `AND`
+* Complex `WHERE`-clauses
+* `GROUPY BY`-clauses
+* `HAVING`-clauses
+* `ORDER BY`-clauses
 
 ### Not Yet Supported Features
 
-* The Star Operator \*
-* Nested SQL Queries like: ```SELECT a FROM x WHERE a IN SELECT a FROM y```
-* All Set Operations (Union, Except, Intersect)
-* Recursive SQL Queries
-* Limit
+* The star operator \*
+* Nested SQL queries like: `SELECT a FROM x WHERE a IN (SELECT a FROM y)`
+* Set operations (`UNION`, `EXCEPT`, `INTERSECT`)
+* Recursive SQL queries
+* `LIMIT`-clause
 
 ## Examples
 
@@ -80,7 +78,7 @@ The DaphneDSL scripts can be found in `doc/tutorial/sqlExample1.daph` and `doc/t
 
 ### Example 1
 
-```cpp
+```R
 //Creation of different matrices for a Frame
     //seq(a, b, c) generates a sequences of the form [a, b] and step size c
     employee_id = seq(1, 20, 1);
@@ -110,7 +108,7 @@ The DaphneDSL scripts can be found in `doc/tutorial/sqlExample1.daph` and `doc/t
 
 ### Example 2
 
-```cpp
+```R
 employee_id = seq(1, 20, 1);
 salary = rand(20, 1, 250.0, 500.0, 1.0, -1);
 age = [20, 30, 23, 65, 70, 42, 34, 55, 76, 32, 53, 40, 42, 69, 63, 26, 70, 36, 21, 23];


### PR DESCRIPTION
- The online documentation generated automatically from the Markdown files in directory doc/ through mkdocs contained a vast number of little syntactic issues, which made it appear untidy.
- This commit fixes the following kinds of such issues:
  - Fixed numerous indentation issues (especially in relation to lists; mkdocs demands a strict Markdown syntax here (otherwise, the generated HTML is chaotic), e.g., indentation of 4 spaces, blank lines in many situations).
  - Fixed numerous typos and grammar mistakes.
  - Ensured consistent wording/spelling: "DAPHNE" (not "Daphne"), "DAPHNE" (not "the DAPHNE system/prototype"), "GitHub" (not "github"), "Slurm" (not "SLURM"), "HTML" (not "html"), and several more.
  - Consistenly upper-cased all headlines (lines starting with #).
  - Removed HTML tags (e.g., "<br />") in most cases (can usually be done natively in Markdown).
  - Added a language for syntax highlighting to all code blocks (lines enclosed by ```) where it was missing.
  - Turned double-quoated (``x``) and triple-quoted (```x```) inline code fragments to single-quoted (`x`) ones (unless they contained backticks "`").
  - Employed inline code highlighting (`x`) in many more places.
  - Replaced [here](...) links by expressive names.
  - Added missing license headers.
  - Removed "What Next?" section in one file (not very useful).
  - Fixed a few links to source files (need to start with /).
- The contents/semantics of the documentation was not changed.

-----

**Going through a pull request just to make sure the CI checks pass.**