### PR TITLE
Addition of a getter and setter to lists

### DIFF
--- a/doc/DaphneDSL/Builtins.md
+++ b/doc/DaphneDSL/Builtins.md
@@ -707,3 +707,6 @@ These must be provided in a separate [`.meta`-file](/doc/FileMetaDataFormat.md).
 
     Replaces the element at position `idx` (counting starts at zero) from the given list `lst` with the given element `elm`.
     Returns (1) the result as a new list (the argument list stays unchanged), and (2) the old element.
+- **`getElementInList`**`(lst:list, idx:size)`
+
+    Returns the element at position `idx` (counting starts at zero) from the given list `lst`.

--- a/doc/DaphneDSL/Builtins.md
+++ b/doc/DaphneDSL/Builtins.md
@@ -702,3 +702,8 @@ These must be provided in a separate [`.meta`-file](/doc/FileMetaDataFormat.md).
 
     Removes the element at position `idx` (counting starts at zero) from the given list `lst`.
     Returns (1) the result as a new list (the argument list stays unchanged), and (2) the removed element.
+
+- **`replaceElementInList`**`(lst:list, idx:size, elm:matrix)`
+
+    Replaces the element at position `idx` (counting starts at zero) from the given list `lst` with the given element `elm`.
+    Returns (1) the result as a new list (the argument list stays unchanged), and (2) the old element.

--- a/src/ir/daphneir/DaphneInferTypesOpInterface.cpp
+++ b/src/ir/daphneir/DaphneInferTypesOpInterface.cpp
@@ -752,6 +752,16 @@ std::vector<Type> daphne::ReplaceElementInListOp::inferTypes() {
                                           "ReplaceElementInListOp expects a list as its first argument");
 }
 
+std::vector<Type> daphne::GetElementInListOp::inferTypes() {
+    // The type of the result is the element type of the argument list.
+    Type argListTy = getArgList().getType();
+    if (auto lt = argListTy.dyn_cast<daphne::ListType>())
+        return {lt.getElementType()};
+    else
+        throw ErrorHandler::compilerError(getLoc(), "InferTypesOpInterface",
+                                          "GetElementInListOp expects a list as its first argument");
+}
+
 // ****************************************************************************
 // Type inference function
 // ****************************************************************************

--- a/src/ir/daphneir/DaphneInferTypesOpInterface.cpp
+++ b/src/ir/daphneir/DaphneInferTypesOpInterface.cpp
@@ -741,6 +741,17 @@ std::vector<Type> daphne::RemoveOp::inferTypes() {
                                           "RemoveOp expects a list as its first argument");
 }
 
+std::vector<Type> daphne::ReplaceElementInListOp::inferTypes() {
+    // The type of the first result is the same as that of the argument list.
+    // The type of the second result is the element type of the argument list.
+    Type argListTy = getArgList().getType();
+    if (auto lt = argListTy.dyn_cast<daphne::ListType>())
+        return {lt, lt.getElementType()};
+    else
+        throw ErrorHandler::compilerError(getLoc(), "InferTypesOpInterface",
+                                          "ReplaceElementInListOp expects a list as its first argument");
+}
+
 // ****************************************************************************
 // Type inference function
 // ****************************************************************************

--- a/src/ir/daphneir/DaphneOps.td
+++ b/src/ir/daphneir/DaphneOps.td
@@ -2011,6 +2011,15 @@ def Daphne_RemoveOp : Daphne_Op<"remove", [
     let results = (outs ListOrU:$resList, MatrixOrU:$elem);
 }
 
+def Daphne_ReplaceElementInListOp : Daphne_Op<"replaceElementInList", [
+    DeclareOpInterfaceMethods<InferTypesOpInterface>
+]> {
+    let summary = "Replaces the element at the specified index from the given list with the given element. Returns the old element.";
+    
+    let arguments = (ins ListOrU:$argList, Size:$idx, MatrixOrU:$argElem);
+    let results = (outs ListOrU:$resList, MatrixOrU:$oldElem);
+}
+
 // ****************************************************************************
 // Old operations
 // ****************************************************************************

