### PR TITLE
[DAPHNE-#824] Ensuring the result of "X @ t(X)" is symmetric.

### DIFF
--- a/src/compiler/inference/AdaptTypesToKernelsPass.cpp
+++ b/src/compiler/inference/AdaptTypesToKernelsPass.cpp
@@ -103,6 +103,10 @@ void AdaptTypesToKernelsPass::runOnOperation() {
                 for (size_t i = 0; i < numOperands; i++)
                     operandIdxs.push_back(i);
                 targetVTy = resVTy;
+            } else if (op->hasTrait<OpTrait::CastFirstArgToResType>()) {
+                // Cast input 0 to the result value type.
+                operandIdxs = {0};
+                targetVTy = resVTy;
             } else if (op->hasTrait<OpTrait::CastFirstTwoArgsToResType>()) {
                 // Cast inputs 0 and 1 to the result value type.
                 operandIdxs = {0, 1};

--- a/src/ir/daphneir/DaphneAdaptTypesToKernelsTraits.h
+++ b/src/ir/daphneir/DaphneAdaptTypesToKernelsTraits.h
@@ -21,6 +21,8 @@ namespace mlir::OpTrait {
 
 template <class ConcreteOp> class CastArgsToResType : public TraitBase<ConcreteOp, CastArgsToResType> {};
 
+template <class ConcreteOp> class CastFirstArgToResType : public TraitBase<ConcreteOp, CastFirstArgToResType> {};
+
 template <class ConcreteOp>
 class CastFirstTwoArgsToResType : public TraitBase<ConcreteOp, CastFirstTwoArgsToResType> {};
 

--- a/src/ir/daphneir/DaphneOps.td
+++ b/src/ir/daphneir/DaphneOps.td
@@ -1021,11 +1021,10 @@ def Daphne_SyrkOp : Daphne_Op<"syrk", [
     TypeFromFirstArg,
     DeclareOpInterfaceMethods<VectorizableOpInterface>,
     NumRowsFromArgNumCols, NumColsFromArg, CUDASupport,FPGAOPENCLSupport, 
-    CastArgsToResType
+    CastFirstArgToResType
 ]> {
-    // TODO: support `A @ t(A)` operation
-    let summary = [{Performs the operation `t(A) @ A`}];
-    let arguments = (ins MatrixOrU:$arg);
+    let summary = [{Performs the operation `t(A) @ A` if `transLeft` is `true`; or `A @ t(A)`, otherwise.}];
+    let arguments = (ins MatrixOrU:$arg, BoolScalar:$transLeft);
     let results = (outs MatrixOrU:$res);
 }
 

--- a/src/ir/daphneir/DaphneTypeAdaptationTraits.td
+++ b/src/ir/daphneir/DaphneTypeAdaptationTraits.td
@@ -20,6 +20,7 @@
 include "mlir/IR/OpBase.td"
 
 def CastArgsToResType: NativeOpTrait<"CastArgsToResType">;
+def CastFirstArgToResType: NativeOpTrait<"CastFirstArgToResType">;
 def CastFirstTwoArgsToResType: NativeOpTrait<"CastFirstTwoArgsToResType">;
 def CastArgsToResTypeRandMatrixOp: NativeOpTrait<"CastArgsToResTypeRandMatrixOp">;
 def CastArgsToMostGeneralArgType: NativeOpTrait<"CastArgsToMostGeneralArgType">;

--- a/src/parser/daphnedsl/DaphneDSLBuiltins.cpp
+++ b/src/parser/daphnedsl/DaphneDSLBuiltins.cpp
@@ -926,7 +926,10 @@ antlrcpp::Any DaphneDSLBuiltins::build(mlir::Location loc, const std::string &fu
             builder.create<CTableOp>(loc, utils.unknownType, lhs, rhs, weight, resNumRows, resNumCols));
     }
     if (func == "syrk") {
-        return createSameTypeUnaryOp<SyrkOp>(loc, func, args);
+        checkNumArgsExact(loc, func, numArgs, 1);
+        mlir::Value arg = args[0];
+        mlir::Value transLeft = builder.create<mlir::daphne::ConstantOp>(loc, true);
+        return CompilerUtils::retValWithInferredType(builder.create<SyrkOp>(loc, utils.unknownType, arg, transLeft));
     }
     if (func == "gemv") {
         checkNumArgsExact(loc, func, numArgs, 2);

--- a/src/runtime/local/kernels/kernels.json
+++ b/src/runtime/local/kernels/kernels.json
@@ -4895,6 +4895,10 @@
                 {
                     "type": "const DTArg *",
                     "name": "arg"
+                },
+                {
+                    "type": "bool",
+                    "name": "transLeft"
                 }
             ]
         },

--- a/test/api/cli/operations/OperationsTest.cpp
+++ b/test/api/cli/operations/OperationsTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <api/cli/StatusCode.h>
 #include <api/cli/Utils.h>
 
 #include <tags.h>
@@ -22,6 +23,7 @@
 
 #include <sstream>
 #include <string>
+#include <vector>
 
 const std::string dirPath = "test/api/cli/operations/";
 
@@ -71,3 +73,81 @@ MAKE_TEST_CASE("sum", 1)
 MAKE_TEST_CASE("syrk", 1)
 MAKE_TEST_CASE("transpose", 1)
 MAKE_TEST_CASE("upper", 1)
+
+// Checks if the result of both `t(X) @ X` and `X @ t(X)`, when using physical operator selection (default args), is:
+// (1) equal to the result of the same expressions when not using physical operator selection (up to round-off errors),
+// and (2) symmetric (there should not even be round-off errors).
+TEST_CASE("operator_at_symmetry", TAG_OPERATIONS) {
+    // We use a few different shapes for the matrix X, since an incorrect implementation might still produce symmetric
+    // results for some shapes (before the commit that introduced this test case, `X @ t(X)` was lowered to the
+    // matmul-kernel, which didn't produce symmetric results for some input shapes). We ensure that the result is
+    // symmetric by lowering to the syrk-kernel. To check if the result is (not only symmetric but also) correct (up to
+    // round-off errors), we compare it to the result without the rewrite from MatMulOp to SyrkOp, by passing
+    // `--no-phy-op-selection`.
+
+    std::string scriptFilePath = dirPath + "operator_at_symmetry.daphne";
+
+    std::string checkSymArgFalse = "checkSymmetry=false";
+    std::string checkSymArgTrue = "checkSymmetry=true";
+
+    std::string sep = "-----\n";
+    std::string outExpSym = "t(X) @ X is symmetric\nX @ t(X) is symmetric\n" + sep;
+
+    std::vector<size_t> choiceSize = {1, 3, 57, 100, 256};
+    for (size_t numRows : choiceSize)
+        for (size_t numCols : choiceSize) {
+            DYNAMIC_SECTION("" << numRows << "x" << numCols) {
+                std::string numRowsArg = "numRows=" + std::to_string(numRows);
+                std::string numColsArg = "numCols=" + std::to_string(numCols);
+
+                // In all variable names:
+                // "1" stands for "with physical operator selection"
+                // "2" stands for "without physical operator selection"
+
+                // Run DAPHNE with physical operator selection (default args).
+                std::stringstream out1, err1;
+                int status1 = runDaphne(out1, err1, scriptFilePath.c_str(), numRowsArg.c_str(), numColsArg.c_str(),
+                                        checkSymArgTrue.c_str());
+
+                // Run DAPHNE without physical operator selection.
+                std::stringstream out2, err2;
+                int status2 = runDaphne(out2, err2, "--no-phy-op-selection", scriptFilePath.c_str(), numRowsArg.c_str(),
+                                        numColsArg.c_str(), checkSymArgFalse.c_str());
+
+                // Both runs of DAPHNE must succeed.
+                // Just CHECK (don't REQUIRE) success, such that in case of a failure, the following checks run and
+                // provide useful messages.
+                CHECK(status1 == StatusCode::SUCCESS);
+                CHECK(status2 == StatusCode::SUCCESS);
+
+                std::string outStr1 = out1.str();
+                std::string outStr2 = out2.str();
+
+                // Extract the first section of the output, which contains the results of the two expressions.
+                size_t pos1 = outStr1.find(sep);
+                size_t pos2 = outStr2.find(sep);
+                REQUIRE(pos1 > 0);                  // results output must no be empty
+                REQUIRE(pos2 > 0);                  // results output must no be empty
+                REQUIRE(pos1 != std::string::npos); // separator must be present
+                REQUIRE(pos2 != std::string::npos); // separator must be present
+                // The result of `t(X) @ X` must be the same (up to round-off errors) with and without physical operator
+                // selection. The same must hold for `X @ t(X)`. An approximate check is achieved through the limited
+                // precision when printing the matrices in DaphneDSL.
+                CHECK(outStr1.substr(0, pos1) == outStr2.substr(0, pos2));
+
+                // Only for the results with physical operator selection:
+                // - Extract the second section of the output, which contains the results of the symmetry check.
+                // - The results of both `t(X) @ X` and `X @ t(X)` must be symmetric.
+                CHECK(outStr1.substr(pos1 + sep.size(), outExpSym.size()) == outExpSym);
+
+                // We don't check the contents of the third section of the output, which contains the eigen values and
+                // eigen vectors, since we are not interested in the concrete data; we just want to see if their
+                // calculation succeeds.
+
+                // The error output of both runs of DAPHNE must be empty.
+                // Don't check empty(), because then catch2 doesn't display the error output.
+                CHECK(err1.str() == "");
+                CHECK(err2.str() == "");
+            }
+        }
+}

--- a/test/api/cli/operations/operator_at_symmetry.daphne
+++ b/test/api/cli/operations/operator_at_symmetry.daphne
@@ -1,0 +1,34 @@
+// '@' for matrix multiplication
+// The result of multiplying a matrix by its transposed should be symmetric (there should not even be round-off errors).
+
+# Generate some random data.
+X = rand($numRows, $numCols, 0.0, 1.0, 1, 12345);
+
+# Calculate the results.
+YL = t(X) @ X;
+YR = X @ t(X);
+
+# Print the result.
+print(YL);
+print(YR);
+
+print("-----");
+
+if($checkSymmetry) {
+    # Use isSymmetric() to check symmetry.
+    print("t(X) @ X is " + (isSymmetric(YL) ? "" : "NOT ") + "symmetric");
+    print("X @ t(X) is " + (isSymmetric(YR) ? "" : "NOT ") + "symmetric");
+
+    print("-----");
+
+    # At some point, the DAPHNE compiler may be clever enough to infer at compile-time that YL and YR are symmetric.
+    # Then, it may replace the calls to isSymmetric() by constants, thereby circumventing the check at run-time.
+    # Thus, we also use the eigen() built-in function here, because it performs a check for symmetry internally.
+    evalsL, evecsL = eigen(YL);
+    evalsR, evecsR = eigen(YR);
+    # Print the eigen values and eigen vectors such that their calculation is not optimized away.
+    print(evalsL);
+    print(evecsL);
+    print(evalsR);
+    print(evecsR);
+}


### PR DESCRIPTION
- The result of both "t(X) @ X" and "X @ t(X)" should be a symmetric matrix for any input matrix X.
- Problem:
  - So far, the result of "X @ t(X)" could be not fully symmetric; there could be tiny deviations when comparing the upper and lower triangles.
  - Actually, the involved MatMulOp should be rewritten to a SyrkOp for both expressions; SyrkOp is backed by the syrk-kernel, which calls BLAS syrk() internally and guarantees a symmetric result.
  - This rewrite from MatMulOp to SyrkOp is performed by the PhyOperatorSelectionPass.
  - However, so far, this rewrite only happened for "t(X) @ X", not for "X @ t(X)".
- This commit ensures that not only "t(X) @ X" but also "X @ t(X)" is lowered to SyrkOp; that way, we gurantee that the result of the expression is indeed a symmetric matrix.
- Changes:
  - SyrkOp has an additional boolean argument that specifies if "t(A) @ A" or "A @ t(A)" shall be calculated (similar to BLAS syrk()).
  - As a consequence, the type adaptation trait on SyrkOp had to be changed from CastArgsToResType to CastFirstArgToResType (which had to be newly created).
  - Updated SyrkOp's implementation of the VectorizableOpInterface to take the new argument into account.
  - The DaphneDSL built-in function syrk() remains unchanged, i.e., does not get the additional argument. This is because this built-in function only exists as a workaround for a specific situation, while actually users should use logical matrix multuplications (@ operator) and the system should figure out the best physical algorithm automatically. Hence, no new script-level test cases for the syrk() built-in function.
  - PhyOperatorSelectionPass also rewrites "X @ t(X)" to "syrk(X, false)"; furthermore this pass was restructured a bit for improved clarity.
  - The syrk-kernel also has the new argument and was changed accordingly to support both "t(X) @ X" and "X @ t(X)" by providing the right argument to BLAS syrk().
  - The unit test cases for the syrk-kernel take the new parameter into account (check both values).
  - Added a new script-level test case that checks if the result of both "t(X) @ X" and "X @ t(X)" is (1) symmetric and (2) correct up to round-off errors.
- Closes #824.

-----

**I'm just going through a pull request to see if the CI checks pass. Comments on the code are welcome, but not required.**