### PR TITLE
feat: add macOS (Apple Silicon) build support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,12 +154,32 @@ if(USE_CUDA AND CMAKE_CUDA_COMPILER)
 endif()
 
 find_program(LLD_PROGRAM lld)
-if(LLD_PROGRAM)
+if(LLD_PROGRAM AND NOT APPLE)
     message(STATUS "Using lld")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fuse-ld=lld")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fuse-ld=lld")
 endif()
 
+# On macOS, LLVM/MLIR's cmake config creates partial zstd IMPORTED targets
+# (shared + static) but not the zstd::libzstd alias. Homebrew's zstd cmake
+# config then fails when Arrow tries to re-find zstd because some targets
+# already exist. Work around by telling Arrow that zstd is already found.
+# Also fix the INTERFACE_INCLUDE_DIRECTORIES: LLVM's Findzstd.cmake sets it
+# to /opt/homebrew/include (all of Homebrew), which pulls in wrong versions
+# of headers (e.g. fmt 11.2 vs our thirdparty fmt 11.0). Narrow it to the
+# zstd-specific include path.
+if(APPLE AND TARGET zstd::libzstd_shared)
+    set(zstdAlt_FOUND TRUE)
+    find_path(_ZSTD_SPECIFIC_INCLUDE zstd.h PATHS /opt/homebrew/opt/zstd/include NO_DEFAULT_PATH)
+    if(_ZSTD_SPECIFIC_INCLUDE)
+        set_target_properties(zstd::libzstd_shared PROPERTIES
+            INTERFACE_INCLUDE_DIRECTORIES "${_ZSTD_SPECIFIC_INCLUDE}")
+        if(TARGET zstd::libzstd_static)
+            set_target_properties(zstd::libzstd_static PROPERTIES
+                INTERFACE_INCLUDE_DIRECTORIES "${_ZSTD_SPECIFIC_INCLUDE}")
+        endif()
+    endif()
+endif()
 find_package(Arrow REQUIRED)
 find_package(Parquet REQUIRED)
 
@@ -205,7 +225,7 @@ if(USE_HDFS)
     endif()
 
     include_directories(${PROJECT_SOURCE_DIR} ${HDFS_LIB_LOCATION})
-    find_library(hdfs3 NAMES libhdfs3.so HINTS ${PROJECT_BINARY_DIR}/installed/lib REQUIRED)
+    find_library(hdfs3 NAMES hdfs3 HINTS ${PROJECT_BINARY_DIR}/installed/lib REQUIRED)
     message(STATUS "HDFS_LIB_FOUND: ${HDFS_LIB_FOUND}")
     if(DEFINED HDFS_LIB_FOUND)
         add_definitions(-DUSE_HDFS)

--- a/build.sh
+++ b/build.sh
@@ -26,6 +26,32 @@
 # Stop immediately if any command fails.
 set -e
 
+#******************************************************************************
+# Platform detection and portable helpers
+#******************************************************************************
+IS_DARWIN=0
+if [ "$(uname -s)" == "Darwin" ]; then
+    IS_DARWIN=1
+fi
+
+# Portable replacement for nproc (not available on macOS)
+get_nproc() {
+    if [ "$IS_DARWIN" == "1" ]; then
+        sysctl -n hw.ncpu
+    else
+        nproc
+    fi
+}
+
+# Portable replacement for sed -i (different syntax on macOS)
+sed_inplace() {
+    if [ "$IS_DARWIN" == "1" ]; then
+        sed -i '' "$@"
+    else
+        sed -i "$@"
+    fi
+}
+
 build_ts_begin=$(date +%s%N)
 
 #******************************************************************************
@@ -455,6 +481,10 @@ BUILD_MPI="-DUSE_MPI=OFF"
 BUILD_HDFS="-DUSE_HDFS=OFF"
 BUILD_IO_URING="-DUSE_IO_URING=OFF"
 BUILD_PAPI="-DUSE_PAPI=ON"
+# Default PAPI to OFF on macOS (not well supported)
+if [ "$IS_DARWIN" == "1" ]; then
+    BUILD_PAPI="-DUSE_PAPI=OFF"
+fi
 WITH_DEPS=1
 DEPS_ONLY=0
 WITH_SUBMODULE_UPDATE=1
@@ -583,12 +613,26 @@ fi
 #******************************************************************************
 # #8 Download and install third-party dependencies if requested (default is yes, omit with --no-deps))
 #******************************************************************************
+# On macOS, use Apple Clang for third-party dependency builds to avoid
+# boringssl/GCC incompatibilities. DAPHNE itself uses GCC-15 (set below).
+
 if [ $WITH_DEPS -gt 0 ]; then
+    # CMake 4.x removed compatibility with cmake_minimum_required < 3.5.
+    # Many third-party deps use older versions; this global setting allows them to configure.
+    export CMAKE_POLICY_VERSION_MINIMUM=3.5
+
+    # On macOS, use GCC-15 for all builds (deps + DAPHNE) for ABI compatibility.
+    # The boringssl patches below handle GCC-specific issues.
+    if [ "$IS_DARWIN" == "1" ]; then
+        export CC=gcc-15
+        export CXX=g++-15
+    fi
+
     LLVM_ARCH=X86
     # optimizes for multiple x86_64 architectures
     PAPI_OBLAS_ARCH=NEHALEM
     # Determine CPU architecture to compile for
-    if [ $(arch) == 'armv*'  ] || [ $(arch) == 'aarch64' ]; then
+    if [ $(arch) == 'armv*'  ] || [ $(arch) == 'aarch64' ] || [ $(arch) == 'arm64' ]; then
       echo "Building for ARMv8 architecture"
       LLVM_ARCH=AArch64
       PAPI_OBLAS_ARCH=ARMV8
@@ -636,7 +680,7 @@ if [ $WITH_DEPS -gt 0 ]; then
                 --with-components="coretemp infiniband io lustre net powercap rapl sde stealtime" \
 
 
-            CFLAGS="-fPIC -DPIC" make -j"$(nproc)" DYNAMIC_ARCH=1 TARGET="$PAPI_OBLAS_ARCH"
+            CFLAGS="-fPIC -DPIC" make -j"$(get_nproc)" DYNAMIC_ARCH=1 TARGET="$PAPI_OBLAS_ARCH"
             make install
             cd - > /dev/null
             dependency_install_success "papi_v${papiVersion}"
@@ -661,7 +705,7 @@ if [ $WITH_DEPS -gt 0 ]; then
     if ! is_dependency_installed "hwloc_v${hwlocVersion}"; then
         cd "$sourcePrefix/$hwlocDirName/"
         ./configure --prefix="$hwlocInstDirName"
-        make -j"$(nproc)" DYNAMIC_ARCH=1 TARGET="$PAPI_OBLAS_ARCH"
+        make -j"$(get_nproc)" DYNAMIC_ARCH=1 TARGET="$PAPI_OBLAS_ARCH"
         make install
         cd - > /dev/null
         dependency_install_success "hwloc_v${hwlocVersion}"
@@ -702,7 +746,11 @@ if [ $WITH_DEPS -gt 0 ]; then
             -d "$sourcePrefix/$antlrCppRuntimeDirName"
         # Github disabled the unauthenticated git:// protocol, patch antlr4 to use https://
         # until we upgrade to antlr4-4.9.3+