--- a/src/ir/daphneir/DaphneOps.td
+++ b/src/ir/daphneir/DaphneOps.td
@@ -2020,6 +2020,15 @@ def Daphne_ReplaceElementInListOp : Daphne_Op<"replaceElementInList", [
     let results = (outs ListOrU:$resList, MatrixOrU:$oldElem);
 }
 
+def Daphne_GetElementInListOp : Daphne_Op<"getElementInList", [
+    DeclareOpInterfaceMethods<InferTypesOpInterface>
+]> {
+    let summary = "Returns the element at the specified index from the given list";
+    
+    let arguments = (ins ListOrU:$argList, Size:$idx);
+    let results = (outs MatrixOrU:$elem);
+}
+
 // ****************************************************************************
 // Old operations
 // ****************************************************************************

--- a/src/parser/daphnedsl/DaphneDSLBuiltins.cpp
+++ b/src/parser/daphnedsl/DaphneDSLBuiltins.cpp
@@ -1347,6 +1347,12 @@ antlrcpp::Any DaphneDSLBuiltins::build(mlir::Location loc, const std::string &fu
 
         return builder.create<ReplaceElementInListOp>(loc, utils.unknownType, utils.unknownType, list, idx, elem).getResults();
     }
+    if (func == "getElementInList") {
+        checkNumArgsExact(loc, func, numArgs, 2);
+        mlir::Value list = args[0];
+        mlir::Value idx = utils.castSizeIf(args[1]);
+        return builder.create<GetElementInListOp>(loc, utils.unknownType, list, idx).getResult();
+    }
 
     // ********************************************************************
 

--- a/src/parser/daphnedsl/DaphneDSLBuiltins.cpp
+++ b/src/parser/daphnedsl/DaphneDSLBuiltins.cpp
@@ -1339,6 +1339,14 @@ antlrcpp::Any DaphneDSLBuiltins::build(mlir::Location loc, const std::string &fu
 
         return builder.create<RemoveOp>(loc, utils.unknownType, utils.unknownType, list, idx).getResults();
     }
+    if (func == "replaceElementInList") {
+        checkNumArgsExact(loc, func, numArgs, 3);
+        mlir::Value list = args[0];
+        mlir::Value idx = utils.castSizeIf(args[1]);
+        mlir::Value elem = args[2];
+
+        return builder.create<ReplaceElementInListOp>(loc, utils.unknownType, utils.unknownType, list, idx, elem).getResults();
+    }
 
     // ********************************************************************
 

--- a/src/runtime/local/datastructures/List.h
+++ b/src/runtime/local/datastructures/List.h
@@ -140,6 +140,42 @@ template <typename DataType> class List : public Structure {
         // must not be freed here, since we return it.
         return element;
     }