-        sed -i 's#git://github.com#https://github.com#' "$sourcePrefix/$antlrCppRuntimeDirName/runtime/CMakeLists.txt"
+        sed_inplace 's#git://github.com#https://github.com#' "$sourcePrefix/$antlrCppRuntimeDirName/runtime/CMakeLists.txt"
+
+        # CMake 4.x no longer supports setting deprecated policies to OLD. Remove them.
+        sed_inplace '/CMAKE_POLICY(SET CMP00[2-5][0-9] OLD)/d' \
+            "$sourcePrefix/$antlrCppRuntimeDirName/CMakeLists.txt"
 
         daphne_msg "Build Antlr v${antlrVersion}"
         cmake -S "$sourcePrefix/$antlrCppRuntimeDirName" -B "${buildPrefix}/${antlrCppRuntimeDirName}" \
@@ -764,7 +812,15 @@ if [ $WITH_DEPS -gt 0 ]; then
     if ! is_dependency_installed "${dep_openBlas[@]}"; then
         cd "$sourcePrefix/$openBlasDirName"
         make clean
-        make -j"$(nproc)" DYNAMIC_ARCH=1 TARGET="$PAPI_OBLAS_ARCH"
+        # GCC 15+ treats -Wincompatible-pointer-types as error; OpenBLAS 0.3.23 triggers it
+        # macOS doesn't support DYNAMIC_ARCH (clang assembler lacks many -mtune targets)
+        if [ "$IS_DARWIN" == "1" ]; then
+            make -j"$(get_nproc)" TARGET="$PAPI_OBLAS_ARCH" \
+                CFLAGS="-Wno-error=incompatible-pointer-types" \
+                COMMON_OPT="-Wno-error=incompatible-pointer-types"
+        else
+            make -j"$(get_nproc)" DYNAMIC_ARCH=1 TARGET="$PAPI_OBLAS_ARCH"
+        fi
         make PREFIX="$openBlasInstDirName" install
         cd - >/dev/null
         dependency_install_success "${dep_openBlas[@]}"
@@ -793,7 +849,7 @@ if [ $WITH_DEPS -gt 0 ]; then
     # abseil (compiled separately to apply a patch)
     #------------------------------------------------------------------------------
     abslPath=$sourcePrefix/abseil-cpp
-    if [ $(arch) == 'armv64'  ] || [ $(arch) == 'aarch64' ]; then
+    if [ $(arch) == 'armv64'  ] || [ $(arch) == 'aarch64' ] || [ $(arch) == 'arm64' ]; then
         abslVersion=20211102.0
     fi
     dep_absl=("absl_v${abslVersion}" "v1")
@@ -802,7 +858,7 @@ if [ $WITH_DEPS -gt 0 ]; then
         daphne_msg "Get abseil version ${abslVersion}"
         rm -rf "$abslPath"
         git clone --depth 1 --branch "$abslVersion" https://github.com/abseil/abseil-cpp.git "$abslPath"
-        if [ $(arch) == 'armv*'  ] || [ $(arch) == 'aarch64' ]; then
+        if [ $(arch) == 'armv*'  ] || [ $(arch) == 'aarch64' ] || [ $(arch) == 'arm64' ]; then
            daphne_msg "Applying 0002-absl-stdmax-params.patch"
            patch -Np1 -i "${patchDir}/0002-absl-stdmax-params.patch" -d "$abslPath"
         fi
@@ -820,26 +876,28 @@ if [ $WITH_DEPS -gt 0 ]; then
     #------------------------------------------------------------------------------
     # MPI (Default is MPI library is OpenMPI but cut can be any)
     #------------------------------------------------------------------------------
-    MPIZipName=openmpi-$openMPIVersion.tar.gz
-    MPIInstDirName=$installPrefix
-    dep_mpi=("openmpi_v${openMPIVersion}" "v1")
+    if [ "$BUILD_MPI" == "-DUSE_MPI=ON" ]; then
+        MPIZipName=openmpi-$openMPIVersion.tar.gz
+        MPIInstDirName=$installPrefix
+        dep_mpi=("openmpi_v${openMPIVersion}" "v1")
 
-    if ! is_dependency_downloaded "${dep_mpi[@]}"; then
-        daphne_msg "Get openmpi version ${openMPIVersion}"
-        wget "https://download.open-mpi.org/release/open-mpi/v4.1/$MPIZipName" -qO "${cacheDir}/${MPIZipName}"
-        tar -xf "$cacheDir/$MPIZipName" --directory "$sourcePrefix"
-        dependency_download_success "${dep_mpi[@]}"
-        mkdir -p "$MPIInstDirName"
-    fi
-    if ! is_dependency_installed "${dep_mpi[@]}"; then
-        cd "$sourcePrefix/openmpi-$openMPIVersion"
-        ./configure --prefix="$MPIInstDirName"
-        make -j"$(nproc)" all
-        make install
-        cd -
-        dependency_install_success "${dep_mpi[@]}"
-    else
-        daphne_msg "No need to build OpenMPI again"
+        if ! is_dependency_downloaded "${dep_mpi[@]}"; then
+            daphne_msg "Get openmpi version ${openMPIVersion}"
+            wget "https://download.open-mpi.org/release/open-mpi/v4.1/$MPIZipName" -qO "${cacheDir}/${MPIZipName}"
+            tar -xf "$cacheDir/$MPIZipName" --directory "$sourcePrefix"
+            dependency_download_success "${dep_mpi[@]}"
+            mkdir -p "$MPIInstDirName"
+        fi
+        if ! is_dependency_installed "${dep_mpi[@]}"; then
+            cd "$sourcePrefix/openmpi-$openMPIVersion"
+            ./configure --prefix="$MPIInstDirName"
+            make -j"$(get_nproc)" all
+            make install
+            cd -
+            dependency_install_success "${dep_mpi[@]}"
+        else
+            daphne_msg "No need to build OpenMPI again"
+        fi
     fi
     #------------------------------------------------------------------------------
     # gRPC
@@ -866,8 +924,21 @@ if [ $WITH_DEPS -gt 0 ]; then
         dependency_download_success "${dep_grpc[@]}"
     fi
     if ! is_dependency_installed "${dep_grpc[@]}"; then
+        # Patch boringssl for GCC compatibility on macOS:
+        # 1) __builtin_available() is a Clang-only builtin; on macOS 10.12+
+        #    getentropy() is always available so the check can be removed.
+        # 2) -stdlib=libc++ is a Clang-only flag; GCC uses libstdc++ natively.
+        if [ "$IS_DARWIN" == "1" ]; then
+            sed_inplace 's/if (__builtin_available(macos 10\.12, \*))/if (1)/g' \
+                "$sourcePrefix/$grpcDirName/third_party/boringssl-with-bazel/src/crypto/fipsmodule/rand/urandom.c"
+            sed_inplace '/stdlib=libc++/d' \
+                "$sourcePrefix/$grpcDirName/third_party/boringssl-with-bazel/CMakeLists.txt"
+            sed_inplace '/stdlib=libc++/d' \
+                "$sourcePrefix/$grpcDirName/third_party/boringssl-with-bazel/src/CMakeLists.txt"
+        fi
         cmake -G Ninja -S "$sourcePrefix/$grpcDirName" -B "$buildPrefix/$grpcDirName" \
             -DCMAKE_INSTALL_PREFIX="$grpcInstDir" \
+            -DCMAKE_PREFIX_PATH="$installPrefix" \
             -DCMAKE_BUILD_TYPE=Release \
             -DgRPC_INSTALL=ON \
             -DgRPC_BUILD_TESTS=OFF \
@@ -897,8 +968,8 @@ if [ $WITH_DEPS -gt 0 ]; then
     fi
 
     # this works around a build error that occurs on Ubuntu with Boost installed
-    if [ $(lsb_release -is) == "Ubuntu" ]; then
-        if [ $(dpkg -l | grep libboost | wc -l) == "" ]; then
+    if [ "$IS_DARWIN" != "1" ] && [ "$(lsb_release -is 2>/dev/null)" == "Ubuntu" ]; then
+        if [ "$(dpkg -l | grep libboost | wc -l)" == "" ]; then
             daphne_msg "Setting BOOST_ROOT=/usr on Ubuntu Linux with libboost installed"
             sleep 5
             export BOOST_ROOT=/usr
@@ -906,6 +977,14 @@ if [ $WITH_DEPS -gt 0 ]; then
     fi
 
     if ! is_dependency_installed "${dep_arrow[@]}"; then
+        # GCC-15 is stricter about missing includes; Arrow 13 uses std::find
+        # without #include <algorithm> in filesystem/util_internal.cc.
+        if [ "$IS_DARWIN" == "1" ]; then
+            arrow_file="${sourcePrefix}/${arrowDirName}/cpp/src/arrow/filesystem/util_internal.cc"
+            if ! grep -q '#include <algorithm>' "$arrow_file" 2>/dev/null; then
+                sed_inplace '1s/^/#include <algorithm>\n/' "$arrow_file"
+            fi
+        fi
         cmake -G Ninja -S "${sourcePrefix}/${arrowDirName}/cpp" -B "${buildPrefix}/${arrowDirName}" \
             -DCMAKE_INSTALL_PREFIX="${installPrefix}" -DARROW_CSV=ON -DARROW_FILESYSTEM=ON -DARROW_PARQUET=ON \
             -DARROW_WITH_BROTLI=ON -DARROW_WITH_BZ2=ON -DARROW_WITH_LZ4=ON -DARROW_WITH_SNAPPY=ON -DARROW_WITH_ZLIB=ON \
@@ -951,7 +1030,8 @@ if [ $WITH_DEPS -gt 0 ]; then
     fi
     if ! is_dependency_installed "spdlog_v${spdlogVersion}"; then
         cmake -G Ninja -S "${sourcePrefix}/${spdlogDirName}" -B "${buildPrefix}/${spdlogDirName}" \
-            -DSPDLOG_FMT_EXTERNAL=ON -DCMAKE_INSTALL_PREFIX="${installPrefix}" -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+            -DSPDLOG_FMT_EXTERNAL=ON -DCMAKE_INSTALL_PREFIX="${installPrefix}" -DCMAKE_PREFIX_PATH="${installPrefix}" \
+            -DCMAKE_POSITION_INDEPENDENT_CODE=ON
         cmake --build "${buildPrefix}/${spdlogDirName}" --target install/strip
         dependency_install_success "spdlog_v${spdlogVersion}"
     else
@@ -1047,13 +1127,23 @@ if [ $WITH_DEPS -gt 0 ]; then
         daphne_msg "Building LLVM/MLIR from ${llvmCommit}"
         cd "${thirdpartyPath}/${llvmName}"
         echo "Need to build MLIR/LLVM."
+        # On macOS, use GCC-15 for LLVM/MLIR build to ensure ABI compatibility
+        # with the rest of the project (all using libstdc++). LLD is disabled
+        # because it is a Clang/LLVM-specific linker.
+        if [ "$IS_DARWIN" == "1" ]; then
+            LLVM_COMPILER_FLAGS="-DCMAKE_C_COMPILER=gcc-15 -DCMAKE_CXX_COMPILER=g++-15"
+            LLVM_LLD_FLAG=""
+        else
+            LLVM_COMPILER_FLAGS="-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++"
+            LLVM_LLD_FLAG="-DLLVM_ENABLE_LLD=ON"
+        fi
         cmake -G Ninja -S llvm -B "$buildPrefix/$llvmName" \
             -DLLVM_ENABLE_PROJECTS=mlir \
             -DLLVM_BUILD_EXAMPLES=OFF \
             -DLLVM_TARGETS_TO_BUILD="$LLVM_ARCH" \
             -DCMAKE_BUILD_TYPE=Release \
             -DLLVM_ENABLE_ASSERTIONS=ON \
-            -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DLLVM_ENABLE_LLD=ON \
+            $LLVM_COMPILER_FLAGS $LLVM_LLD_FLAG \
             -DLLVM_ENABLE_RTTI=ON \
             -DCMAKE_INSTALL_PREFIX="$installPrefix"
         cmake --build "$buildPrefix/$llvmName" --target check-mlir
@@ -1085,7 +1175,7 @@ if [ $WITH_DEPS -gt 0 ]; then
         if ! is_dependency_installed "liburing_v${liburingVersion}"; then
             cd "$sourcePrefix/$liburingDirName"
             ./configure --cc="$liburing_cc" --cxx="$liburing_cxx" --prefix="$liburingInstDirName"