+
+    /**
+     * @brief Replaces the element at the given position with the provided element.
+     *
+     * @param idx The position of the element to replace.
+     * @param element The new element to insert.
+     * @return The old element that was replaced.
+     */
+    const DataType* replace(size_t idx, const DataType* element) {
+        if (idx >= elements.size())
+            throw std::runtime_error("trying to replace element at position " + std::to_string(idx) +
+                                    " in a list with " + std::to_string(elements.size()) + " elements");
+        const DataType* oldElement = elements[idx];
+        // Increase ref counter for the new element before replacing
+        element->increaseRefCounter();
+        // Replace the element
+        elements[idx] = element;
+        // Note that we do not decrease the reference counter of the element. It
+        // must not be freed here, since we return it.       
+        return oldElement;
+    }
+
+    /**
+     * @brief Returns a copy of the element at the given position.
+     *
+     * @param idx The position of the element to return.
+     * @return The element at the given position.
+     */
+    const DataType *get(size_t idx) const {
+        if (idx >= elements.size())
+            throw std::runtime_error("trying to access element at position " + std::to_string(idx) +
+                                    " from a list with " + std::to_string(elements.size()) + " elements");
+        // Increase ref counter for the element before returning it
+        elements[idx]->increaseRefCounter();
+        return elements[idx];
+    }
 };
 
 template <typename DataType> std::ostream &operator<<(std::ostream &os, const List<DataType> &obj) {

--- a/src/runtime/local/datastructures/List.h
+++ b/src/runtime/local/datastructures/List.h
@@ -148,7 +148,7 @@ template <typename DataType> class List : public Structure {
      * @param element The new element to insert.
      * @return The old element that was replaced.
      */
-    const DataType* replace(size_t idx, const DataType* element) {
+    const DataType *replace(size_t idx, const DataType* element) {
         if (idx >= elements.size())
             throw std::runtime_error("trying to replace element at position " + std::to_string(idx) +
                                     " in a list with " + std::to_string(elements.size()) + " elements");
@@ -168,7 +168,7 @@ template <typename DataType> class List : public Structure {
      * @param idx The position of the element to return.
      * @return The element at the given position.
      */
-    const DataType *get(size_t idx) const {
+    const DataType *getElementInList(size_t idx) const {
         if (idx >= elements.size())
             throw std::runtime_error("trying to access element at position " + std::to_string(idx) +
                                     " from a list with " + std::to_string(elements.size()) + " elements");

--- a/src/runtime/local/kernels/ReplaceElementInList.h
+++ b/src/runtime/local/kernels/ReplaceElementInList.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024 The DAPHNE Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <runtime/local/context/DaphneContext.h>
+#include <runtime/local/datastructures/CSRMatrix.h>
+#include <runtime/local/datastructures/DataObjectFactory.h>
+#include <runtime/local/datastructures/DenseMatrix.h>
+#include <runtime/local/datastructures/List.h>
+
+// ****************************************************************************
+// Convenience function
+// ****************************************************************************
+
+template <class DT> void replaceElementInList(List<DT> *&resList, DT *&elem, const List<DT> *argList, size_t idx, const DT *newElem, DCTX(ctx)) {
+    resList = DataObjectFactory::create<List<DT>>(argList);
+    elem = const_cast<DT *>(resList->replace(idx, newElem));
+}

--- a/src/runtime/local/kernels/getElementInList.h
+++ b/src/runtime/local/kernels/getElementInList.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024 The DAPHNE Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <runtime/local/context/DaphneContext.h>
+#include <runtime/local/datastructures/CSRMatrix.h>
+#include <runtime/local/datastructures/DataObjectFactory.h>
+#include <runtime/local/datastructures/DenseMatrix.h>
+#include <runtime/local/datastructures/List.h>
+
+// ****************************************************************************
+// Convenience function
+// ****************************************************************************
+
+template <class DT> void getElementInList(DT *&elem, const List<DT> *argList, size_t idx, DCTX(ctx)) {
+    elem = const_cast<DT *>(argList->getElementInList(idx));
+}

--- a/src/runtime/local/kernels/kernels.json
+++ b/src/runtime/local/kernels/kernels.json
@@ -6180,6 +6180,62 @@
 
     {
         "kernelTemplate": {
+            "header": "ReplaceElementInList.h",
+            "opName": "replaceElementInList",
+            "returnType": "void",
+            "templateParams": [
+                {
+                    "name": "DT",
+                    "isDataType": true
+                }
+            ],
+            "runtimeParams": [
+                {
+                    "type": "List<DT> *&",
+                    "name": "resList"
+                },
+                {
+                    "type": "DT *&",
+                    "name": "elem"
+                },
+                {
+                    "type": "const List<DT> *",
+                    "name": "argList"
+                },
+                {
+                    "type": "size_t",
+                    "name": "idx"
+                },
+                {
+                    "type": "const DT *",
+                    "name": "newElem"
+                }
+            ]
+        },
+        "instantiations": [
+            [["DenseMatrix", "double"]],
+            [["DenseMatrix", "float"]],
+            [["DenseMatrix", "int64_t"]],
+            [["DenseMatrix", "int32_t"]],
+            [["DenseMatrix", "int8_t"]],
+            [["DenseMatrix", "uint64_t"]],
+            [["DenseMatrix", "uint32_t"]],
+            [["DenseMatrix", "uint8_t"]],
+            [["DenseMatrix", "size_t"]],
+            [["CSRMatrix", "double"]],
+            [["CSRMatrix", "float"]],
+            [["CSRMatrix", "int64_t"]],
+            [["CSRMatrix", "int32_t"]],
+            [["CSRMatrix", "int8_t"]],
+            [["CSRMatrix", "uint64_t"]],
+            [["CSRMatrix", "uint32_t"]],
+            [["CSRMatrix", "uint8_t"]],
+            [["CSRMatrix", "size_t"]]
+        ]
+    },
+
+    {
+        "kernelTemplate": {
             "header": "Conv2DForward.h",
             "opName": "conv2DForward",
             "returnType": "void",

--- a/src/runtime/local/kernels/kernels.json
+++ b/src/runtime/local/kernels/kernels.json
@@ -6236,6 +6236,54 @@
 
     {
         "kernelTemplate": {
+            "header": "GetElementInList.h",
+            "opName": "getElementInList",
+            "returnType": "void",
+            "templateParams": [
+                {
+                    "name": "DT",
+                    "isDataType": true
+                }
+            ],
+            "runtimeParams": [
+                {
+                    "type": "DT *&",
+                    "name": "elem"
+                },
+                {
+                    "type": "const List<DT> *",
+                    "name": "argList"
+                },
+                {
+                    "type": "size_t",
+                    "name": "idx"
+                }
+            ]
+        },
+        "instantiations": [
+            [["DenseMatrix", "double"]],
+            [["DenseMatrix", "float"]],
+            [["DenseMatrix", "int64_t"]],
+            [["DenseMatrix", "int32_t"]],
+            [["DenseMatrix", "int8_t"]],
+            [["DenseMatrix", "uint64_t"]],
+            [["DenseMatrix", "uint32_t"]],
+            [["DenseMatrix", "uint8_t"]],
+            [["DenseMatrix", "size_t"]],
+            [["CSRMatrix", "double"]],
+            [["CSRMatrix", "float"]],
+            [["CSRMatrix", "int64_t"]],
+            [["CSRMatrix", "int32_t"]],
+            [["CSRMatrix", "int8_t"]],
+            [["CSRMatrix", "uint64_t"]],
+            [["CSRMatrix", "uint32_t"]],
+            [["CSRMatrix", "uint8_t"]],
+            [["CSRMatrix", "size_t"]]
+        ]
+    },
+
+    {
+        "kernelTemplate": {
             "header": "Conv2DForward.h",
             "opName": "conv2DForward",
             "returnType": "void",

--- a/test/api/cli/lists/ListsTest.cpp
+++ b/test/api/cli/lists/ListsTest.cpp
@@ -43,5 +43,5 @@ const std::string dirPath = "test/api/cli/lists/";
         }                                                                                                              \
     }
 
-MAKE_SUCCESS_TEST_CASE("lists", 4)
-MAKE_FAILURE_TEST_CASE("lists", 3)
+MAKE_SUCCESS_TEST_CASE("lists", 5)
+MAKE_FAILURE_TEST_CASE("lists", 6)

--- a/test/api/cli/lists/ListsTest.cpp
+++ b/test/api/cli/lists/ListsTest.cpp
@@ -43,5 +43,5 @@ const std::string dirPath = "test/api/cli/lists/";
         }                                                                                                              \
     }
 
-MAKE_SUCCESS_TEST_CASE("lists", 5)
-MAKE_FAILURE_TEST_CASE("lists", 6)
+MAKE_SUCCESS_TEST_CASE("lists", 6)
+MAKE_FAILURE_TEST_CASE("lists", 9)

--- a/test/api/cli/lists/lists_failure_4.daphne
+++ b/test/api/cli/lists/lists_failure_4.daphne
@@ -1,0 +1,4 @@
+// Replace an element from a list, out-of-bounds (too low) position.
+
+l = createList([1]);
+l, e = replaceElementInList(l, -1, [6,7]);

--- a/test/api/cli/lists/lists_failure_5.daphne
+++ b/test/api/cli/lists/lists_failure_5.daphne
@@ -1,0 +1,4 @@
+// Replace an element from a list, out-of-bounds (too high) position.
+
+l = createList([1]);
+l, e = replaceElementInList(l, 10, [6,7]);

--- a/test/api/cli/lists/lists_failure_6.daphne
+++ b/test/api/cli/lists/lists_failure_6.daphne
@@ -1,0 +1,5 @@
+// Replace an element from an empty list.
+
+l = createList([1]);
+l, e = remove(l, 0);
+l, e = replaceElementInList(l, 0, [5]); // replace from empty list

--- a/test/api/cli/lists/lists_failure_7.daphne
+++ b/test/api/cli/lists/lists_failure_7.daphne
@@ -1,0 +1,4 @@
+// Get an element from a list, out-of-bounds (too low) position.
+
+l = createList([1]);
+e = getElementInList(l, -1);

--- a/test/api/cli/lists/lists_failure_8.daphne
+++ b/test/api/cli/lists/lists_failure_8.daphne
@@ -1,0 +1,4 @@
+// Get an element from a list, out-of-bounds (too high) position.
+
+l = createList([1]);
+e = getElementInList(l, 1);

--- a/test/api/cli/lists/lists_failure_9.daphne
+++ b/test/api/cli/lists/lists_failure_9.daphne
@@ -1,0 +1,5 @@
+// Get an element from an empty list.
+
+l = createList([1]);
+l, e = remove(l, 0);
+e = getElementInList(l, 0); // get from empty list

--- a/test/api/cli/lists/lists_success_5.daphne
+++ b/test/api/cli/lists/lists_success_5.daphne
@@ -1,0 +1,9 @@
+// Replacing an element in a list functions.
+//The original list remains unchanged.
+//The old element is correctly returned.
+
+l1 = createList([0],[1],[2],[3],[4]);
+l2, e = replaceElementInList(l1, 2, [933]);
+print(l1);
+print(l2);
+print(e);

--- a/test/api/cli/lists/lists_success_5.txt
+++ b/test/api/cli/lists/lists_success_5.txt
@@ -1,0 +1,24 @@
+List(5, DenseMatrix, int64_t)
+DenseMatrix(1x1, int64_t)
+0
+DenseMatrix(1x1, int64_t)
+1
+DenseMatrix(1x1, int64_t)
+2
+DenseMatrix(1x1, int64_t)
+3
+DenseMatrix(1x1, int64_t)
+4
+List(5, DenseMatrix, int64_t)
+DenseMatrix(1x1, int64_t)
+0
+DenseMatrix(1x1, int64_t)
+1
+DenseMatrix(1x1, int64_t)
+933
+DenseMatrix(1x1, int64_t)
+3
+DenseMatrix(1x1, int64_t)
+4
+DenseMatrix(1x1, int64_t)
+2

--- a/test/api/cli/lists/lists_success_6.daphne
+++ b/test/api/cli/lists/lists_success_6.daphne
@@ -1,0 +1,11 @@
+//get first, middle, and last element of list.
+
+l1 = createList([0],[1],[2],[3],[4]);
+first_elem = getElementInList(l1,0);
+middle_elem = getElementInList(l1,2);
+last_elem = getElementInList(l1,4);
+print(l1);
+print("TEST: RETRIEVED ELEMENTS");
+print(first_elem);
+print(middle_elem);
+print(last_elem);

--- a/test/api/cli/lists/lists_success_6.txt
+++ b/test/api/cli/lists/lists_success_6.txt
@@ -1,0 +1,18 @@
+List(5, DenseMatrix, int64_t)
+DenseMatrix(1x1, int64_t)
+0
+DenseMatrix(1x1, int64_t)
+1
+DenseMatrix(1x1, int64_t)
+2
+DenseMatrix(1x1, int64_t)
+3
+DenseMatrix(1x1, int64_t)
+4
+TEST: RETRIEVED ELEMENTS
+DenseMatrix(1x1, int64_t)
+0
+DenseMatrix(1x1, int64_t)
+2
+DenseMatrix(1x1, int64_t)
+4


### PR DESCRIPTION
This PR adds support for a getter and a setter for the list data structure in DaphneDSL. I am open to changing the names of the functions and also how they operate. I wasn't sure how to call the functions, so I made the names verbose to leave no confusion of what the function does. As for the setter method, I modeled it to be as close as possible to the remove method for lists to increase the chances of the function working as intended.

New Functions:

1. RemoveElementInList()
2. GetElementInList()

Exactly how the functions work are written in the documentation for built in functions, Builtin.md.

Tests cases have been written similar to the pre existing tests for lists. 