-            make -j"$(nproc)"
+            make -j"$(get_nproc)"
             cp ./src/liburing.a "$installPrefix/lib/"
             cp -r ./src/include/* "$installPrefix/include"
             cd - > /dev/null
@@ -1123,9 +1213,22 @@ fi
 
 daphne_msg "Build Daphne"
 
+DAPHNE_CMAKE_EXTRA=()
+if [ "$IS_DARWIN" == "1" ]; then
+    macosSdk="${DAPHNE_MACOS_SDK:-/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk}"
+    # GCC-15 is already exported; explicitly pass to cmake as well.
+    export SDKROOT="$macosSdk"
+
+    DAPHNE_CMAKE_EXTRA+=(
+        -DCMAKE_C_COMPILER=gcc-15
+        -DCMAKE_CXX_COMPILER=g++-15
+        -DCMAKE_OSX_SYSROOT="$macosSdk"
+    )
+fi
+
 cmake -S "$projectRoot" -B "$daphneBuildDir" -G Ninja -DANTLR_VERSION="$antlrVersion" \
     -DCMAKE_PREFIX_PATH="$installPrefix" \
-    $BUILD_CUDA $BUILD_FPGAOPENCL $BUILD_DEBUG $BUILD_MPI $BUILD_HDFS $BUILD_PAPI
+    $BUILD_CUDA $BUILD_FPGAOPENCL $BUILD_DEBUG $BUILD_MPI $BUILD_HDFS $BUILD_PAPI $DAPHNE_CMAKE_EXTRA
 
 cmake --build "$daphneBuildDir" --target "$target"
 

--- a/doc/development/BuildingDaphne.md
+++ b/doc/development/BuildingDaphne.md
@@ -132,6 +132,37 @@ All possible options for the build script:
 
 ---
 
+## Building on macOS (Experimental)
+
+DAPHNE can be built natively on macOS with Apple Silicon (ARM64). This support is experimental.
+
+### Prerequisites
+
+Install [Homebrew](https://brew.sh/), then install the required packages:
+
+```bash
+brew install gcc@15 cmake ninja wget zstd libomp
+```
+
+GCC is required because DAPHNE and all its dependencies must be built with the
+same C++ standard library (libstdc++). Apple Clang uses libc++, which is
+ABI-incompatible and causes link failures.
+
+### Building
+
+```bash
+./build.sh --no-papi
+```
+
+The build script automatically detects macOS and configures GCC-15 as the compiler. PAPI is not supported on macOS, so `--no-papi` is required.
+
+### Known Limitations
+
+- CPU pinning (thread affinity) is disabled on macOS
+- PAPI-based profiling is not available
+- CUDA and FPGA options are not supported on macOS
+- Only Apple Silicon (ARM64) has been tested
+
 ## Building on WSL
 
 When using Windows Subsystems for Linux (WSL), the default memory limit for WSL is 50% of the total memory of the underlying Windows host. This can lead to build fails due to SIGKILL for DAPHNE builds. [Advanced settings configuration in WSL](https://learn.microsoft.com/en-us/windows/wsl/wsl-config) describes how the memory limit can be configured.

--- a/src/api/cli/DaphneUserConfig.h
+++ b/src/api/cli/DaphneUserConfig.h
@@ -24,6 +24,11 @@
 #include <util/LogConfig.h>
 class DaphneLogger;
 
+#ifdef __APPLE__
+#include <climits>
+#include <mach-o/dyld.h>
+#endif
+
 #include <filesystem>
 #include <limits>
 #include <map>
@@ -148,8 +153,14 @@ struct DaphneUserConfig {
     void resolveLibDir() {
         const std::string exedirPlaceholder = "{exedir}/";
         if (libdir.substr(0, exedirPlaceholder.size()) == exedirPlaceholder) {
-            // This next line adds to our Linux platform lock-in.
+#ifdef __APPLE__
+            char pathBuf[PATH_MAX];
+            uint32_t size = sizeof(pathBuf);
+            _NSGetExecutablePath(pathBuf, &size);
+            std::filesystem::path daphneExeDir(std::filesystem::canonical(pathBuf).parent_path());
+#else
             std::filesystem::path daphneExeDir(std::filesystem::canonical("/proc/self/exe").parent_path());
+#endif
             libdir = daphneExeDir / libdir.substr(exedirPlaceholder.size());
         }
     }

--- a/src/compiler/lowering/CMakeLists.txt
+++ b/src/compiler/lowering/CMakeLists.txt
@@ -37,7 +37,7 @@ add_mlir_dialect_library(MLIRDaphneTransforms
     LINK_COMPONENTS
     Core
 )
-find_library(HWLOC_LIB NAMES libhwloc.so HINTS ${PROJECT_BINARY_DIR}/installed/lib REQUIRED)
+find_library(HWLOC_LIB NAMES hwloc HINTS ${PROJECT_BINARY_DIR}/installed/lib REQUIRED)
 
 target_link_libraries(MLIRDaphneTransforms PUBLIC
     CompilerUtils
@@ -52,6 +52,7 @@ target_link_libraries(MLIRDaphneTransforms PUBLIC
     MLIRFuncTransforms
     SQLParser
     ${HWLOC_LIB}
+    fmt::fmt
 
 )
 

--- a/src/compiler/lowering/RewriteToCallKernelOpPass.cpp
+++ b/src/compiler/lowering/RewriteToCallKernelOpPass.cpp
@@ -498,8 +498,8 @@ class DistributedPipelineKernelReplacement : public OpConversionPattern<daphne::
             rewriter.create<daphne::StoreVariadicPackOp>(loc, cvpInputs, op.getInputs()[i],
                                                          rewriter.getI64IntegerAttr(i));
         // Constants for #inputs.
-        auto coNumInputs = rewriter.create<daphne::ConstantOp>(loc, numInputs);
-        [[maybe_unused]] auto coNumOutputs = rewriter.create<daphne::ConstantOp>(loc, numOutputs);
+        auto coNumInputs = rewriter.create<daphne::ConstantOp>(loc, static_cast<uint64_t>(numInputs));
+        [[maybe_unused]] auto coNumOutputs = rewriter.create<daphne::ConstantOp>(loc, static_cast<uint64_t>(numOutputs));
         // Variadic pack for out_rows.
         auto cvpOutRows =
             rewriter.create<daphne::CreateVariadicPackOp>(loc, vptSize, rewriter.getI64IntegerAttr(numOutputs));

--- a/src/compiler/lowering/RewriteToCallKernelOpPass.cpp
+++ b/src/compiler/lowering/RewriteToCallKernelOpPass.cpp
@@ -502,8 +502,9 @@ class DistributedPipelineKernelReplacement : public OpConversionPattern<daphne::
             rewriter.create<daphne::StoreVariadicPackOp>(loc, cvpInputs, op.getInputs()[i],
                                                          rewriter.getI64IntegerAttr(i));
         // Constants for #inputs.
-        auto coNumInputs = rewriter.create<daphne::ConstantOp>(loc, numInputs);
-        [[maybe_unused]] auto coNumOutputs = rewriter.create<daphne::ConstantOp>(loc, numOutputs);
+        auto coNumInputs = rewriter.create<daphne::ConstantOp>(loc, static_cast<uint64_t>(numInputs));
+        [[maybe_unused]] auto coNumOutputs =
+            rewriter.create<daphne::ConstantOp>(loc, static_cast<uint64_t>(numOutputs));
         // Variadic pack for out_rows.
         auto cvpOutRows =
             rewriter.create<daphne::CreateVariadicPackOp>(loc, vptSize, rewriter.getI64IntegerAttr(numOutputs));

--- a/src/compiler/utils/CompilerUtils.cpp
+++ b/src/compiler/utils/CompilerUtils.cpp
@@ -93,6 +93,20 @@ template <> std::pair<bool, bool> CompilerUtils::isConstant<bool>(mlir::Value v)
     return isConstantHelper<bool, mlir::BoolAttr>(v, [](mlir::BoolAttr attr) { return attr.getValue(); });
 }
 
+#if defined(__APPLE__) && defined(__aarch64__)
+// On macOS ARM64, long/unsigned long are distinct types from int64_t/uint64_t
+// (long = long, int64_t = long long), so we need separate instantiations.
+template <> std::pair<bool, long> CompilerUtils::isConstant<long>(mlir::Value v) {
+    return isConstantHelper<long, mlir::IntegerAttr>(
+        v, [](mlir::IntegerAttr attr) { return static_cast<long>(attr.getValue().getLimitedValue()); });
+}
+
+template <> std::pair<bool, unsigned long> CompilerUtils::isConstant<unsigned long>(mlir::Value v) {
+    return isConstantHelper<unsigned long, mlir::IntegerAttr>(
+        v, [](mlir::IntegerAttr attr) { return static_cast<unsigned long>(attr.getValue().getLimitedValue()); });
+}
+#endif
+
 // **************************************************************************************************
 // Specializations of constantOrThrow for various types
 // **************************************************************************************************
@@ -159,6 +173,18 @@ template <> double CompilerUtils::constantOrDefault<double>(mlir::Value v, doubl
 template <> bool CompilerUtils::constantOrDefault<bool>(mlir::Value v, bool d) {
     return constantOrDefaultHelper<bool, mlir::BoolAttr>(v, d, [](mlir::BoolAttr attr) { return attr.getValue(); });
 }
+
+#if defined(__APPLE__) && defined(__aarch64__)
+template <> long CompilerUtils::constantOrDefault<long>(mlir::Value v, long d) {
+    return constantOrDefaultHelper<long, mlir::IntegerAttr>(
+        v, d, [](mlir::IntegerAttr attr) { return static_cast<long>(attr.getValue().getLimitedValue()); });
+}
+
+template <> unsigned long CompilerUtils::constantOrDefault<unsigned long>(mlir::Value v, unsigned long d) {
+    return constantOrDefaultHelper<unsigned long, mlir::IntegerAttr>(
+        v, d, [](mlir::IntegerAttr attr) { return static_cast<unsigned long>(attr.getValue().getLimitedValue()); });
+}
+#endif
 
 // **************************************************************************************************
 // Other

--- a/src/ir/daphneir/DaphneVectorizableOpInterface.cpp
+++ b/src/ir/daphneir/DaphneVectorizableOpInterface.cpp
@@ -300,7 +300,7 @@ template <class AllAggOp> std::vector<daphne::VectorSplit> getVectorSplits_AllAg
 }
 template <class AllAggOp>
 std::vector<std::pair<Value, Value>> createOpsOutputSizes_AllAggOp(AllAggOp *op, OpBuilder &builder) {
-    auto cst1 = builder.create<daphne::ConstantOp>(op->getLoc(), size_t(1));
+    auto cst1 = builder.create<daphne::ConstantOp>(op->getLoc(), static_cast<uint64_t>(1));
     return {{cst1, cst1}};
 }
 

--- a/src/parser/daphnedsl/DaphneDSLVisitor.cpp
+++ b/src/parser/daphnedsl/DaphneDSLVisitor.cpp
@@ -1652,8 +1652,8 @@ antlrcpp::Any DaphneDSLVisitor::visitMatrixLiteralExpr(DaphneDSLGrammarParser::M
     // Missing dimensions are inferred (defaults to column matrix).
     if (!ctx->rows && !ctx->cols) {
         numMatElems = ctx->expr().size();
-        cols = builder.create<mlir::daphne::ConstantOp>(loc, static_cast<size_t>(1));
-        rows = builder.create<mlir::daphne::ConstantOp>(loc, static_cast<size_t>(ctx->expr().size()));
+        cols = builder.create<mlir::daphne::ConstantOp>(loc, static_cast<uint64_t>(1));
+        rows = builder.create<mlir::daphne::ConstantOp>(loc, static_cast<uint64_t>(ctx->expr().size()));
     } else {
         numMatElems = (ctx->rows && ctx->cols) ? ctx->expr().size() - 2 : ctx->expr().size() - 1;
         if (ctx->cols && ctx->rows) {
@@ -1663,12 +1663,12 @@ antlrcpp::Any DaphneDSLVisitor::visitMatrixLiteralExpr(DaphneDSLGrammarParser::M
             cols = valueOrErrorOnVisit(ctx->cols);
             rows =
                 builder.create<mlir::daphne::EwDivOp>(loc, builder.getIntegerType(64, false),
-                                                      builder.create<mlir::daphne::ConstantOp>(loc, numMatElems), cols);
+                                                      builder.create<mlir::daphne::ConstantOp>(loc, static_cast<uint64_t>(numMatElems)), cols);
         } else {
             rows = valueOrErrorOnVisit(ctx->rows);
             cols =
                 builder.create<mlir::daphne::EwDivOp>(loc, builder.getIntegerType(64, false),
-                                                      builder.create<mlir::daphne::ConstantOp>(loc, numMatElems), rows);
+                                                      builder.create<mlir::daphne::ConstantOp>(loc, static_cast<uint64_t>(numMatElems)), rows);
         }
     }
     cols = utils.castSizeIf(cols);
@@ -1939,17 +1939,17 @@ antlrcpp::Any DaphneDSLVisitor::visitLiteral(DaphneDSLGrammarParser::LiteralCont
         litStr = std::regex_replace(litStr, std::regex("_|'"), "");
 
         if (litStr.back() == 'u')
-            return static_cast<mlir::Value>(builder.create<mlir::daphne::ConstantOp>(loc, std::stoul(litStr)));
+            return static_cast<mlir::Value>(builder.create<mlir::daphne::ConstantOp>(loc, static_cast<uint64_t>(std::stoul(litStr))));
         else if ((litStr.length() > 2) && std::string_view(litStr).substr(litStr.length() - 3) == "ull") {
             // The suffix "ull" must be checked before the suffix "l", since "l"
             // is a suffix of "ull".
             return static_cast<mlir::Value>(
                 builder.create<mlir::daphne::ConstantOp>(loc, static_cast<uint64_t>(std::stoull(litStr))));
         } else if (litStr.back() == 'l')
-            return static_cast<mlir::Value>(builder.create<mlir::daphne::ConstantOp>(loc, std::stol(litStr)));
+            return static_cast<mlir::Value>(builder.create<mlir::daphne::ConstantOp>(loc, static_cast<int64_t>(std::stol(litStr))));
         else if (litStr.back() == 'z') {
             return static_cast<mlir::Value>(
-                builder.create<mlir::daphne::ConstantOp>(loc, static_cast<std::size_t>(std::stoll(litStr))));
+                builder.create<mlir::daphne::ConstantOp>(loc, static_cast<uint64_t>(std::stoll(litStr))));
         } else {
             // Note that a leading minus of a numeric literal is not parsed as
             // part of the literal itself, but handled separately as a unary

--- a/src/parser/daphnedsl/DaphneDSLVisitor.cpp
+++ b/src/parser/daphnedsl/DaphneDSLVisitor.cpp
@@ -1652,8 +1652,8 @@ antlrcpp::Any DaphneDSLVisitor::visitMatrixLiteralExpr(DaphneDSLGrammarParser::M
     // Missing dimensions are inferred (defaults to column matrix).
     if (!ctx->rows && !ctx->cols) {
         numMatElems = ctx->expr().size();
-        cols = builder.create<mlir::daphne::ConstantOp>(loc, static_cast<size_t>(1));
-        rows = builder.create<mlir::daphne::ConstantOp>(loc, static_cast<size_t>(ctx->expr().size()));
+        cols = builder.create<mlir::daphne::ConstantOp>(loc, static_cast<uint64_t>(1));
+        rows = builder.create<mlir::daphne::ConstantOp>(loc, static_cast<uint64_t>(ctx->expr().size()));
     } else {
         numMatElems = (ctx->rows && ctx->cols) ? ctx->expr().size() - 2 : ctx->expr().size() - 1;
         if (ctx->cols && ctx->rows) {
@@ -1661,14 +1661,14 @@ antlrcpp::Any DaphneDSLVisitor::visitMatrixLiteralExpr(DaphneDSLGrammarParser::M
             rows = valueOrErrorOnVisit(ctx->rows);
         } else if (ctx->cols) {
             cols = valueOrErrorOnVisit(ctx->cols);
-            rows =
-                builder.create<mlir::daphne::EwDivOp>(loc, builder.getIntegerType(64, false),
-                                                      builder.create<mlir::daphne::ConstantOp>(loc, numMatElems), cols);
+            rows = builder.create<mlir::daphne::EwDivOp>(
+                loc, builder.getIntegerType(64, false),
+                builder.create<mlir::daphne::ConstantOp>(loc, static_cast<uint64_t>(numMatElems)), cols);
         } else {
             rows = valueOrErrorOnVisit(ctx->rows);
-            cols =
-                builder.create<mlir::daphne::EwDivOp>(loc, builder.getIntegerType(64, false),
-                                                      builder.create<mlir::daphne::ConstantOp>(loc, numMatElems), rows);
+            cols = builder.create<mlir::daphne::EwDivOp>(
+                loc, builder.getIntegerType(64, false),
+                builder.create<mlir::daphne::ConstantOp>(loc, static_cast<uint64_t>(numMatElems)), rows);
         }
     }
     cols = utils.castSizeIf(cols);
@@ -1939,17 +1939,19 @@ antlrcpp::Any DaphneDSLVisitor::visitLiteral(DaphneDSLGrammarParser::LiteralCont
         litStr = std::regex_replace(litStr, std::regex("_|'"), "");
 
         if (litStr.back() == 'u')
-            return static_cast<mlir::Value>(builder.create<mlir::daphne::ConstantOp>(loc, std::stoul(litStr)));
+            return static_cast<mlir::Value>(
+                builder.create<mlir::daphne::ConstantOp>(loc, static_cast<uint64_t>(std::stoul(litStr))));
         else if ((litStr.length() > 2) && std::string_view(litStr).substr(litStr.length() - 3) == "ull") {
             // The suffix "ull" must be checked before the suffix "l", since "l"
             // is a suffix of "ull".
             return static_cast<mlir::Value>(
                 builder.create<mlir::daphne::ConstantOp>(loc, static_cast<uint64_t>(std::stoull(litStr))));
         } else if (litStr.back() == 'l')
-            return static_cast<mlir::Value>(builder.create<mlir::daphne::ConstantOp>(loc, std::stol(litStr)));
+            return static_cast<mlir::Value>(
+                builder.create<mlir::daphne::ConstantOp>(loc, static_cast<int64_t>(std::stol(litStr))));
         else if (litStr.back() == 'z') {
             return static_cast<mlir::Value>(
-                builder.create<mlir::daphne::ConstantOp>(loc, static_cast<std::size_t>(std::stoll(litStr))));
+                builder.create<mlir::daphne::ConstantOp>(loc, static_cast<uint64_t>(std::stoll(litStr))));
         } else {
             // Note that a leading minus of a numeric literal is not parsed as
             // part of the literal itself, but handled separately as a unary

--- a/src/runtime/distributed/worker/CMakeLists.txt
+++ b/src/runtime/distributed/worker/CMakeLists.txt
@@ -31,7 +31,7 @@ get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
 get_property(extension_libs GLOBAL PROPERTY MLIR_EXTENSION_LIBS)
 
 if(USE_HDFS)
-        find_library(LIBHDFS3 NAMES libhdfs3.so HINTS ${PROJECT_BINARY_DIR}/installed/lib REQUIRED)
+        find_library(LIBHDFS3 NAMES hdfs3 HINTS ${PROJECT_BINARY_DIR}/installed/lib REQUIRED)
 else()
         set(LIBHDFS3 "")
 endif()

--- a/src/runtime/local/datastructures/CSRMatrix.cpp
+++ b/src/runtime/local/datastructures/CSRMatrix.cpp
@@ -31,3 +31,7 @@ template class CSRMatrix<signed char>;
 template class CSRMatrix<unsigned char>;
 template class CSRMatrix<unsigned int>;
 template class CSRMatrix<unsigned long>;
+#if defined(__APPLE__) && defined(__aarch64__)
+template class CSRMatrix<long long>;
+template class CSRMatrix<unsigned long long>;
+#endif

--- a/src/runtime/local/datastructures/ChunkedTensor.cpp
+++ b/src/runtime/local/datastructures/ChunkedTensor.cpp
@@ -37,3 +37,7 @@ template class ChunkedTensor<int>;
 template class ChunkedTensor<long>;
 template class ChunkedTensor<unsigned int>;
 template class ChunkedTensor<unsigned long>;
+#if defined(__APPLE__) && defined(__aarch64__)
+template class ChunkedTensor<long long>;
+template class ChunkedTensor<unsigned long long>;
+#endif

--- a/src/runtime/local/datastructures/ContiguousTensor.cpp
+++ b/src/runtime/local/datastructures/ContiguousTensor.cpp
@@ -37,3 +37,7 @@ template class ContiguousTensor<int>;
 template class ContiguousTensor<long>;
 template class ContiguousTensor<unsigned int>;
 template class ContiguousTensor<unsigned long>;
+#if defined(__APPLE__) && defined(__aarch64__)
+template class ContiguousTensor<long long>;
+template class ContiguousTensor<unsigned long long>;
+#endif

--- a/src/runtime/local/datastructures/DenseMatrix.cpp
+++ b/src/runtime/local/datastructures/DenseMatrix.cpp
@@ -341,6 +341,11 @@ template class DenseMatrix<signed char>;
 template class DenseMatrix<unsigned char>;
 template class DenseMatrix<unsigned int>;
 template class DenseMatrix<unsigned long>;
+// On macOS ARM64, long long / unsigned long long are distinct from long / unsigned long.
+#if defined(__APPLE__) && defined(__aarch64__)
+template class DenseMatrix<long long>;
+template class DenseMatrix<unsigned long long>;
+#endif
 template class DenseMatrix<bool>;
 template class DenseMatrix<std::string>;
 template class DenseMatrix<FixedStr16>;

--- a/src/runtime/local/datastructures/ValueTypeUtils.cpp
+++ b/src/runtime/local/datastructures/ValueTypeUtils.cpp
@@ -97,6 +97,12 @@ template <> const ValueTypeCode ValueTypeUtils::codeFor<float> = ValueTypeCode::
 template <> const ValueTypeCode ValueTypeUtils::codeFor<double> = ValueTypeCode::F64;
 template <> const ValueTypeCode ValueTypeUtils::codeFor<std::string> = ValueTypeCode::STR;
 template <> const ValueTypeCode ValueTypeUtils::codeFor<FixedStr16> = ValueTypeCode::FIXEDSTR16;
+// On macOS ARM64, long/unsigned long are distinct from long long/unsigned long long
+// (int64_t/uint64_t). Add explicit specializations so DenseMatrix<long> etc. can compile.
+#if defined(__APPLE__) && defined(__aarch64__)
+template <> const ValueTypeCode ValueTypeUtils::codeFor<long> = ValueTypeCode::SI64;
+template <> const ValueTypeCode ValueTypeUtils::codeFor<unsigned long> = ValueTypeCode::UI64;
+#endif
 
 template <> const std::string ValueTypeUtils::cppNameFor<int8_t> = "int8_t";
 template <> const std::string ValueTypeUtils::cppNameFor<int32_t> = "int32_t";
@@ -110,6 +116,10 @@ template <> const std::string ValueTypeUtils::cppNameFor<bool> = "bool";
 template <> const std::string ValueTypeUtils::cppNameFor<const char *> = "const char*";
 template <> const std::string ValueTypeUtils::cppNameFor<std::string> = "std::string";
 template <> const std::string ValueTypeUtils::cppNameFor<FixedStr16> = "FixedStr";
+#if defined(__APPLE__) && defined(__aarch64__)
+template <> const std::string ValueTypeUtils::cppNameFor<long> = "int64_t";
+template <> const std::string ValueTypeUtils::cppNameFor<unsigned long> = "uint64_t";
+#endif
 
 template <> const std::string ValueTypeUtils::irNameFor<int8_t> = "si8";
 template <> const std::string ValueTypeUtils::irNameFor<int32_t> = "si32";
@@ -119,6 +129,10 @@ template <> const std::string ValueTypeUtils::irNameFor<uint32_t> = "ui32";
 template <> const std::string ValueTypeUtils::irNameFor<uint64_t> = "ui64";
 template <> const std::string ValueTypeUtils::irNameFor<float> = "f32";
 template <> const std::string ValueTypeUtils::irNameFor<double> = "f64";
+#if defined(__APPLE__) && defined(__aarch64__)
+template <> const std::string ValueTypeUtils::irNameFor<long> = "si64";
+template <> const std::string ValueTypeUtils::irNameFor<unsigned long> = "ui64";
+#endif
 
 template <> const int8_t ValueTypeUtils::defaultValue<int8_t> = 0;
 template <> const int32_t ValueTypeUtils::defaultValue<int32_t> = 0;
@@ -132,6 +146,10 @@ template <> const bool ValueTypeUtils::defaultValue<bool> = false;
 template <> const char *ValueTypeUtils::defaultValue<const char *> = "";
 template <> const std::string ValueTypeUtils::defaultValue<std::string> = std::string("");
 template <> const FixedStr16 ValueTypeUtils::defaultValue<FixedStr16> = FixedStr16();
+#if defined(__APPLE__) && defined(__aarch64__)
+template <> const long ValueTypeUtils::defaultValue<long> = 0;
+template <> const unsigned long ValueTypeUtils::defaultValue<unsigned long> = 0;
+#endif
 
 const std::string ValueTypeUtils::cppNameForCode(ValueTypeCode type) {
     switch (type) {

--- a/src/runtime/local/kernels/BinaryOpCode.h
+++ b/src/runtime/local/kernels/BinaryOpCode.h
@@ -89,7 +89,7 @@ static std::string_view binary_op_codes[] = {
  * @tparam op The binary operation.
  */
 template <BinaryOpCode op, typename VTRes, typename VTLhs, typename VTRhs>
-static constexpr bool supportsBinaryOp = false;
+inline constexpr bool supportsBinaryOp = false;
 
 // Macros for concisely specifying which binary operations should be
 // supported on which value types.
@@ -97,12 +97,12 @@ static constexpr bool supportsBinaryOp = false;
 // Generates code specifying that the binary operation `Op` should be supported
 // on the value type `VT` (for the result and the two arguments, for
 // simplicity).
-#define SUPPORT(Op, VT) template <> constexpr bool supportsBinaryOp<BinaryOpCode::Op, VT, VT, VT> = true;
+#define SUPPORT(Op, VT) template <> inline constexpr bool supportsBinaryOp<BinaryOpCode::Op, VT, VT, VT> = true;
 
 // Generates code specifying that the binary operation `Op` should be supported on
 // the value types `VTLhs` and `VTRhs` with result `VTRes`.
 #define SUPPORT_RLR(Op, VTRes, VTLhs, VTRhs)                                                                           \
-    template <> constexpr bool supportsBinaryOp<BinaryOpCode::Op, VTRes, VTLhs, VTRhs> = true;
+    template <> inline constexpr bool supportsBinaryOp<BinaryOpCode::Op, VTRes, VTLhs, VTRhs> = true;
 
 // Generates code specifying that all binary operations of a certain category
 // should be supported on the given value type `VT` (for the result and the two

--- a/src/runtime/local/kernels/CMakeLists.txt
+++ b/src/runtime/local/kernels/CMakeLists.txt
@@ -19,6 +19,18 @@ set(CMAKE_CXX_STANDARD 20 CACHE STRING "C++ standard to conform to")
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 find_package(Python3 REQUIRED COMPONENTS Interpreter)
+# Apple Clang needs Homebrew's libomp for OpenMP support
+if(APPLE)
+    execute_process(COMMAND brew --prefix libomp
+        OUTPUT_VARIABLE LIBOMP_PREFIX OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(LIBOMP_PREFIX)
+        set(OpenMP_C_FLAGS "-Xpreprocessor -fopenmp -I${LIBOMP_PREFIX}/include" CACHE STRING "" FORCE)
+        set(OpenMP_CXX_FLAGS "-Xpreprocessor -fopenmp -I${LIBOMP_PREFIX}/include" CACHE STRING "" FORCE)
+        set(OpenMP_C_LIB_NAMES "omp" CACHE STRING "" FORCE)
+        set(OpenMP_CXX_LIB_NAMES "omp" CACHE STRING "" FORCE)
+        set(OpenMP_omp_LIBRARY "${LIBOMP_PREFIX}/lib/libomp.dylib" CACHE FILEPATH "" FORCE)
+    endif()
+endif()
 find_package(OpenMP REQUIRED)
 
 # The library of pre-compiled CUDA kernels
@@ -129,14 +141,14 @@ list(APPEND LIBS DaphneMetaDataParser MLIRDaphne MLIRDaphneTransforms)
 list(APPEND LIBS Eigen3::Eigen Arrow::arrow_shared Parquet::parquet_shared)
 
 if(USE_PAPI)
-    find_library(PAPI_LIB NAMES libpapi.so HINTS ${PROJECT_BINARY_DIR}/installed/lib REQUIRED)
+    find_library(PAPI_LIB NAMES papi HINTS ${PROJECT_BINARY_DIR}/installed/lib REQUIRED)
 endif()
 
-find_library(HWLOC_LIB NAMES libhwloc.so HINTS ${PROJECT_BINARY_DIR}/installed/lib REQUIRED)
+find_library(HWLOC_LIB NAMES hwloc HINTS ${PROJECT_BINARY_DIR}/installed/lib REQUIRED)
 
 if(USE_HDFS)
         target_include_directories(AllKernels PUBLIC ${PROJECT_SOURCE_DIR}/thirdparty/installed/include/hdfs)
-        find_library(LIBHDFS3 NAMES libhdfs3.so HINTS ${PROJECT_BINARY_DIR}/installed/lib REQUIRED)
+        find_library(LIBHDFS3 NAMES hdfs3 HINTS ${PROJECT_BINARY_DIR}/installed/lib REQUIRED)
 endif()
 
 target_link_libraries(KernelObjLib PUBLIC ${LIBS} ${MPI_LIBRARIES} ${PAPI_LIB} ${HWLOC_LIB} ${LIBHDFS3})

--- a/src/runtime/local/kernels/CTable.h
+++ b/src/runtime/local/kernels/CTable.h
@@ -133,7 +133,7 @@ struct CTable<CSRMatrix<VTWeight>, DenseMatrix<VTCoord>, DenseMatrix<VTCoord>, V
             if (isResNumColsFromRhs)
                 resNumCols = *std::max_element(rhsVals, &rhsVals[rhsNumRows]) + 1;
             res = DataObjectFactory::create<CSRMatrix<VTWeight>>(
-                resNumRows, resNumCols, std::min(static_cast<ssize_t>(lhsNumRows), resNumRows * resNumCols), true);
+                resNumRows, resNumCols, std::min(static_cast<int64_t>(lhsNumRows), resNumRows * resNumCols), true);
         }
 
         if (isResNumRowsFromLhs && isResNumColsFromRhs) {

--- a/src/runtime/local/kernels/UnaryOpCode.h
+++ b/src/runtime/local/kernels/UnaryOpCode.h
@@ -85,7 +85,7 @@ static std::string_view unary_op_codes[] = {
  * @tparam VTRes The result value type.
  * @tparam VTArg The argument value type.
  */
-template <UnaryOpCode op, typename VTRes, typename VTArg> static constexpr bool supportsUnaryOp = false;
+template <UnaryOpCode op, typename VTRes, typename VTArg> inline constexpr bool supportsUnaryOp = false;
 
 // Macros for concisely specifying which unary operations should be
 // supported on which value types.
@@ -93,7 +93,7 @@ template <UnaryOpCode op, typename VTRes, typename VTArg> static constexpr bool 
 // Generates code specifying that the unary operation `Op` should be supported
 // on the value type `VT` (for both the result and the argument, for
 // simplicity).
-#define SUPPORT(Op, VT) template <> constexpr bool supportsUnaryOp<UnaryOpCode::Op, VT, VT> = true;
+#define SUPPORT(Op, VT) template <> inline constexpr bool supportsUnaryOp<UnaryOpCode::Op, VT, VT> = true;
 
 // Generates code specifying that all unary operations typically supported on
 // numeric value types should be supported on the given value type `VT`

--- a/src/runtime/local/kernels/genKernelInst.py
+++ b/src/runtime/local/kernels/genKernelInst.py
@@ -43,6 +43,7 @@ system start-up.
 
 import io
 import json
+import platform
 import re
 import sys
 from typing import List, Tuple
@@ -280,7 +281,7 @@ def generateKernelInstantiation(kernelTemplateInfo, templateValues, opCodes, out
             "backend": API,
             # Assumes that the generated catalog file is saved in
             # the same directory as the kernels libraries.
-            "libPath": "libAllKernels.so" if API == "CPP" else f"lib{API}Kernels.so"
+            "libPath": ("libAllKernels.dylib" if platform.system() == "Darwin" else "libAllKernels.so") if API == "CPP" else (f"lib{API}Kernels.dylib" if platform.system() == "Darwin" else f"lib{API}Kernels.so")
         })
 
     # Generate the function(s).

--- a/src/runtime/local/vectorized/MTWrapper_dense.cpp
+++ b/src/runtime/local/vectorized/MTWrapper_dense.cpp
@@ -94,10 +94,12 @@ template <typename VT>
     std::vector<TaskQueue *> qvector;
     if (ctx->getUserConfig().pinWorkers) {
         for (int i = 0; i < this->_numQueues; i++) {
+#ifdef __linux__
             cpu_set_t cpuset;
             CPU_ZERO(&cpuset);
             CPU_SET(i, &cpuset);
             sched_setaffinity(0, sizeof(cpu_set_t), &cpuset);
+#endif
             std::unique_ptr<TaskQueue> tmp = std::make_unique<BlockingTaskQueue>(len);
             q.push_back(std::move(tmp));
             qvector.push_back(q[i].get());
@@ -260,10 +262,12 @@ template <typename VT>
         // Multiple Queues addition
         if (ctx->getUserConfig().pinWorkers) {
             for (int i = 0; i < this->_numQueues; i++) {
+#ifdef __linux__
                 cpu_set_t cpuset;
                 CPU_ZERO(&cpuset);
                 CPU_SET(i, &cpuset);
                 sched_setaffinity(0, sizeof(cpu_set_t), &cpuset);
+#endif
                 std::unique_ptr<TaskQueue> tmp = std::make_unique<BlockingTaskQueue>(cpu_task_len);
                 q.push_back(std::move(tmp));
                 qvector.push_back(q[i].get());

--- a/src/runtime/local/vectorized/MTWrapper_sparse.cpp
+++ b/src/runtime/local/vectorized/MTWrapper_sparse.cpp
@@ -33,10 +33,12 @@ void MTWrapper<CSRMatrix<VT>>::executeCpuQueues(
     std::vector<TaskQueue *> qvector;
     if (ctx->getUserConfig().pinWorkers) {
         for (int i = 0; i < this->_numQueues; i++) {
+#ifdef __linux__
             cpu_set_t cpuset;
             CPU_ZERO(&cpuset);
             CPU_SET(i, &cpuset);
             sched_setaffinity(0, sizeof(cpu_set_t), &cpuset);
+#endif
             std::unique_ptr<TaskQueue> tmp = std::make_unique<BlockingTaskQueue>(len);
             q.push_back(std::move(tmp));
             qvector.push_back(q[i].get());

--- a/src/runtime/local/vectorized/TaskQueues.h
+++ b/src/runtime/local/vectorized/TaskQueues.h
@@ -64,11 +64,13 @@ class BlockingTaskQueue : public TaskQueue {
     }
 
     void enqueueTask(Task *t, int targetCPU) override {
+#ifdef __linux__
         // Change CPU pinning before enqueue to utilize NUMA first-touch policy
         cpu_set_t cpuset;
         CPU_ZERO(&cpuset);
         CPU_SET(targetCPU, &cpuset);
         sched_setaffinity(0, sizeof(cpu_set_t), &cpuset);
+#endif
         enqueueTask(t);
     }
 

--- a/src/runtime/local/vectorized/Tasks.h
+++ b/src/runtime/local/vectorized/Tasks.h
@@ -65,10 +65,9 @@ template <class DT> struct CompiledPipelineTaskData {
     DCTX(_ctx);
 
     [[maybe_unused]] CompiledPipelineTaskData<DT> withDifferentRange(uint64_t newRl, uint64_t newRu) {
-        CompiledPipelineTaskData<DT> flatCopy = *this;
-        flatCopy._rl = newRl;
-        flatCopy._ru = newRu;
-        return flatCopy;
+        return CompiledPipelineTaskData<DT>{_funcs, _isScalar, _inputs, _numInputs, _numOutputs, _outRows, _outCols,
+                                            _splits, _combines, newRl, newRu, _wholeResultRows, _wholeResultCols,
+                                            _offset, _ctx};
     }
 };
 

--- a/src/runtime/local/vectorized/Tasks.h
+++ b/src/runtime/local/vectorized/Tasks.h
@@ -65,10 +65,9 @@ template <class DT> struct CompiledPipelineTaskData {
     DCTX(_ctx);
 
     [[maybe_unused]] CompiledPipelineTaskData<DT> withDifferentRange(uint64_t newRl, uint64_t newRu) {
-        CompiledPipelineTaskData<DT> flatCopy = *this;
-        flatCopy._rl = newRl;
-        flatCopy._ru = newRu;
-        return flatCopy;
+        return CompiledPipelineTaskData<DT>{_funcs,   _isScalar,        _inputs,          _numInputs, _numOutputs,
+                                            _outRows, _outCols,         _splits,          _combines,  newRl,
+                                            newRu,    _wholeResultRows, _wholeResultCols, _offset,    _ctx};
     }
 };
 

--- a/src/runtime/local/vectorized/Worker.h
+++ b/src/runtime/local/vectorized/Worker.h
@@ -19,7 +19,9 @@
 #include <runtime/local/vectorized/Tasks.h>
 
 #include <numeric>
+#ifdef __linux__
 #include <sched.h>
+#endif
 #include <thread>
 
 class Worker {

--- a/src/runtime/local/vectorized/WorkerCPU.h
+++ b/src/runtime/local/vectorized/WorkerCPU.h
@@ -53,11 +53,13 @@ class WorkerCPU : public Worker {
 
     void run() override {
         if (_pinWorkers) {
+#ifdef __linux__
             // pin worker to CPU core
             cpu_set_t cpuset;
             CPU_ZERO(&cpuset);
             CPU_SET(_threadID, &cpuset);
             sched_setaffinity(0, sizeof(cpu_set_t), &cpuset);
+#endif
         }
 
         int currentDomain = _physical_ids[_threadID];


### PR DESCRIPTION
DAPHNE was previously Linux-only. This adds support for building and running on macOS with Apple Silicon (ARM64) using GCC-15 from Homebrew.

DAPHNE’s build currently assumes a Linux environment: GNU userland
tools, `.so` library names, `/proc/self/exe`, Linux CPU affinity APIs,
`nproc`, and a single set of integer typedef relationships. Those
assumptions prevent the project and several generated/runtime components
from compiling natively on Apple Silicon.

Use GCC 15 consistently on macOS so DAPHNE and its third-party
dependencies use the same C++ standard library ABI. Avoid `lld`,
Linux-only affinity calls, and .so-specific library lookup where those
choices are not portable. Add the Apple Silicon type specializations
needed where `long`, `long long`, and the fixed width integer aliases do
not collapse the same way they do on the existing Linux build.

The dependency build also needs macOS-specific handling because older upstream
packages do not configure cleanly with current CMake/GCC/Homebrew combinations,
and Homebrew/LLVM/Arrow can disagree about imported zstd targets and include
paths. These adjustments keep the native dependency build on one coherent
toolchain and prevent system/Homebrew headers from accidentally shadowing the
vendored ones.

Document the result as experimental macOS ARM64 support, with `PAPI` and
CPU pinning called out as unavailable there.



Closes #759.