### PR TITLE
refactor(ir): Mark pure DaphneIR base classes as Pure [#512]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 build/
 build-*/
 build_*/
+!test/build/
 /bin
 /lib
 /tmp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,32 @@ find_package(fmt)
 add_definitions(-DSPDLOG_FMT_EXTERNAL)
 
 option(USE_CUDA "Whether to activate compilation of CUDA features" OFF)
+
+# Optional cap on parallel jobs for the memory-heavy kernel targets, via a Ninja job pool.
+# The generated kernels_*.cpp files instantiate a lot of templates, and each cc1 can
+# hold several GB resident, so building them all at once can hit the OOM killer on hosts
+# with little RAM per core (WSL default, small VMs, containers with a --memory limit).
+# Set to a positive integer to cap KernelObjLib (and CUDAKernels when USE_CUDA=ON);
+# leave empty for uncapped (the default). Ninja only, ignored with a warning otherwise.
+set(DAPHNE_KERNEL_COMPILE_JOBS "" CACHE STRING
+    "Max concurrent compile jobs for the pre-compiled kernel targets (Ninja only; empty = uncapped).")
+
+if(NOT "${DAPHNE_KERNEL_COMPILE_JOBS}" STREQUAL "")
+    if(NOT DAPHNE_KERNEL_COMPILE_JOBS MATCHES "^[1-9][0-9]*$")
+        message(FATAL_ERROR "DAPHNE_KERNEL_COMPILE_JOBS must be a positive integer, got '${DAPHNE_KERNEL_COMPILE_JOBS}'.")
+    endif()
+    if(NOT CMAKE_GENERATOR MATCHES "Ninja")
+        message(WARNING "DAPHNE_KERNEL_COMPILE_JOBS is set but generator is '${CMAKE_GENERATOR}'. JOB_POOLS is Ninja-only; ignoring.")
+    else()
+        set_property(GLOBAL APPEND PROPERTY JOB_POOLS daphne_kernel_compile=${DAPHNE_KERNEL_COMPILE_JOBS})
+        # Single flag used by the kernel target definitions to decide whether
+        # to attach JOB_POOL_COMPILE. Referencing the pool without registering
+        # it makes Ninja fail with "unknown pool name" at build-graph load,
+        # so both sides of the flag must stay in sync.
+        set(DAPHNE_KERNEL_POOL_ACTIVE TRUE)
+    endif()
+endif()
+
 include(CheckLanguage)
 check_language(CUDA)
 if(USE_CUDA AND CMAKE_CUDA_COMPILER)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,7 +136,7 @@ if(NOT "${DAPHNE_KERNEL_COMPILE_JOBS}" STREQUAL "")
     if(NOT CMAKE_GENERATOR MATCHES "Ninja")
         message(WARNING "DAPHNE_KERNEL_COMPILE_JOBS is set but generator is '${CMAKE_GENERATOR}'. JOB_POOLS is Ninja-only; ignoring.")
     else()
-        set_property(GLOBAL APPEND PROPERTY JOB_POOLS daphne_kernel_compile=${DAPHNE_KERNEL_COMPILE_JOBS})
+        set_property(GLOBAL PROPERTY JOB_POOLS daphne_kernel_compile=${DAPHNE_KERNEL_COMPILE_JOBS})
         # Single flag used by the kernel target definitions to decide whether
         # to attach JOB_POOL_COMPILE. Referencing the pool without registering
         # it makes Ninja fail with "unknown pool name" at build-graph load,

--- a/build.sh
+++ b/build.sh
@@ -138,8 +138,9 @@ calc_daphne_jobs() {
     local cj=$(( usable / 2 ))
     [ "$cj" -lt 1 ] && cj=1
     [ "$cj" -gt "$ncpu" ] && cj=$ncpu
-    local kj=$usable
-    [ "$kj" -gt "$cj" ] && kj=$cj
+    # Kernel pool never exceeds the global cap (kernel slots consume global
+    # slots too); today both knobs use the same value.
+    local kj=$cj
     echo "$cj $kj"
 }
 

--- a/build.sh
+++ b/build.sh
@@ -52,6 +52,97 @@ sed_inplace() {
     fi
 }
 
+# How much RAM this process can actually use, in whole GB (rounded down).
+# Tries the cgroup limits first (so it respects docker --memory), then
+# /proc/meminfo, then macOS sysctl, and falls back to 4 if none of those work.
+# /proc/meminfo reports host RAM, so it's only accurate when there's no container limit.
+get_memory_gb() {
+    local mem_bytes=0
+
+    if [ "$IS_DARWIN" = "1" ]; then
+        local raw
+        raw=$(sysctl -n hw.memsize 2>/dev/null) || raw=0
+        if [[ "$raw" =~ ^[0-9]+$ ]] && [ "$raw" -gt 0 ]; then
+            echo $(( raw / 1024 / 1024 / 1024 ))
+        else
+            echo 4
+        fi
+        return
+    fi
+
+    # cgroup v2: walk the cgroup hierarchy, take the minimum non-"max" memory.max
+    local cg_path
+    cg_path=$(awk -F: '/^0:/{print $3; exit}' /proc/self/cgroup 2>/dev/null)
+    if [ -n "$cg_path" ]; then
+        local path="$cg_path" val min_limit=0 mem_max_file
+        while true; do
+            mem_max_file="/sys/fs/cgroup${path}/memory.max"
+            if [ -r "$mem_max_file" ]; then
+                val=$(cat "$mem_max_file" 2>/dev/null)
+                if [ "$val" != "max" ] && [[ "$val" =~ ^[0-9]+$ ]]; then
+                    if [ "$min_limit" -eq 0 ] || [ "$val" -lt "$min_limit" ]; then
+                        min_limit="$val"
+                    fi
+                fi
+            fi
+            [ "$path" = "/" ] || [ -z "$path" ] && break
+            path=$(dirname "$path")
+            [ "$path" = "." ] && break
+        done
+        [ "$min_limit" -gt 0 ] && mem_bytes="$min_limit"
+    fi
+
+    # cgroup v1 fallback (legacy or hybrid kernels)
+    if [ "$mem_bytes" -eq 0 ]; then
+        local v1="/sys/fs/cgroup/memory/memory.limit_in_bytes"
+        if [ -r "$v1" ]; then
+            local v1val
+            v1val=$(cat "$v1" 2>/dev/null)
+            # Sentinel for "unlimited" on v1 is > 1 PB; any real limit is below that
+            if [[ "$v1val" =~ ^[0-9]+$ ]] && [ "$v1val" -gt 0 ] && \
+               [ "$v1val" -lt 1125899906842624 ]; then
+                mem_bytes="$v1val"
+            fi
+        fi
+    fi
+
+    # /proc/meminfo: host RAM (final fallback; not container-aware)
+    if [ "$mem_bytes" -eq 0 ] && [ -r /proc/meminfo ]; then
+        # Multiply outside awk: mawk (default on the Ubuntu images) prints
+        # byte counts >= 2^31 as "1.37439e+11", which the digits-only guard
+        # below rejects, wrongly falling back to 4 GB on any >= 2 GB host.
+        local mem_kb
+        mem_kb=$(awk '/^MemTotal:/{print $2; exit}' /proc/meminfo)
+        mem_kb="${mem_kb:-0}"
+        [[ "$mem_kb" =~ ^[0-9]+$ ]] && mem_bytes=$(( mem_kb * 1024 ))
+    fi
+
+    if ! [[ "$mem_bytes" =~ ^[0-9]+$ ]] || [ "$mem_bytes" -eq 0 ]; then
+        echo 4
+        return
+    fi
+    echo $(( mem_bytes / 1024 / 1024 / 1024 ))
+}
+
+# Picks job counts that fit in avail_gb of RAM and prints "compile_jobs kernel_jobs".
+# compile_jobs is the global Ninja cap: floor((avail-1)/2), clamped to [1, nproc].
+# kernel_jobs uses the same value, since a kernel slot also takes a global slot
+# so there's no point setting it higher.
+# We budget ~2 GB per slot to cover the worst case: DistributedPipeline.cpp peaks
+# around 3.63 GB, other MLIR targets ~1.5 GB, kernel TUs ~1 GB.
+calc_daphne_jobs() {
+    local avail_gb=$1
+    local ncpu
+    ncpu=$(get_nproc)
+    local usable=$(( avail_gb > 1 ? avail_gb - 1 : 1 ))
+    local cj=$(( usable / 2 ))
+    [ "$cj" -lt 1 ] && cj=1
+    [ "$cj" -gt "$ncpu" ] && cj=$ncpu
+    local kj=$usable
+    [ "$kj" -gt "$cj" ] && kj=$cj
+    echo "$cj $kj"
+}
+
 build_ts_begin=$(date +%s%N)
 
 #******************************************************************************
@@ -1214,6 +1305,34 @@ fi
 daphne_msg "Build Daphne"
 
 DAPHNE_CMAKE_EXTRA=()
+
+# Work out how much RAM we have and pick sane parallelism defaults.
+# (get_memory_gb respects docker --memory, otherwise falls back to host RAM.)
+# Only kicks in when memory is the limiting factor; env vars you set take priority.
+# The guard is OR, not AND: if you set just one knob we still auto-fill the other below.
+if [ -z "${DAPHNE_COMPILE_JOBS:-}" ] || [ -z "${DAPHNE_KERNEL_COMPILE_JOBS:-}" ]; then
+    _avail_gb=$(get_memory_gb)
+    read -r _auto_cj _auto_kj <<< "$(calc_daphne_jobs "$_avail_gb")"
+    _nproc=$(get_nproc)
+    if [ "$_auto_cj" -lt "$_nproc" ]; then
+        daphne_msg "Memory-constrained host detected (${_avail_gb} GB available)"
+        daphne_msg "Auto-setting COMPILE_JOBS=${_auto_cj}, KERNEL_COMPILE_JOBS=${_auto_kj} to prevent OOM"
+        daphne_msg "Override by setting DAPHNE_COMPILE_JOBS / DAPHNE_KERNEL_COMPILE_JOBS env vars"
+    fi
+    : "${DAPHNE_COMPILE_JOBS:=$_auto_cj}"
+    : "${DAPHNE_KERNEL_COMPILE_JOBS:=$_auto_kj}"
+fi
+
+# Pass the job counts on to cmake/ninja.
+# The kernel count goes in as a CMake cache variable (a Ninja job pool),
+# and the global count becomes cmake --build --parallel.
+if [ -n "${DAPHNE_KERNEL_COMPILE_JOBS:-}" ]; then
+    DAPHNE_CMAKE_EXTRA+=(-DDAPHNE_KERNEL_COMPILE_JOBS="$DAPHNE_KERNEL_COMPILE_JOBS")
+fi
+CMAKE_BUILD_EXTRA=()
+if [ -n "${DAPHNE_COMPILE_JOBS:-}" ]; then
+    CMAKE_BUILD_EXTRA+=(--parallel "$DAPHNE_COMPILE_JOBS")
+fi
 if [ "$IS_DARWIN" == "1" ]; then
     macosSdk="${DAPHNE_MACOS_SDK:-/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk}"
     # GCC-15 is already exported; explicitly pass to cmake as well.
@@ -1228,9 +1347,9 @@ fi
 
 cmake -S "$projectRoot" -B "$daphneBuildDir" -G Ninja -DANTLR_VERSION="$antlrVersion" \
     -DCMAKE_PREFIX_PATH="$installPrefix" \
-    $BUILD_CUDA $BUILD_FPGAOPENCL $BUILD_DEBUG $BUILD_MPI $BUILD_HDFS $BUILD_PAPI ${DAPHNE_CMAKE_EXTRA[@]}
+    $BUILD_CUDA $BUILD_FPGAOPENCL $BUILD_DEBUG $BUILD_MPI $BUILD_HDFS $BUILD_PAPI "${DAPHNE_CMAKE_EXTRA[@]}"
 
-cmake --build "$daphneBuildDir" --target "$target"
+cmake --build "$daphneBuildDir" --target "$target" "${CMAKE_BUILD_EXTRA[@]}"
 
 build_ts_end=$(date +%s%N)
 daphne_msg "Successfully built Daphne://${target} (took $(printableTimestamp $((build_ts_end - build_ts_begin))))"

--- a/build.sh
+++ b/build.sh
@@ -1315,13 +1315,16 @@ if [ -z "${DAPHNE_COMPILE_JOBS:-}" ] || [ -z "${DAPHNE_KERNEL_COMPILE_JOBS:-}" ]
     _avail_gb=$(get_memory_gb)
     read -r _auto_cj _auto_kj <<< "$(calc_daphne_jobs "$_avail_gb")"
     _nproc=$(get_nproc)
-    if [ "$_auto_cj" -lt "$_nproc" ]; then
-        daphne_msg "Memory-constrained host detected (${_avail_gb} GB available)"
-        daphne_msg "Auto-setting COMPILE_JOBS=${_auto_cj}, KERNEL_COMPILE_JOBS=${_auto_kj} to prevent OOM"
-        daphne_msg "Override by setting DAPHNE_COMPILE_JOBS / DAPHNE_KERNEL_COMPILE_JOBS env vars"
-    fi
     : "${DAPHNE_COMPILE_JOBS:=$_auto_cj}"
     : "${DAPHNE_KERNEL_COMPILE_JOBS:=$_auto_kj}"
+    # Report the values the build will actually use, which may be a mix of a
+    # preset env var and an auto-detected default, rather than the raw auto
+    # values (those can differ from the effective ones when a knob is preset).
+    if [ "$DAPHNE_COMPILE_JOBS" -lt "$_nproc" ]; then
+        daphne_msg "Memory-constrained host detected (${_avail_gb} GB available)"
+        daphne_msg "Using COMPILE_JOBS=${DAPHNE_COMPILE_JOBS}, KERNEL_COMPILE_JOBS=${DAPHNE_KERNEL_COMPILE_JOBS} to prevent OOM"
+        daphne_msg "Override by setting DAPHNE_COMPILE_JOBS / DAPHNE_KERNEL_COMPILE_JOBS env vars"
+    fi
 fi
 
 # Pass the job counts on to cmake/ninja.

--- a/doc/GettingStarted.md
+++ b/doc/GettingStarted.md
@@ -263,6 +263,7 @@ launching DAPHNE via Docker (see below) should work the same way as in a native 
 #### Hardware
 
 - about 7.5 GB of free disk space to build from source (mostly due to dependencies)
+- on memory-constrained hosts (WSL, small VMs, Docker Desktop, containers with a `--memory` limit), `build.sh` automatically caps build parallelism to prevent OOM, with no manual configuration needed; see [Memory Requirements](development/BuildingDaphne.md#memory-requirements) for details and manual override options
 - Optional:
     - NVidia GPU for CUDA ops (tested on Pascal and newer architectures); 8GB for CUDA SDK
     - Intel GPU for OneAPI ops (tested on Coffeelake graphics); 23 GB for OneAPI

--- a/doc/development/BuildingDaphne.md
+++ b/doc/development/BuildingDaphne.md
@@ -178,7 +178,7 @@ Compiling the pre-compiled kernels library instantiates many kernel templates. E
 
 ```
 Memory-constrained host detected (8 GB available)
-Auto-setting COMPILE_JOBS=3, KERNEL_COMPILE_JOBS=3 to prevent OOM
+Using COMPILE_JOBS=3, KERNEL_COMPILE_JOBS=3 to prevent OOM
 Override by setting DAPHNE_COMPILE_JOBS / DAPHNE_KERNEL_COMPILE_JOBS env vars
 ```
 

--- a/doc/development/BuildingDaphne.md
+++ b/doc/development/BuildingDaphne.md
@@ -202,9 +202,11 @@ Reference table for manual overrides:
 
 | Available RAM | `DAPHNE_COMPILE_JOBS` | `DAPHNE_KERNEL_COMPILE_JOBS` |
 |---|---|---|
-| ≥ 8 GB | `3` | `3` |
+| 8 GB | `3` | `3` |
 | 6 GB | `2` | `2` |
 | 4 GB | `1` | `1` |
+
+Above 8 GB the recommended count keeps growing: auto-detection uses `floor((RAM_GB - 1) / 2)`, capped at your core count. For example a 16 GB host gets `7` and a 32 GB host gets `15` (or `nproc`, whichever is smaller), so setting a flat `3` on a large host would leave most cores idle.
 
 Leave both options unset to use auto-detection (recommended). The auto-detected values follow a conservative "2 GB per parallel slot" rule; raise them if you know your compile TUs peak lower on your system.
 

--- a/doc/development/BuildingDaphne.md
+++ b/doc/development/BuildingDaphne.md
@@ -33,6 +33,9 @@ Following builds only take a few seconds/minutes.
 Contents:
 
 - [Usage of the build script](#usage-of-the-build-script)
+- [Building on macOS (Experimental)](#building-on-macos-experimental)
+- [Building on WSL](#building-on-wsl)
+- [Memory Requirements](#memory-requirements)
 - [Extension of the build script](#extension)
 
 ---
@@ -165,7 +168,47 @@ The build script automatically detects macOS and configures GCC-15 as the compil
 
 ## Building on WSL
 
-When using Windows Subsystems for Linux (WSL), the default memory limit for WSL is 50% of the total memory of the underlying Windows host. This can lead to build fails due to SIGKILL for DAPHNE builds. [Advanced settings configuration in WSL](https://learn.microsoft.com/en-us/windows/wsl/wsl-config) describes how the memory limit can be configured.
+When using Windows Subsystem for Linux (WSL), the default memory limit for WSL is 50% of the total memory of the underlying Windows host. This can lead to DAPHNE build failures where `cc1plus` is killed by the Linux OOM killer. [Advanced settings configuration in WSL](https://learn.microsoft.com/en-us/windows/wsl/wsl-config) describes how the memory limit can be configured. If raising the limit is not an option, see [Memory Requirements](#memory-requirements) for how to cap build parallelism instead.
+
+## Memory Requirements
+
+Compiling the pre-compiled kernels library instantiates many kernel templates. Each translation unit can consume several GB of RAM at peak. On memory-constrained hosts (WSL default, small VMs, Docker Desktop with the default VM sizing, containers started with a `--memory` limit) building all kernel translation units in parallel can trigger the OOM killer, which surfaces as `fatal error: Killed signal terminated program cc1plus`.
+
+`build.sh` detects this automatically. It reads the available memory from the cgroup v2 memory limit (when running inside a Docker container with `--memory=`) or from `/proc/meminfo` (bare metal, WSL 2, or an unconstrained container), then sets safe values for both job-count knobs before the build starts. When the detected memory is below what `nproc` would otherwise allow, it prints a message:
+
+```
+Memory-constrained host detected (8 GB available)
+Auto-setting COMPILE_JOBS=3, KERNEL_COMPILE_JOBS=3 to prevent OOM
+Override by setting DAPHNE_COMPILE_JOBS / DAPHNE_KERNEL_COMPILE_JOBS env vars
+```
+
+No manual configuration is needed for a first-time build. Just run `./build.sh`.
+
+To use different values, set one or both env vars before invoking the script; the auto-detected defaults are skipped for any knob that is already set:
+
+```bash
+DAPHNE_COMPILE_JOBS=4 DAPHNE_KERNEL_COMPILE_JOBS=2 ./build.sh
+```
+
+The two knobs and their scope:
+
+**`DAPHNE_COMPILE_JOBS`** caps total Ninja concurrency for all targets (passed as `cmake --build --parallel N`). Without this, Ninja defaults to `nproc` parallel jobs, which can OOM the MLIR/compiler targets before the kernel phase is even reached.
+
+**`DAPHNE_KERNEL_COMPILE_JOBS`** is a finer-grained cap applied on top, only for the extra-heavy kernel translation units (`KernelObjLib`, and `CUDAKernels` when `--cuda` is used). Implemented as a Ninja job pool; ignored with a warning under other generators.
+
+Auto-detection sets both knobs to the same value (kernel jobs count against the global cap too, so the kernel-specific pool only bites when it's tighter than the global one). You would set them to different values only if you want, say, a global cap of 4 for the MLIR phase but a tighter cap of 2 specifically for the kernel phase.
+
+Reference table for manual overrides:
+
+| Available RAM | `DAPHNE_COMPILE_JOBS` | `DAPHNE_KERNEL_COMPILE_JOBS` |
+|---|---|---|
+| ≥ 8 GB | `3` | `3` |
+| 6 GB | `2` | `2` |
+| 4 GB | `1` | `1` |
+
+Leave both options unset to use auto-detection (recommended). The auto-detected values follow a conservative "2 GB per parallel slot" rule; raise them if you know your compile TUs peak lower on your system.
+
+One kernel translation unit (`DistributedPipeline.cpp`) intrinsically peaks at ~3.6 GiB regardless of the `JOBS` setting. On hosts with less than about 4 GB of available RAM the build cannot fit even with `DAPHNE_COMPILE_JOBS=1`; increase the host / container memory in that case. Reducing this floor further would require splitting `DistributedWrapper.h` (which `DistributedPipeline.cpp` includes) one level deeper, which is a larger refactor left as follow-up work.
 
 ## Extension
 

--- a/scripts/testing/test-issue512.sh
+++ b/scripts/testing/test-issue512.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Copyright 2026 The DAPHNE Consortium
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Baseline test runner for issue #512 (Simplification Rewrites for Linear
+# Algebra) work.
+#
+# This wrapper invokes ./test.sh with two Catch2 tag exclusions that filter
+# out pre-existing aarch64-only failures unrelated to #512:
+#
+#   ~[distributed]  issue #1011: "Simple distributed worker functionality
+#                      test" aborts the run_tests binary via SIGABRT on
+#                      aarch64, preventing the remaining ~2,111 downstream
+#                      test cases from executing at all.
+#
+#   ~[sql]          issue #1012: --columnar mode crashes on aarch64 with
+#                      an llvm::cast<TypedValue<IndexType>> assertion when
+#                      running columnar_4..7 and group_6 scripts.
+#
+# Both failures are aarch64-only; upstream x86_64 CI is unaffected.
+# Drop the corresponding flag once #1011 / #1012 are fixed.
+#
+# All arguments to this script are forwarded to ./test.sh (which in turn
+# forwards them to the Catch2 main function).
+#
+# Invoke from the repository root:
+#   ./scripts/testing/test-issue512.sh --no-build
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+cd "$REPO_ROOT"
+
+# Catch2 tag exclusions. Each is documented against its upstream issue above.
+EXCLUDE_DISTRIBUTED="~[distributed]"  # issue #1011
+EXCLUDE_SQL="~[sql]"                  # issue #1012
+
+exec ./test.sh "$@" "$EXCLUDE_DISTRIBUTED" "$EXCLUDE_SQL"

--- a/src/compiler/execution/DaphneIrExecutor.cpp
+++ b/src/compiler/execution/DaphneIrExecutor.cpp
@@ -159,10 +159,10 @@ bool DaphneIrExecutor::runPasses(mlir::ModuleOp module) {
         pm.addNestedPass<mlir::func::FuncOp>(mlir::daphne::createInferencePass());
         // Simplify the IR.
         pm.addPass(mlir::createCanonicalizerPass());
-        // Remove unused ops exposed by the columnar rewrite and canonicalization.
-        // One CSE pass is sufficient: MLIR's CSE walks the dominance tree once
-        // and hashes (op-name, operands, attributes, result-types), so pure ops
-        // are canonicalized in a single visit.
+        // Remove duplicate ops exposed by the columnar rewrite and
+        // canonicalization. One CSE pass is enough (was previously looped
+        // five times): CSE visits each op after its operands, so a whole
+        // duplicated chain collapses in a single pass.
         pm.addPass(mlir::createCSEPass());
     }
     if (userConfig_.explain_columnar)
@@ -318,8 +318,8 @@ void DaphneIrExecutor::buildCodegenPipeline(mlir::PassManager &pm) {
     // pm.addPass(mlir::daphne::createPrintIRPass("IR after createConvertDaphneToLinalgPass"));
     pm.addNestedPass<mlir::func::FuncOp>(mlir::createLinalgGeneralizeNamedOpsPass());
     pm.addNestedPass<mlir::func::FuncOp>(mlir::createLinalgElementwiseOpFusionPass());
-    // Elementwise fusion often exposes duplicate memref/tensor ops that are
-    // eligible for CSE now that the surrounding ops carry the Pure trait.
+    // Elementwise fusion often exposes duplicate memref/tensor/linalg ops;
+    // run CSE once to deduplicate them before the next stage.
     pm.addNestedPass<mlir::func::FuncOp>(mlir::createCSEPass());
     // pm.addPass(mlir::daphne::createPrintIRPass("IR after LinalgPasses"));
 

--- a/src/compiler/execution/DaphneIrExecutor.cpp
+++ b/src/compiler/execution/DaphneIrExecutor.cpp
@@ -121,6 +121,8 @@ bool DaphneIrExecutor::runPasses(mlir::ModuleOp module) {
     if (userConfig_.explain_parsing)
         pm.addPass(mlir::daphne::createPrintIRPass("IR after parsing:"));
 
+    // First simplification pass right after parsing: canonicalize, then CSE to
+    // drop the duplicate ops it exposes.
     pm.addPass(mlir::createCanonicalizerPass());
     pm.addPass(mlir::createCSEPass());
     if (userConfig_.explain_parsing_simplified)

--- a/src/compiler/execution/DaphneIrExecutor.cpp
+++ b/src/compiler/execution/DaphneIrExecutor.cpp
@@ -159,11 +159,11 @@ bool DaphneIrExecutor::runPasses(mlir::ModuleOp module) {
         pm.addNestedPass<mlir::func::FuncOp>(mlir::daphne::createInferencePass());
         // Simplify the IR.
         pm.addPass(mlir::createCanonicalizerPass());
-        // Remove unused ops after simplifications.
-        // TODO The CSE pass seems to eliminate only "one row" of dead code at a time, so we need it as many times as
-        // the longest chain of ops we reduce; how to apply CSE until a fixpoint?
-        for (size_t i = 0; i < 5; i++)
-            pm.addPass(mlir::createCSEPass());
+        // Remove unused ops exposed by the columnar rewrite and canonicalization.
+        // One CSE pass is sufficient: MLIR's CSE walks the dominance tree once
+        // and hashes (op-name, operands, attributes, result-types), so pure ops
+        // are canonicalized in a single visit.
+        pm.addPass(mlir::createCSEPass());
     }
     if (userConfig_.explain_columnar)
         pm.addPass(mlir::daphne::createPrintIRPass("IR after lowering to columnar ops:"));
@@ -318,6 +318,9 @@ void DaphneIrExecutor::buildCodegenPipeline(mlir::PassManager &pm) {
     // pm.addPass(mlir::daphne::createPrintIRPass("IR after createConvertDaphneToLinalgPass"));
     pm.addNestedPass<mlir::func::FuncOp>(mlir::createLinalgGeneralizeNamedOpsPass());
     pm.addNestedPass<mlir::func::FuncOp>(mlir::createLinalgElementwiseOpFusionPass());
+    // Elementwise fusion often exposes duplicate memref/tensor ops that are
+    // eligible for CSE now that the surrounding ops carry the Pure trait.
+    pm.addNestedPass<mlir::func::FuncOp>(mlir::createCSEPass());
     // pm.addPass(mlir::daphne::createPrintIRPass("IR after LinalgPasses"));
 
     auto bufOpts = mlir::getBufferizationOptionsForSparsification(/*analysisOnly=*/false);
@@ -334,6 +337,9 @@ void DaphneIrExecutor::buildCodegenPipeline(mlir::PassManager &pm) {
     // pm.addPass(mlir::createSparsificationAndBufferizationPass());
     pm.addPass(mlir::createStorageSpecifierToLLVMPass());
     pm.addNestedPass<mlir::func::FuncOp>(mlir::createCanonicalizerPass());
+    // Canonicalization can expose further duplicates; run CSE once more so the
+    // subsequent lowering sees the smallest possible IR.
+    pm.addNestedPass<mlir::func::FuncOp>(mlir::createCSEPass());
 
     pm.addNestedPass<mlir::func::FuncOp>(mlir::createConvertLinalgToLoopsPass());
     pm.addNestedPass<mlir::func::FuncOp>(mlir::memref::createExpandReallocPass());

--- a/src/ir/daphneir/DaphneOps.td
+++ b/src/ir/daphneir/DaphneOps.td
@@ -1342,7 +1342,7 @@ def Daphne_ColSelectLtOp : Daphne_ColSelectCmpOp<"colSelectLt">;
 def Daphne_ColSelectLeOp : Daphne_ColSelectCmpOp<"colSelectLe">;
 
 def Daphne_ColProjectOp : Daphne_Op<"colProject", [
-    DataTypeCol, ValueTypeFromFirstArg
+    DataTypeCol, ValueTypeFromFirstArg, Pure
 ]> {
     let summary = "Projection on columnar data; input: data, positions; output: data.";
     let description = [{
@@ -1382,7 +1382,7 @@ def Daphne_ColMergeOp : Daphne_ColSetOp<"colMerge"> {
 }
 
 def Daphne_ColJoinOp : Daphne_Op<"colJoin", [
-    DeclareOpInterfaceMethods<InferTypesOpInterface>
+    DeclareOpInterfaceMethods<InferTypesOpInterface>, Pure
 ]> {
     let summary = "N:1 equi-join on columnar data; input: data, unique data; output: sorted positions, positions.";
     let description = [{
@@ -1398,7 +1398,7 @@ def Daphne_ColJoinOp : Daphne_Op<"colJoin", [
 }
 
 def Daphne_ColSemiJoinOp : Daphne_Op<"colSemiJoin", [
-    DataTypeCol, ValueTypeSize
+    DataTypeCol, ValueTypeSize, Pure
 ]> {
     let summary = "Semi-join on columnar data; input: data, data, output: sorted positions.";
     let description = [{
@@ -1411,7 +1411,7 @@ def Daphne_ColSemiJoinOp : Daphne_Op<"colSemiJoin", [
 }
 
 def Daphne_ColGroupFirstOp : Daphne_Op<"colGroupFirst", [
-    DeclareOpInterfaceMethods<InferTypesOpInterface>
+    DeclareOpInterfaceMethods<InferTypesOpInterface>, Pure
 ]> {
     let summary = "Initial grouping step on columnar data; input: data; output: positions (group ids), positions (of representatives).";
     let description = [{
@@ -1427,7 +1427,7 @@ def Daphne_ColGroupFirstOp : Daphne_Op<"colGroupFirst", [
 }
 
 def Daphne_ColGroupNextOp : Daphne_Op<"colGroupNext", [
-    DeclareOpInterfaceMethods<InferTypesOpInterface>
+    DeclareOpInterfaceMethods<InferTypesOpInterface>, Pure
 ]> {
     let summary = "Subsequent grouping step on columnar data; input: data, positions (group ids); output: positions (group ids), positions (of representatives).";
     let description = [{

--- a/src/ir/daphneir/DaphneOps.td
+++ b/src/ir/daphneir/DaphneOps.td
@@ -819,6 +819,8 @@ def Daphne_OrderOp : Daphne_Op<"order", [
 // Matrix decompositions & co
 // ****************************************************************************
 
+// Mark a decomposition Pure only once it has a deterministic kernel: eigenCal
+// does, so it is CSE/DCE-eligible; lu/qr/svd have none yet and stay untagged.
 def Daphne_EigenOp : Daphne_Op<"eigenCal", [TypeFromFirstArg, DeclareOpInterfaceMethods<InferTypesOpInterface>,
         DeclareOpInterfaceMethods<InferShapeOpInterface>, Pure]> {
     let arguments = (ins MatrixOf<[FloatScalar]>:$arg);

--- a/src/ir/daphneir/DaphneOps.td
+++ b/src/ir/daphneir/DaphneOps.td
@@ -777,7 +777,8 @@ def Daphne_TransposeOp : Daphne_Op<"transpose", [
 
 class Daphne_BindOp<string name, list<Trait> traits = []> : Daphne_Op<name, !listconcat(traits, [
     DataTypeFromArgs,
-    CastArgsToResType
+    CastArgsToResType,
+    Pure
 ])> {
     let arguments = (ins MatrixOrFrame:$lhs, MatrixOrFrame:$rhs);
     let results = (outs MatrixOrFrame:$res);
@@ -787,8 +788,7 @@ def Daphne_ColBindOp : Daphne_BindOp<"colBind", [
     ValueTypesConcat,
     DeclareOpInterfaceMethods<InferFrameLabelsOpInterface>,
     DeclareOpInterfaceMethods<VectorizableOpInterface>,
-    NumRowsFromAllArgs, NumColsFromSumOfAllArgs, CUDASupport,
-    Pure
+    NumRowsFromAllArgs, NumColsFromSumOfAllArgs, CUDASupport
 ]>;
 
 def Daphne_RowBindOp : Daphne_BindOp<"rowBind", [
@@ -851,7 +851,7 @@ def Daphne_SvdOp : Daphne_Op<"svd"> {
 // ----------------------------------------------------------------------------
 
 class Daphne_ActivationForwardOp<string name, list<Trait> traits = []> :
-        Daphne_Op<name, traits> {
+        Daphne_Op<name, !listconcat(traits, [Pure])> {
     let arguments = (ins  MatrixOf<[FloatScalar]>:$input);
 
     let results = (outs MatrixOf<[FloatScalar]>:$data);
@@ -956,7 +956,7 @@ def Daphne_Conv2DBackwardDataOp : Daphne_Op<"conv2DBackwardData"> {
 // Pooling
 // ----------------------------------------------------------------------------
 
-class Daphne_PoolForwardOp<string name, list<Trait> traits = []> : Daphne_Op<name, traits> {
+class Daphne_PoolForwardOp<string name, list<Trait> traits = []> : Daphne_Op<name, !listconcat(traits, [Pure])> {
     let arguments = (ins  MatrixOf<[FloatScalar]>:$input,
         // input shape (NCHW)
         Size:$inputBatchSize, Size:$inputNumChannels, Size:$inputHeight, Size:$inputWidth,
@@ -1318,7 +1318,7 @@ def Daphne_GroupOp : Daphne_Op<"group", [
 
 class Daphne_ColSelectCmpOp<string name, list<Trait> traits = []>
 : Daphne_Op<name, !listconcat(traits, [
-    DataTypeCol, ValueTypeSize
+    DataTypeCol, ValueTypeSize, Pure
 ])> {
     let summary = "Selection on columnar data; input: data; output: sorted positions.";
     let description = [{
@@ -1358,7 +1358,7 @@ def Daphne_ColProjectOp : Daphne_Op<"colProject", [
 
 class Daphne_ColSetOp<string name, list<Trait> traits = []>
 : Daphne_Op<name, !listconcat(traits, [
-    DataTypeCol, ValueTypeSize
+    DataTypeCol, ValueTypeSize, Pure
 ])> {
     let arguments = (ins ColumnOrU:$lhsPos, ColumnOrU:$rhsPos);
     let results = (outs ColumnOrU:$resPos);
@@ -1444,7 +1444,7 @@ def Daphne_ColGroupNextOp : Daphne_Op<"colGroupNext", [
 
 class Daphne_ColCalcBinaryOp<string name, list<Trait> traits = []>
 : Daphne_Op<name, !listconcat(traits, [
-    DataTypeCol, ValueTypeFromArgs
+    DataTypeCol, ValueTypeFromArgs, Pure
 ])> {
     let summary = "Elementwise binary operation on columnar data; input: data; output: data.";
     let description = [{
@@ -1461,7 +1461,7 @@ def Daphne_ColCalcMulOp : Daphne_ColCalcBinaryOp<"colCalcMul">;
 
 class Daphne_ColAllAggOp<string name, list<Trait> traits = []>
 : Daphne_Op<name, !listconcat(traits, [
-    DataTypeCol, ValueTypeFromFirstArg
+    DataTypeCol, ValueTypeFromFirstArg, Pure
 ])> {
     let summary = "Full aggregation of columnar data; input: data; output: data.";
     let description = [{
@@ -1476,7 +1476,7 @@ def Daphne_ColAllAggSumOp : Daphne_ColAllAggOp<"colSumAll">;
 
 class Daphne_ColGrpAggOp<string name, list<Trait> traits = []>
 : Daphne_Op<name, !listconcat(traits, [
-    DataTypeCol, ValueTypeFromFirstArg
+    DataTypeCol, ValueTypeFromFirstArg, Pure
 ])> {
     let summary = "Grouped aggregation of columnar data; input: data, positions (group ids); output: data.";
     let description = [{

--- a/src/ir/daphneir/DaphneOps.td
+++ b/src/ir/daphneir/DaphneOps.td
@@ -649,7 +649,7 @@ def Daphne_ExtractOp : Daphne_Op<"extract", [
 def Daphne_ExtractRowOp : Daphne_Op<"extractRow", [
     TypeFromFirstArg,
     DeclareOpInterfaceMethods<InferFrameLabelsOpInterface>,
-    NumRowsFromIthArg<1>, NumColsFromArg
+    NumRowsFromIthArg<1>, NumColsFromArg, Pure
 ]> {
     let summary = "Copies the specified rows from the argument to the result.";
 
@@ -671,7 +671,7 @@ def Daphne_ExtractRowOp : Daphne_Op<"extractRow", [
 
 def Daphne_SliceRowOp : Daphne_Op<"sliceRow", [
     TypeFromFirstArg,
-    DeclareOpInterfaceMethods<InferShapeOpInterface>
+    DeclareOpInterfaceMethods<InferShapeOpInterface>, Pure
 ]> {
     let summary = "Copies the specified rows from the argument to the result.";
 
@@ -715,7 +715,7 @@ def Daphne_ExtractColOp : Daphne_Op<"extractCol", [
 
 def Daphne_SliceColOp : Daphne_Op<"sliceCol", [
     DeclareOpInterfaceMethods<InferTypesOpInterface>,
-    DeclareOpInterfaceMethods<InferShapeOpInterface>
+    DeclareOpInterfaceMethods<InferShapeOpInterface>, Pure
 ]> {
     let summary = "Copies the specified columns from the argument to the result.";
 
@@ -732,7 +732,7 @@ def Daphne_SliceColOp : Daphne_Op<"sliceCol", [
 
 def Daphne_InsertRowOp : Daphne_Op<"insertRow", [
     TypeFromFirstArg, // this is debatable
-    ShapeFromArg
+    ShapeFromArg, Pure
 ]> {
     let arguments = (ins MatrixOrFrame:$arg, MatrixOrFrame:$ins, SI64:$rowLowerIncl, SI64:$rowUpperExcl);
     let results = (outs MatrixOrFrame:$res);
@@ -740,7 +740,7 @@ def Daphne_InsertRowOp : Daphne_Op<"insertRow", [
 
 def Daphne_InsertColOp : Daphne_Op<"insertCol", [
     TypeFromFirstArg, // this is debatable
-    ShapeFromArg
+    ShapeFromArg, Pure
 ]> {
     let arguments = (ins MatrixOrFrame:$arg, MatrixOrFrame:$ins, SI64:$colLowerIncl, SI64:$colUpperExcl);
     let results = (outs MatrixOrFrame:$res);

--- a/src/ir/daphneir/DaphneOps.td
+++ b/src/ir/daphneir/DaphneOps.td
@@ -199,7 +199,7 @@ def Daphne_SeqOp : Daphne_Op<"seq", [
 // Matrix/frame meta data
 // ****************************************************************************
 
-def Daphne_TypeOfOp : Daphne_Op<"typeOf"> {
+def Daphne_TypeOfOp : Daphne_Op<"typeOf", [Pure]> {
     let arguments = (ins AnyTypeOf<[AnyScalar, MatrixOrFrame]>:$arg);
     let results = (outs StrScalar:$res);
 }
@@ -217,14 +217,14 @@ def Daphne_NumRowsOp : Daphne_NumOp<"numRows">;
 def Daphne_NumColsOp : Daphne_NumOp<"numCols">;
 def Daphne_NumCellsOp : Daphne_NumOp<"numCells">;
 
-def Daphne_SparsityOp : Daphne_Op<"sparsity", [DataTypeSca]> {
+def Daphne_SparsityOp : Daphne_Op<"sparsity", [DataTypeSca, Pure]> {
   let arguments = (ins MatrixOf<[AnyScalar]>:$arg);
   let results = (outs FloatScalar:$res);
 
   let hasCanonicalizeMethod = 1;
 }
 
-def Daphne_IsSymmetricOp : Daphne_Op<"isSymmetric"> {
+def Daphne_IsSymmetricOp : Daphne_Op<"isSymmetric", [Pure]> {
     let summary = "Checks if a matrix is symmetric";
     let description = [{
         This operation checks if the input matrix is symmetric.
@@ -752,7 +752,7 @@ def Daphne_InsertColOp : Daphne_Op<"insertCol", [
 
 def Daphne_ReshapeOp : Daphne_Op<"reshape", [
     TypeFromFirstArg,
-    NumRowsFromIthScalar<1>, NumColsFromIthScalar<2>, SparsityFromArg
+    NumRowsFromIthScalar<1>, NumColsFromIthScalar<2>, SparsityFromArg, Pure
 ]> {
     let arguments = (ins MatrixOrU:$arg, Size:$numRows, Size:$numCols);
     let results = (outs MatrixOrU:$res);
@@ -798,7 +798,7 @@ def Daphne_RowBindOp : Daphne_BindOp<"rowBind", [
 ]>;
 
 def Daphne_ReverseOp : Daphne_Op<"reverse", [
-    TypeFromFirstArg, ShapeFromArg
+    TypeFromFirstArg, ShapeFromArg, Pure
 ]> {
     let arguments = (ins MatrixOrU:$arg);
     let results = (outs MatrixOrU:$res);
@@ -808,7 +808,7 @@ def Daphne_OrderOp : Daphne_Op<"order", [
     DeclareOpInterfaceMethods<InferFrameLabelsOpInterface>,
     DeclareOpInterfaceMethods<InferTypesOpInterface>, // due to possibility of returning indexes
     SameVariadicOperandSize,
-    DeclareOpInterfaceMethods<InferShapeOpInterface>
+    DeclareOpInterfaceMethods<InferShapeOpInterface>, Pure
 ]> {
     // TODO Maybe colIdxs and ascs should be attributes.
     let arguments = (ins MatrixOrFrame:$arg, Variadic<Size>:$colIdxs, Variadic<BoolScalar>:$ascs, BoolScalar:$returnIdxs);
@@ -918,7 +918,7 @@ def Daphne_BiasAddOp : Daphne_Op<"BiasAdd", [ ValueTypeFromFirstArg, DataTypeFro
 
 def Daphne_Conv2DForwardOp : Daphne_Op<"Convolution_Forward",
     [ DeclareOpInterfaceMethods<InferTypesOpInterface>, DeclareOpInterfaceMethods<InferShapeOpInterface>,
-      CUDASupport ]> {
+      CUDASupport, Pure ]> {
     let arguments = (ins
         MatrixOf<[FloatScalar]>:$input, MatrixOf<[FloatScalar]>:$filter, MatrixOf<[FloatScalar]>:$bias,
         // input shape
@@ -1000,7 +1000,7 @@ def Daphne_MaxPoolBackwardOp : Daphne_Op<"maxPoolBackward", [ CUDASupport ]> {
 // ----------------------------------------------------------------------------
 // Softmax
 // ----------------------------------------------------------------------------
-def Daphne_SoftmaxOp : Daphne_Op<"Softmax", [ DataTypeFromFirstArg, ValueTypeFromFirstArg, CUDASupport ]> {
+def Daphne_SoftmaxOp : Daphne_Op<"Softmax", [ DataTypeFromFirstArg, ValueTypeFromFirstArg, CUDASupport, Pure ]> {
     let arguments = (ins  MatrixOf<[FloatScalar]>:$input);
 
     let results = (outs MatrixOf<[FloatScalar]>:$data);

--- a/src/ir/daphneir/DaphneOps.td
+++ b/src/ir/daphneir/DaphneOps.td
@@ -418,7 +418,8 @@ class Daphne_OuterBinaryOp<string name, Type scalarType, list<Trait> traits = []
     DataTypeMat,
     NumRowsFromIthArg<0>, NumColsFromIthArg<1>,
     CastArgsToResType,
-    DeclareOpInterfaceMethods<VectorizableOpInterface>
+    DeclareOpInterfaceMethods<VectorizableOpInterface>,
+    Pure
 ])> {
     let arguments = (ins MatrixOf<[scalarType]>:$lhs, MatrixOf<[scalarType]>:$rhs);
     let results = (outs MatrixOf<[scalarType]>:$res);
@@ -493,7 +494,8 @@ def Daphne_CondOp : Daphne_Op<"cond", [
 // Aggregation and statistical
 // ****************************************************************************
 
-class Daphne_AggOp<string name, Type inScalarType, list<Trait> traits = []> : Daphne_Op<name, traits> {
+class Daphne_AggOp<string name, Type inScalarType, list<Trait> traits = []>
+: Daphne_Op<name, !listconcat(traits, [Pure])> {
     let arguments = (ins MatrixOf<[inScalarType]>:$arg);
 }
 
@@ -585,7 +587,8 @@ def Daphne_CumAggMaxOp  : Daphne_CumAggOp<"maxCum" , AnyScalar, [ValueTypeFromFi
 class Daphne_GrpAggOp<string name, Type scalarType, list<Trait> traits = []>
 : Daphne_Op<name, !listconcat(traits, [
     DataTypeMat,
-    NumRowsFromIthScalar<2>, NumColsFromArg
+    NumRowsFromIthScalar<2>, NumColsFromArg,
+    Pure
 ])> {
     let arguments = (ins MatrixOf<[scalarType]>:$arg, MatrixOf<[Size]>:$groupIds, Size:$numGroups/*, Optional<MatrixOrU>:$weights*/);
     let results = (outs MatrixOf<[scalarType]>:$groupAggs);

--- a/src/ir/daphneir/DaphneOps.td
+++ b/src/ir/daphneir/DaphneOps.td
@@ -242,7 +242,7 @@ def Daphne_MatMulOp : Daphne_Op<"matMul", [
     DataTypeMat, ValueTypeFromArgs,
     DeclareOpInterfaceMethods<InferShapeOpInterface>,
     DeclareOpInterfaceMethods<InferSparsityOpInterface>, CUDASupport, FPGAOPENCLSupport,
-    CastFirstTwoArgsToResType, NoMemoryEffect
+    CastFirstTwoArgsToResType, Pure
 ]> {
     let arguments = (ins MatrixOf<[NumScalar]>:$lhs, MatrixOf<[NumScalar]>:$rhs, BoolScalar:$transa, BoolScalar:$transb);
     let results = (outs MatrixOf<[NumScalar]>:$res);
@@ -258,7 +258,7 @@ class Daphne_EwUnaryOp<string name, Type scalarType, list<Trait> traits = []> : 
     ShapeFromArg,
     CastArgsToResType,
     DeclareOpInterfaceMethods<VectorizableOpInterface>,
-    NoMemoryEffect
+    Pure
 ])> {
     let arguments = (ins AnyTypeOf<[MatrixOf<[scalarType]>, scalarType, Unknown]>:$arg);
     let results = (outs AnyTypeOf<[MatrixOf<[scalarType]>, scalarType, Unknown]>:$res);
@@ -336,7 +336,7 @@ class Daphne_EwBinaryOp<string name, Type scalarType, list<Trait> traits = []>
     DeclareOpInterfaceMethods<DistributableOpInterface>,
     DeclareOpInterfaceMethods<VectorizableOpInterface>,
     ShapeEwBinary,
-    NoMemoryEffect
+    Pure
 ])> {
     let arguments = (ins AnyTypeOf<[MatrixOf<[scalarType]>, scalarType, Unknown]>:$lhs, AnyTypeOf<[MatrixOf<[scalarType]>, scalarType, Unknown]>:$rhs);
     let results = (outs AnyTypeOf<[MatrixOf<[scalarType]>, scalarType, Unknown]>:$res);

--- a/src/ir/daphneir/DaphneOps.td
+++ b/src/ir/daphneir/DaphneOps.td
@@ -161,7 +161,8 @@ def Daphne_CreateFrameOp : Daphne_Op<"createFrame", [
 def Daphne_DiagMatrixOp : Daphne_Op<"diagMatrix", [
     TypeFromFirstArg,
     NumRowsFromArg, NumColsFromArgNumRows,
-    DeclareOpInterfaceMethods<InferSparsityOpInterface>
+    DeclareOpInterfaceMethods<InferSparsityOpInterface>,
+    Pure
 ]> {
     let arguments = (ins MatrixOrU:$arg);
     let results = (outs MatrixOrU:$res);
@@ -819,7 +820,7 @@ def Daphne_OrderOp : Daphne_Op<"order", [
 // ****************************************************************************
 
 def Daphne_EigenOp : Daphne_Op<"eigenCal", [TypeFromFirstArg, DeclareOpInterfaceMethods<InferTypesOpInterface>,
-        DeclareOpInterfaceMethods<InferShapeOpInterface>]> {
+        DeclareOpInterfaceMethods<InferShapeOpInterface>, Pure]> {
     let arguments = (ins MatrixOf<[FloatScalar]>:$arg);
     let results = (outs MatrixOf<[FloatScalar]>:$eigenValues, MatrixOf<[FloatScalar]>:$eigenVectors);
 }
@@ -1024,7 +1025,7 @@ def Daphne_TriOp : Daphne_Op<"tri", [
 }
 
 def Daphne_SolveOp : Daphne_Op<"solve", [
-    DataTypeMat, ValueTypeFromArgs, NumRowsFromArg, OneCol, CUDASupport, CastArgsToResType
+    DataTypeMat, ValueTypeFromArgs, NumRowsFromArg, OneCol, CUDASupport, CastArgsToResType, Pure
 ]> {
     let arguments = (ins MatrixOf<[NumScalar]>:$a, MatrixOf<[NumScalar]>:$b);
     let results = (outs MatrixOf<[NumScalar]>:$x);
@@ -1048,8 +1049,8 @@ def Daphne_CTableOp : Daphne_Op<"ctable", [
 def Daphne_SyrkOp : Daphne_Op<"syrk", [
     TypeFromFirstArg,
     DeclareOpInterfaceMethods<VectorizableOpInterface>,
-    NumRowsFromArgNumCols, NumColsFromArg, CUDASupport,FPGAOPENCLSupport, 
-    CastFirstArgToResType
+    NumRowsFromArgNumCols, NumColsFromArg, CUDASupport,FPGAOPENCLSupport,
+    CastFirstArgToResType, Pure
 ]> {
     let summary = [{Performs the operation `t(A) @ A` if `transLeft` is `true`; or `A @ t(A)`, otherwise.}];
     let arguments = (ins MatrixOrU:$arg, BoolScalar:$transLeft);
@@ -1060,7 +1061,7 @@ def Daphne_GemvOp : Daphne_Op<"gemv", [
     DeclareOpInterfaceMethods<VectorizableOpInterface>,
     DataTypeMat, ValueTypeFromArgs,
     NumRowsFromArgNumCols, OneCol, CUDASupport,
-    CastArgsToResType
+    CastArgsToResType, Pure
 ]> {
     // TODO: support `A @ x` operation
     let summary = [{Performs the operation `t(A) @ x`}];

--- a/src/runtime/local/kernels/CMakeLists.txt
+++ b/src/runtime/local/kernels/CMakeLists.txt
@@ -99,6 +99,24 @@ execute_process(
     ${PROJECT_SOURCE_DIR}/lib/catalog.json CPP
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/src/runtime/local/kernels/)
 
+# Verify that hand-written explicit template instantiations (currently just
+# DistributedPipeline.cpp) match what kernels.json lists for the same kernel.
+# Drift here shows up as an undefined-reference link error much later in the
+# build; failing here surfaces the problem at configure time with a fix hint.
+execute_process(
+  COMMAND
+    ${Python3_EXECUTABLE} checkExplicitInstantiations.py kernels.json
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/src/runtime/local/kernels/
+  RESULT_VARIABLE _checkExplicitInstantiations_result
+  OUTPUT_VARIABLE _checkExplicitInstantiations_stdout
+  ERROR_VARIABLE _checkExplicitInstantiations_stderr)
+if(NOT _checkExplicitInstantiations_result EQUAL 0)
+    message(FATAL_ERROR
+        "checkExplicitInstantiations.py reported drift between kernels.json "
+        "and hand-written explicit instantiations:\n"
+        "${_checkExplicitInstantiations_stderr}")
+endif()
+
 file(GLOB CODEGEN_CPP_FILES CONFIGURE_DEPENDS
      "${PROJECT_BINARY_DIR}/src/runtime/local/kernels/kernels_*.cpp")
 # message("CODEGEN_CPP_FILES: ${CODEGEN_CPP_FILES}")
@@ -115,6 +133,7 @@ set(SOURCES_cpp_kernels
         ${PROJECT_SOURCE_DIR}/src/runtime/local/instrumentation/KernelInstrumentation.cpp
         ${CODEGEN_CPP_FILES}
         ${PROJECT_SOURCE_DIR}/src/runtime/local/kernels/CreateDaphneContext.cpp
+        ${PROJECT_SOURCE_DIR}/src/runtime/local/kernels/DistributedPipeline.cpp
         ${PROJECT_SOURCE_DIR}/src/runtime/local/kernels/Pooling.cpp
         ${PROJECT_SOURCE_DIR}/src/runtime/local/kernels/VectorizedPipeline.h
         ${PROJECT_SOURCE_DIR}/src/runtime/local/vectorized/MTWrapper_dense.cpp

--- a/src/runtime/local/kernels/CMakeLists.txt
+++ b/src/runtime/local/kernels/CMakeLists.txt
@@ -90,6 +90,9 @@ if(USE_CUDA AND CMAKE_CUDA_COMPILER)
             CUDA::cusparse ${CUDA_cudnn_LIBRARY} CUDA::cusolver Util MLIRDaphneInference fmt::fmt)
     set_target_properties(CUDAKernels PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/lib)
     set_property(TARGET CUDAKernels PROPERTY CUDA_ARCHITECTURES all)
+    if(DAPHNE_KERNEL_POOL_ACTIVE)
+        set_property(TARGET CUDAKernels PROPERTY JOB_POOL_COMPILE daphne_kernel_compile)
+    endif()
 endif()
 
 execute_process(
@@ -144,6 +147,9 @@ set(SOURCES_cpp_kernels
 # The library of pre-compiled kernels. Will be linked into the JIT-compiled user program.
 add_library(KernelObjLib OBJECT ${SOURCES_cpp_kernels} ${HEADERS_cpp_kernels})
 set_target_properties(KernelObjLib PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/lib)
+if(DAPHNE_KERNEL_POOL_ACTIVE)
+    set_property(TARGET KernelObjLib PROPERTY JOB_POOL_COMPILE daphne_kernel_compile)
+endif()
 add_library(AllKernels SHARED $<TARGET_OBJECTS:KernelObjLib>)
 set_target_properties(AllKernels PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/lib)
 

--- a/src/runtime/local/kernels/CMakeLists.txt
+++ b/src/runtime/local/kernels/CMakeLists.txt
@@ -111,7 +111,6 @@ execute_process(
     ${Python3_EXECUTABLE} checkExplicitInstantiations.py kernels.json
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/src/runtime/local/kernels/
   RESULT_VARIABLE _checkExplicitInstantiations_result
-  OUTPUT_VARIABLE _checkExplicitInstantiations_stdout
   ERROR_VARIABLE _checkExplicitInstantiations_stderr)
 if(NOT _checkExplicitInstantiations_result EQUAL 0)
     message(FATAL_ERROR

--- a/src/runtime/local/kernels/DistributedPipeline.cpp
+++ b/src/runtime/local/kernels/DistributedPipeline.cpp
@@ -41,10 +41,7 @@ void distributedPipeline(DTRes **outputs, size_t numOutputs, const Structure **i
 // kernels.json. Drift is detected at CMake configure time by
 // checkExplicitInstantiations.py; if that check fails, add the missing
 // `template void distributedPipeline<...>` line below or drop the extra one.
-template void distributedPipeline<DenseMatrix<double>>(
-        DenseMatrix<double> **outputs, size_t numOutputs,
-        const Structure **inputs, size_t numInputs,
-        int64_t *outRows, int64_t *outCols,
-        int64_t *splits, int64_t *combines,
-        const char *irCode,
-        DaphneContext *ctx);
+template void distributedPipeline<DenseMatrix<double>>(DenseMatrix<double> **outputs, size_t numOutputs,
+                                                       const Structure **inputs, size_t numInputs, int64_t *outRows,
+                                                       int64_t *outCols, int64_t *splits, int64_t *combines,
+                                                       const char *irCode, DaphneContext *ctx);

--- a/src/runtime/local/kernels/DistributedPipeline.cpp
+++ b/src/runtime/local/kernels/DistributedPipeline.cpp
@@ -29,6 +29,7 @@ void distributedPipeline(DTRes **outputs, size_t numOutputs, const Structure **i
                          DCTX(ctx)) {
 
     auto wrapper = std::make_unique<DistributedWrapper<DTRes>>(ctx);
+    // TODO *** -> **
     DTRes ***res = new DTRes **[numOutputs];
     for (size_t i = 0; i < numOutputs; i++)
         res[i] = outputs + i;

--- a/src/runtime/local/kernels/DistributedPipeline.cpp
+++ b/src/runtime/local/kernels/DistributedPipeline.cpp
@@ -14,34 +14,33 @@
  * limitations under the License.
  */
 
-#pragma once
+#include <runtime/local/kernels/DistributedPipeline.h>
 
-// Only the forward declarations live here. The definition of distributedPipeline
-// is in DistributedPipeline.cpp so that translation units using this kernel don't
-// have to pull in all of DistributedWrapper.h (gRPC, protobuf, MPI, MLIR init-all-
-// dialects). That brings the compile-time peak RSS of the generated kernels_*.cpp
-// that reference this kernel down from ~3.6 GiB to ~1 GiB.
+#include <runtime/distributed/coordinator/kernels/DistributedWrapper.h>
 
-#include <runtime/local/context/DaphneContext.h>
-#include <runtime/local/datastructures/DenseMatrix.h>
+#include <memory>
 
-#include <cstddef>
-#include <cstdint>
+using mlir::daphne::VectorCombine;
+using mlir::daphne::VectorSplit;
 
-class Structure;
-
-// One output. The template is instantiated only for DTRes = DenseMatrix<double>
-// via kernels.json; that instantiation is provided out-of-line in
-// DistributedPipeline.cpp.
 template <class DTRes>
 void distributedPipeline(DTRes **outputs, size_t numOutputs, const Structure **inputs, size_t numInputs,
                          int64_t *outRows, int64_t *outCols, int64_t *splits, int64_t *combines, const char *irCode,
-                         DCTX(ctx));
+                         DCTX(ctx)) {
 
-// Only DenseMatrix<double> is used by the CPP kernels library. Declared extern
-// so no TU implicitly instantiates the template from the forward declaration
-// above.
-extern template void distributedPipeline<DenseMatrix<double>>(
+    auto wrapper = std::make_unique<DistributedWrapper<DTRes>>(ctx);
+    DTRes ***res = new DTRes **[numOutputs];
+    for (size_t i = 0; i < numOutputs; i++)
+        res[i] = outputs + i;
+    wrapper->execute(irCode, res, inputs, numInputs, numOutputs, outRows, outCols,
+                     reinterpret_cast<VectorSplit *>(splits), reinterpret_cast<VectorCombine *>(combines));
+}
+
+// Explicit instantiations for the types listed under this kernel in
+// kernels.json. Drift is detected at CMake configure time by
+// checkExplicitInstantiations.py; if that check fails, add the missing
+// `template void distributedPipeline<...>` line below or drop the extra one.
+template void distributedPipeline<DenseMatrix<double>>(
         DenseMatrix<double> **outputs, size_t numOutputs,
         const Structure **inputs, size_t numInputs,
         int64_t *outRows, int64_t *outCols,

--- a/src/runtime/local/kernels/DistributedPipeline.cpp
+++ b/src/runtime/local/kernels/DistributedPipeline.cpp
@@ -35,6 +35,7 @@ void distributedPipeline(DTRes **outputs, size_t numOutputs, const Structure **i
         res[i] = outputs + i;
     wrapper->execute(irCode, res, inputs, numInputs, numOutputs, outRows, outCols,
                      reinterpret_cast<VectorSplit *>(splits), reinterpret_cast<VectorCombine *>(combines));
+    delete[] res;
 }
 
 // Explicit instantiations for the types listed under this kernel in

--- a/src/runtime/local/kernels/DistributedPipeline.h
+++ b/src/runtime/local/kernels/DistributedPipeline.h
@@ -38,9 +38,10 @@ void distributedPipeline(DTRes **outputs, size_t numOutputs, const Structure **i
                          int64_t *outRows, int64_t *outCols, int64_t *splits, int64_t *combines, const char *irCode,
                          DCTX(ctx));
 
-// Only DenseMatrix<double> is used by the CPP kernels library. Declared extern
-// so no TU implicitly instantiates the template from the forward declaration
-// above.
+// The explicit instantiations provided in DistributedPipeline.cpp. The extern
+// template keeps each including TU from instantiating the template again, so it
+// links against the one in the .cpp. checkExplicitInstantiations.py also checks
+// this list against kernels.json at configure time.
 extern template void distributedPipeline<DenseMatrix<double>>(
         DenseMatrix<double> **outputs, size_t numOutputs,
         const Structure **inputs, size_t numInputs,

--- a/src/runtime/local/kernels/DistributedPipeline.h
+++ b/src/runtime/local/kernels/DistributedPipeline.h
@@ -42,10 +42,8 @@ void distributedPipeline(DTRes **outputs, size_t numOutputs, const Structure **i
 // template keeps each including TU from instantiating the template again, so it
 // links against the one in the .cpp. checkExplicitInstantiations.py also checks
 // this list against kernels.json at configure time.
-extern template void distributedPipeline<DenseMatrix<double>>(
-        DenseMatrix<double> **outputs, size_t numOutputs,
-        const Structure **inputs, size_t numInputs,
-        int64_t *outRows, int64_t *outCols,
-        int64_t *splits, int64_t *combines,
-        const char *irCode,
-        DaphneContext *ctx);
+extern template void distributedPipeline<DenseMatrix<double>>(DenseMatrix<double> **outputs, size_t numOutputs,
+                                                              const Structure **inputs, size_t numInputs,
+                                                              int64_t *outRows, int64_t *outCols, int64_t *splits,
+                                                              int64_t *combines, const char *irCode,
+                                                              DaphneContext *ctx);

--- a/src/runtime/local/kernels/checkExplicitInstantiations.py
+++ b/src/runtime/local/kernels/checkExplicitInstantiations.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 The DAPHNE Consortium
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Fails fast at CMake configure time if any kernel that ships its template
+definition out-of-line (via a hand-written .cpp with explicit template
+instantiations) has drifted from what is listed in kernels.json.
+
+Currently guards a single kernel:
+
+    DistributedPipeline.cpp   <->   kernels.json entry for `distributedPipeline`
+
+Shipping distributedPipeline's definition out-of-line in
+DistributedPipeline.cpp removes a large transitive header closure from the
+generated kernels_*.cpp that call it, but the price is that every type
+listed under `distributedPipeline.api[].instantiations` in kernels.json
+must ALSO appear as an explicit `template void distributedPipeline<...>`
+line in DistributedPipeline.cpp. Otherwise the generated wrapper linked
+by KernelObjLib will fail to find the definition, a linker error that
+surfaces late in the build.
+
+Add further entries to CHECKS below if this pattern is applied to more
+kernels in the future.
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+# List of (kernel opName, .cpp path relative to this script's directory) pairs
+# to verify. Each .cpp is expected to carry one `template void <opName><...>`
+# line per instantiation listed under that opName in kernels.json.
+CHECKS = [
+    ("distributedPipeline", "DistributedPipeline.cpp"),
+]
+
+
+def flatten_type(spec):
+    """Turn kernels.json's nested list representation of a C++ type into a
+    canonical single-line spelling. Whitespace is normalized so that the
+    comparison against DistributedPipeline.cpp is not defeated by formatting.
+
+    Examples:
+        ["DenseMatrix", "double"]     ->  "DenseMatrix<double>"
+        [["DenseMatrix", "double"]]   ->  "DenseMatrix<double>"   (unary tuple)
+    """
+    if isinstance(spec, str):
+        return spec
+    if isinstance(spec, list):
+        if len(spec) == 1 and isinstance(spec[0], list):
+            # kernels.json wraps single-template-arg instantiations in an
+            # extra list layer. Peel it.
+            return flatten_type(spec[0])
+        if len(spec) >= 1 and isinstance(spec[0], str):
+            head, *args = spec
+            if not args:
+                return head
+            return f"{head}<{', '.join(flatten_type(a) for a in args)}>"
+    raise ValueError(f"cannot flatten {spec!r}")
+
+
+def instantiations_from_json(json_path, op_name):
+    """Return the set of canonical type spellings listed for op_name under
+    the CPP api in kernels.json."""
+    with open(json_path) as f:
+        data = json.load(f)
+    for entry in data:
+        kt = entry.get("kernelTemplate", {})
+        if kt.get("opName") != op_name:
+            continue
+        for api in entry.get("api", []):
+            names = api.get("name", [])
+            if "CPP" not in names:
+                continue
+            result = set()
+            for inst in api.get("instantiations", []):
+                # Each `inst` is a list of template-arg specs (one per
+                # templateParams entry). For distributedPipeline that's a
+                # single DTRes -> so a one-element list.
+                types = [flatten_type(t) for t in inst]
+                result.add(", ".join(types))
+            return result
+    return None  # opName not found
+
+
+# Match `template void <opName><...>(`, capturing the template argument list.
+def instantiations_from_cpp(cpp_path, op_name):
+    """Return the set of canonical type spellings appearing in explicit
+    `template void <op_name><...>` instantiations in the given .cpp."""
+    text = Path(cpp_path).read_text()
+    # Strip C++ line comments and block comments before matching so that a
+    # comment that mentions the pattern (e.g. a doc line describing what
+    # explicit instantiations look like) is not misread as a real one.
+    text = re.sub(r"//[^\n]*", "", text)
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.DOTALL)
+    pattern = re.compile(
+        r"template\s+void\s+" + re.escape(op_name) + r"\s*<(.+?)>\s*\(",
+        re.DOTALL,
+    )
+    result = set()
+    for m in pattern.finditer(text):
+        # Normalize whitespace: collapse runs to single spaces.
+        canonical = re.sub(r"\s+", " ", m.group(1).strip())
+        result.add(canonical)
+    return result
+
+
+def main():
+    if len(sys.argv) != 2:
+        print(
+            f"usage: {sys.argv[0]} <path-to-kernels.json>",
+            file=sys.stderr,
+        )
+        return 2
+
+    json_path = Path(sys.argv[1])
+    here = Path(__file__).resolve().parent
+
+    all_ok = True
+    for op_name, cpp_rel in CHECKS:
+        cpp_path = here / cpp_rel
+        expected = instantiations_from_json(json_path, op_name)
+        if expected is None:
+            print(
+                f"error: kernels.json has no CPP api entry for opName "
+                f"'{op_name}'; either add one or remove this check.",
+                file=sys.stderr,
+            )
+            all_ok = False
+            continue
+        found = instantiations_from_cpp(cpp_path, op_name)
+
+        missing = expected - found
+        extra = found - expected
+        if missing or extra:
+            all_ok = False
+            print(
+                f"error: explicit-instantiation drift for '{op_name}' "
+                f"between kernels.json and {cpp_rel}:",
+                file=sys.stderr,
+            )
+            for t in sorted(missing):
+                print(
+                    f"  kernels.json lists '{op_name}<{t}>' but "
+                    f"{cpp_rel} does NOT explicitly instantiate it.",
+                    file=sys.stderr,
+                )
+                print(
+                    f"    fix: add `template void {op_name}<{t}>(...);` to "
+                    f"{cpp_rel}, matching the signature already there.",
+                    file=sys.stderr,
+                )
+            for t in sorted(extra):
+                print(
+                    f"  {cpp_rel} explicitly instantiates '{op_name}<{t}>' "
+                    f"but kernels.json does not list it.",
+                    file=sys.stderr,
+                )
+                print(
+                    f"    fix: either add the type to kernels.json under "
+                    f"'{op_name}', or drop the explicit instantiation.",
+                    file=sys.stderr,
+                )
+
+    return 0 if all_ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -60,6 +60,7 @@ set(TEST_SOURCES
         build/BuildHelpersTest.cpp
 
         codegen/CodegenTest.cpp
+        cse/CseTest.cpp
         api/cli/codegen/AggAllTest.cpp
         # api/cli/codegen/AggDimTest.cpp
         # api/cli/codegen/EwBinaryTest.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -57,6 +57,8 @@ set(TEST_SOURCES
 
         api/python/DaphneLibTest.cpp
 
+        build/BuildHelpersTest.cpp
+
         codegen/CodegenTest.cpp
         api/cli/codegen/AggAllTest.cpp
         # api/cli/codegen/AggDimTest.cpp

--- a/test/build/BuildHelpersTest.cpp
+++ b/test/build/BuildHelpersTest.cpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 The DAPHNE Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "run_tests.h"
+
+#include <tags.h>
+
+#include <cstdlib>
+#include <string>
+
+// Runs the shell test for build.sh's memory-detection helpers
+// (get_memory_gb, calc_daphne_jobs) so the tested path stays the
+// actual shell code, not a C++ port. Script self-contained; exits
+// non-zero on any failed assertion.
+TEST_CASE("build.sh memory-detection helpers", TAG_BUILD) {
+    const std::string cmd = "bash test/build/test_build_helpers.sh";
+    int rc = std::system(cmd.c_str());
+    CHECK(rc == 0);
+}

--- a/test/build/test_build_helpers.sh
+++ b/test/build/test_build_helpers.sh
@@ -1,0 +1,306 @@
+#!/bin/bash
+#
+# Shell-level unit tests for the memory-detection and JOBS-picking helpers
+# defined in build.sh: get_memory_gb() and calc_daphne_jobs().
+#
+# Why this file exists: those two functions have several code paths that
+# cannot be exercised by a real docker build (cgroup v1 sentinel, memory.max
+# = "max", missing /proc/meminfo, well-resourced host suppression). This
+# script mocks the filesystem inputs, runs each branch, and asserts the
+# expected output.
+#
+# Invoked via test/build/BuildHelpersTest.cpp as part of the run_tests
+# Catch2 suite ("./test.sh [build]"), and can also be run standalone:
+#
+#   bash test/build/test_build_helpers.sh
+#
+# Exits 0 on success, non-zero if any assertion fails.
+
+set -u
+
+# ---------------------------------------------------------------------------
+# Test framework (kept minimal; no external deps)
+# ---------------------------------------------------------------------------
+FAIL=0
+PASS=0
+
+assert_eq() {
+    # $1 = expected, $2 = actual, $3 = test name
+    if [ "$1" = "$2" ]; then
+        printf '  \033[32mPASS\033[0m  %s\n' "$3"
+        PASS=$((PASS + 1))
+    else
+        printf '  \033[31mFAIL\033[0m  %s\n        expected: %s\n        actual:   %s\n' \
+            "$3" "$1" "$2"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# get_memory_gb (mockable version)
+#
+# The version in build.sh reads absolute paths (/proc/self/cgroup,
+# /sys/fs/cgroup/..., /proc/meminfo) plus macOS sysctl. To exercise each
+# path deterministically we take a MOCK_ROOT prefix and read from
+# $MOCK_ROOT/proc/... and $MOCK_ROOT/sys/fs/cgroup/... instead. The
+# arithmetic and control flow are byte-for-byte the same as build.sh.
+# ---------------------------------------------------------------------------
+get_memory_gb_mocked() {
+    local mock="$1"
+    local mem_bytes=0
+    local os="${2:-Linux}"   # optional 2nd arg: "Darwin" to force macOS branch
+
+    if [ "$os" = "Darwin" ]; then
+        # For macOS we can't mock sysctl portably; only exercised on real
+        # Darwin hosts. This branch is a placeholder to document intent.
+        # The interesting branches for coverage are the Linux ones.
+        local raw="${MOCK_DARWIN_MEMSIZE:-0}"
+        if [[ "$raw" =~ ^[0-9]+$ ]] && [ "$raw" -gt 0 ]; then
+            echo $(( raw / 1024 / 1024 / 1024 ))
+        else
+            echo 4
+        fi
+        return
+    fi
+
+    # cgroup v2 walk
+    local cg_path
+    cg_path=$(awk -F: '/^0:/{print $3; exit}' "$mock/proc/self/cgroup" 2>/dev/null)
+    if [ -n "$cg_path" ]; then
+        local path="$cg_path" val min_limit=0 mem_max_file
+        while true; do
+            mem_max_file="$mock/sys/fs/cgroup${path}/memory.max"
+            if [ -r "$mem_max_file" ]; then
+                val=$(cat "$mem_max_file" 2>/dev/null)
+                if [ "$val" != "max" ] && [[ "$val" =~ ^[0-9]+$ ]]; then
+                    if [ "$min_limit" -eq 0 ] || [ "$val" -lt "$min_limit" ]; then
+                        min_limit="$val"
+                    fi
+                fi
+            fi
+            [ "$path" = "/" ] || [ -z "$path" ] && break
+            path=$(dirname "$path")
+            [ "$path" = "." ] && break
+        done
+        [ "$min_limit" -gt 0 ] && mem_bytes="$min_limit"
+    fi
+
+    # cgroup v1 fallback
+    if [ "$mem_bytes" -eq 0 ]; then
+        local v1="$mock/sys/fs/cgroup/memory/memory.limit_in_bytes"
+        if [ -r "$v1" ]; then
+            local v1val
+            v1val=$(cat "$v1" 2>/dev/null)
+            if [[ "$v1val" =~ ^[0-9]+$ ]] && [ "$v1val" -gt 0 ] && \
+               [ "$v1val" -lt 1125899906842624 ]; then
+                mem_bytes="$v1val"
+            fi
+        fi
+    fi
+
+    # /proc/meminfo fallback
+    if [ "$mem_bytes" -eq 0 ] && [ -r "$mock/proc/meminfo" ]; then
+        # Multiply outside awk (see build.sh): keeps large byte counts out of
+        # mawk's scientific-notation formatting so the guard below accepts them.
+        local mem_kb
+        mem_kb=$(awk '/^MemTotal:/{print $2; exit}' "$mock/proc/meminfo")
+        mem_kb="${mem_kb:-0}"
+        [[ "$mem_kb" =~ ^[0-9]+$ ]] && mem_bytes=$(( mem_kb * 1024 ))
+    fi
+
+    if ! [[ "$mem_bytes" =~ ^[0-9]+$ ]] || [ "$mem_bytes" -eq 0 ]; then
+        echo 4
+        return
+    fi
+    echo $(( mem_bytes / 1024 / 1024 / 1024 ))
+}
+
+# calc_daphne_jobs is pulled verbatim from build.sh (no filesystem reads,
+# just arithmetic). Parametrized by nproc.
+calc_daphne_jobs_mocked() {
+    local avail_gb=$1
+    local ncpu=$2
+    local usable=$(( avail_gb > 1 ? avail_gb - 1 : 1 ))
+    local cj=$(( usable / 2 ))
+    [ "$cj" -lt 1 ] && cj=1
+    [ "$cj" -gt "$ncpu" ] && cj=$ncpu
+    local kj=$cj
+    echo "$cj $kj"
+}
+
+# ---------------------------------------------------------------------------
+# Helper: build a mock filesystem tree from a fixture spec
+# ---------------------------------------------------------------------------
+make_mock_root() {
+    local root
+    root=$(mktemp -d)
+    mkdir -p "$root/proc/self" "$root/sys/fs/cgroup"
+    echo "$root"
+}
+
+# ---------------------------------------------------------------------------
+# get_memory_gb tests
+# ---------------------------------------------------------------------------
+printf '\n== get_memory_gb ==\n'
+
+# --- v2, single limit at container path ---
+r=$(make_mock_root)
+mkdir -p "$r/sys/fs/cgroup/docker/abcd"
+printf '0::/docker/abcd\n'                 > "$r/proc/self/cgroup"
+printf '8589934592'                         > "$r/sys/fs/cgroup/docker/abcd/memory.max"   # 8 GiB
+printf 'max'                                > "$r/sys/fs/cgroup/memory.max" 2>/dev/null   # root
+assert_eq "8" "$(get_memory_gb_mocked "$r")" "v2: container 8g limit"
+rm -rf "$r"
+
+# --- v2, memory.max == "max" everywhere; falls to meminfo ---
+r=$(make_mock_root)
+mkdir -p "$r/sys/fs/cgroup/docker/xyz"
+printf '0::/docker/xyz\n'                   > "$r/proc/self/cgroup"
+printf 'max'                                > "$r/sys/fs/cgroup/docker/xyz/memory.max"
+printf 'max'                                > "$r/sys/fs/cgroup/memory.max"
+# meminfo says 16 GiB
+printf 'MemTotal:       16777216 kB\n'      > "$r/proc/meminfo"
+assert_eq "16" "$(get_memory_gb_mocked "$r")" "v2: all max, fall through to meminfo 16g"
+rm -rf "$r"
+
+# --- v2, tighter limit in PARENT than in leaf: min-of-chain wins ---
+r=$(make_mock_root)
+mkdir -p "$r/sys/fs/cgroup/parent-slice/leaf"
+printf '0::/parent-slice/leaf\n'            > "$r/proc/self/cgroup"
+printf '8589934592'                         > "$r/sys/fs/cgroup/parent-slice/leaf/memory.max"   # 8 GiB
+printf '4294967296'                         > "$r/sys/fs/cgroup/parent-slice/memory.max"        # 4 GiB (tighter)
+printf 'max'                                > "$r/sys/fs/cgroup/memory.max"
+assert_eq "4" "$(get_memory_gb_mocked "$r")" "v2: walks up, picks tighter parent 4g"
+rm -rf "$r"
+
+# --- v1: sentinel value ~unlimited (9223372036854771712 bytes ≈ 8 EiB) → rejected, fall to meminfo ---
+r=$(make_mock_root)
+printf ''                                   > "$r/proc/self/cgroup"           # v2 absent
+mkdir -p "$r/sys/fs/cgroup/memory"
+printf '9223372036854771712'                > "$r/sys/fs/cgroup/memory/memory.limit_in_bytes"   # v1 unlimited sentinel
+printf 'MemTotal:       8388608 kB\n'       > "$r/proc/meminfo"               # 8 GiB fallback
+assert_eq "8" "$(get_memory_gb_mocked "$r")" "v1: sentinel rejected, meminfo 8g wins"
+rm -rf "$r"
+
+# --- v1: real limit 4 GiB ---
+r=$(make_mock_root)
+printf ''                                   > "$r/proc/self/cgroup"
+mkdir -p "$r/sys/fs/cgroup/memory"
+printf '4294967296'                         > "$r/sys/fs/cgroup/memory/memory.limit_in_bytes"   # 4 GiB
+printf 'MemTotal:       16777216 kB\n'      > "$r/proc/meminfo"               # 16g (should be ignored)
+assert_eq "4" "$(get_memory_gb_mocked "$r")" "v1: real 4g limit beats meminfo 16g"
+rm -rf "$r"
+
+# --- meminfo only ---
+r=$(make_mock_root)
+printf ''                                   > "$r/proc/self/cgroup"
+# no v1 file
+printf 'MemTotal:       33554432 kB\n'      > "$r/proc/meminfo"   # 32 GiB
+assert_eq "32" "$(get_memory_gb_mocked "$r")" "meminfo 32g bare host"
+rm -rf "$r"
+
+# --- meminfo on a big host: bytes exceed 2^31, must not be lost to awk's ---
+# --- scientific notation (would report 4g if multiplied inside awk on mawk) ---
+r=$(make_mock_root)
+printf ''                                   > "$r/proc/self/cgroup"
+printf 'MemTotal:       134217728 kB\n'     > "$r/proc/meminfo"   # 128 GiB
+assert_eq "128" "$(get_memory_gb_mocked "$r")" "meminfo 128g host, no sci-notation loss"
+rm -rf "$r"
+
+# --- nothing readable → fallback 4 ---
+r=$(make_mock_root)
+# leave everything empty / missing
+assert_eq "4" "$(get_memory_gb_mocked "$r")" "no source available, fallback 4"
+rm -rf "$r"
+
+# --- malformed memory.max content is ignored (should not crash, should fall through) ---
+r=$(make_mock_root)
+mkdir -p "$r/sys/fs/cgroup/docker/abc"
+printf '0::/docker/abc\n'                   > "$r/proc/self/cgroup"
+printf 'not-a-number\n'                     > "$r/sys/fs/cgroup/docker/abc/memory.max"
+printf 'MemTotal:       8388608 kB\n'       > "$r/proc/meminfo"
+assert_eq "8" "$(get_memory_gb_mocked "$r")" "malformed memory.max ignored, meminfo 8g"
+rm -rf "$r"
+
+# --- v2 present at path but file empty ---
+r=$(make_mock_root)
+mkdir -p "$r/sys/fs/cgroup/docker/def"
+printf '0::/docker/def\n'                   > "$r/proc/self/cgroup"
+printf ''                                   > "$r/sys/fs/cgroup/docker/def/memory.max"   # empty
+printf 'MemTotal:       4194304 kB\n'       > "$r/proc/meminfo"
+assert_eq "4" "$(get_memory_gb_mocked "$r")" "empty memory.max falls through, meminfo 4g"
+rm -rf "$r"
+
+# ---------------------------------------------------------------------------
+# calc_daphne_jobs tests
+# ---------------------------------------------------------------------------
+printf '\n== calc_daphne_jobs (nproc=12) ==\n'
+
+# Standard table with 12-core host (nproc doesn't clip anything under 26 GB)
+declare -a cases_12=(
+    "1 1 1"
+    "2 1 1"
+    "3 1 1"
+    "4 1 1"
+    "5 2 2"
+    "6 2 2"
+    "7 3 3"
+    "8 3 3"
+    "12 5 5"
+    "16 7 7"
+    "26 12 12"    # 12 == nproc, no clamp yet
+    "32 12 12"    # clamp at nproc
+    "64 12 12"    # deep clamp at nproc
+)
+for row in "${cases_12[@]}"; do
+    read -r gb ecj ekj <<<"$row"
+    read -r cj kj <<<"$(calc_daphne_jobs_mocked "$gb" 12)"
+    assert_eq "${ecj} ${ekj}" "${cj} ${kj}" "gb=${gb} nproc=12 → ${ecj}/${ekj}"
+done
+
+printf '\n== calc_daphne_jobs (nproc=1): tiny host clamp ==\n'
+# On a 1-CPU host we can never exceed nproc=1 regardless of RAM.
+for row in "1 1 1" "4 1 1" "8 1 1" "32 1 1"; do
+    read -r gb ecj ekj <<<"$row"
+    read -r cj kj <<<"$(calc_daphne_jobs_mocked "$gb" 1)"
+    assert_eq "${ecj} ${ekj}" "${cj} ${kj}" "gb=${gb} nproc=1 → clamp to 1"
+done
+
+printf '\n== calc_daphne_jobs (nproc=4): modest host clamp ==\n'
+# 4-CPU host clamps at 4 for anything ≥ 10 GB.
+declare -a cases_4=(
+    "1 1 1"
+    "4 1 1"
+    "6 2 2"
+    "8 3 3"
+    "10 4 4"      # clamp begins
+    "16 4 4"      # deep clamp
+    "64 4 4"
+)
+for row in "${cases_4[@]}"; do
+    read -r gb ecj ekj <<<"$row"
+    read -r cj kj <<<"$(calc_daphne_jobs_mocked "$gb" 4)"
+    assert_eq "${ecj} ${ekj}" "${cj} ${kj}" "gb=${gb} nproc=4 → ${ecj}/${ekj}"
+done
+
+# ---------------------------------------------------------------------------
+# Cross-check: the well-resourced host suppression condition
+# ---------------------------------------------------------------------------
+# In build.sh the auto-detect banner prints ONLY when auto_cj < nproc.
+# Verify that for hosts where 2×nproc GB of RAM is present, auto_cj == nproc
+# (suppression fires) so we don't spam the message on beefy hosts.
+printf '\n== well-resourced-host suppression ==\n'
+for nproc in 1 2 4 8 12 16; do
+    # 2*nproc + 1 GB should give cj = nproc exactly
+    gb=$(( 2 * nproc + 1 ))
+    read -r cj _kj <<<"$(calc_daphne_jobs_mocked "$gb" "$nproc")"
+    assert_eq "$nproc" "$cj" "gb=${gb} nproc=${nproc}: cj hits nproc (no banner)"
+done
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+printf '\n== summary ==\n'
+printf '  pass: %d\n' "$PASS"
+printf '  fail: %d\n' "$FAIL"
+exit "$FAIL"

--- a/test/codegen/purity_cse_syrk.mlir
+++ b/test/codegen/purity_cse_syrk.mlir
@@ -1,0 +1,16 @@
+// RUN: daphne-opt --cse %s | FileCheck %s
+
+module {
+  // Two identical syrk ops on the same operand. Now that syrk is Pure, CSE
+  // folds them into one; without the trait CSE skips it and both survive.
+  func.func @dup_syrk(%a: !daphne.Matrix<8x4xf64>) -> !daphne.Matrix<4x4xf64> {
+    %t = "daphne.constant"() {value = true} : () -> i1
+    %0 = "daphne.syrk"(%a, %t) : (!daphne.Matrix<8x4xf64>, i1) -> !daphne.Matrix<4x4xf64>
+    %1 = "daphne.syrk"(%a, %t) : (!daphne.Matrix<8x4xf64>, i1) -> !daphne.Matrix<4x4xf64>
+    %r = "daphne.ewAdd"(%0, %1) : (!daphne.Matrix<4x4xf64>, !daphne.Matrix<4x4xf64>) -> !daphne.Matrix<4x4xf64>
+    return %r : !daphne.Matrix<4x4xf64>
+    // CHECK-LABEL: func.func @dup_syrk
+    // CHECK: "daphne.syrk"
+    // CHECK-NOT: "daphne.syrk"
+  }
+}

--- a/test/cse/CseTest.cpp
+++ b/test/cse/CseTest.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 The DAPHNE Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "run_tests.h"
+
+#include "api/cli/StatusCode.h"
+#include "api/cli/Utils.h"
+
+#include <tags.h>
+
+const std::string dirPath = "test/cse/";
+
+// Place all test files with FileCheck directives in the dirPath.
+// LIT will test all *.mlir files in the directory.
+TEST_CASE("cse", TAG_CSE) {
+    std::stringstream out;
+    std::stringstream err;
+
+    int status = runLIT(out, err, dirPath);
+
+    if (status != StatusCode::SUCCESS) {
+        std::cout << "runLIT return status: " << std::to_string(status) << "\n";
+        std::cout << "runLIT out:\n" << out.str() << "\n";
+        std::cout << "runLIT err:\n" << err.str() << "\n";
+    }
+
+    CHECK(status == StatusCode::SUCCESS);
+}

--- a/test/cse/lit.cfg
+++ b/test/cse/lit.cfg
@@ -1,0 +1,17 @@
+import lit.formats
+import os
+
+config.name = "DAPHNE LIT config"
+config.test_format = lit.formats.ShTest(True)
+
+config.suffixes = [".mlir"]
+
+config.test_source_root = os.path.dirname(__file__)
+
+config.environment["PATH"] = os.path.pathsep.join(
+    (
+        os.path.abspath("bin/"),
+        os.path.abspath("thirdparty/build/llvm-project/bin/"),
+        config.environment["PATH"],
+    )
+)

--- a/test/cse/pure_cse.mlir
+++ b/test/cse/pure_cse.mlir
@@ -1,0 +1,22 @@
+// RUN: daphne-opt --cse %s | FileCheck %s
+
+// COM: Two identical transpose ops on the same operand must collapse to one under CSE.
+// COM: This relies on transpose being marked Pure; CSE skips ops with side effects.
+
+module {
+  func.func @duplicate_transpose() {
+    %0 = "daphne.constant"() {value = 2 : index} : () -> index
+    %1 = "daphne.constant"() {value = 3 : index} : () -> index
+    %2 = "daphne.constant"() {value = false} : () -> i1
+    %3 = "daphne.constant"() {value = true} : () -> i1
+    %4 = "daphne.constant"() {value = 1.000000e+00 : f64} : () -> f64
+    %5 = "daphne.fill"(%4, %1, %0) : (f64, index, index) -> !daphne.Matrix<3x2xf64>
+    // CHECK-COUNT-1: daphne.transpose
+    // CHECK-NOT: daphne.transpose
+    %6 = "daphne.transpose"(%5) : (!daphne.Matrix<3x2xf64>) -> !daphne.Matrix<2x3xf64>
+    %7 = "daphne.transpose"(%5) : (!daphne.Matrix<3x2xf64>) -> !daphne.Matrix<2x3xf64>
+    "daphne.print"(%6, %3, %2) : (!daphne.Matrix<2x3xf64>, i1, i1) -> ()
+    "daphne.print"(%7, %3, %2) : (!daphne.Matrix<2x3xf64>, i1, i1) -> ()
+    "daphne.return"() : () -> ()
+  }
+}

--- a/test/cse/run-lit.py
+++ b/test/cse/run-lit.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python
+
+from lit.main import main
+main()

--- a/test/tags.h
+++ b/test/tags.h
@@ -28,6 +28,7 @@
 #define TAG_CODEGEN "[codegen]"
 #define TAG_CONFIG "[config]"
 #define TAG_CONTROLFLOW "[controlflow]"
+#define TAG_CSE "[cse]"
 #define TAG_DAPHNELIB "[daphnelib]"
 #define TAG_DATASTRUCTURES "[datastructures]"
 #define TAG_DISTRIBUTED "[distributed]"

--- a/test/tags.h
+++ b/test/tags.h
@@ -23,6 +23,7 @@
 // "[b]", then TAG_A TAG_B is "[a]" "[b]", which is equivalent to "[a][b]".
 
 #define TAG_ALGORITHMS "[algorithms]"
+#define TAG_BUILD "[build]"
 #define TAG_CAST "[cast]"
 #define TAG_CODEGEN "[codegen]"
 #define TAG_CONFIG "[config]"


### PR DESCRIPTION
Foundation for #512. This PR doesn't add any algebraic rewrites, it makes MLIR's purity traits and CSE apply to DaphneIR, so those rewrites can compose correctly later.

The four PRs:

1. #1013 (this PR); purity traits, plus retiring the CSE workaround.
2. #1014; the `ScalarConstantFoldable` interface and the algebraic-trait vocabulary; moving existing rewrites onto it and adding new trait-based rewrites.
3. #1015; fail-closed property accessors, symmetric inference for matrix products, and the transpose elision it unlocks.
4. #1016; the linear-algebra rewrites: the trace idiom, diagonal scaling, pulling a scalar out of a sum, dropping length-1 aggregates, repeated-add-to-multiply, and combining shifted matrices.

## What changed

### Attach `Pure` to ~150 ops

`Pure` expands to `TraitList<[AlwaysSpeculatable, NoMemoryEffect]>`. Without `NoMemoryEffect`, CSE's `simplifyOperation` bails out and the op is never a candidate for elimination. Annotated seven base classes in `DaphneOps.td` (aggregations, group-aggregations, outer-binary, bind, activation-forward, pool-forward, the five columnar bases) plus thirteen individual ops: `SyrkOp`, `GemvOp`, `SolveOp`, `DiagMatrixOp`, `EigenOp`, `ReshapeOp`, `ReverseOp`, `OrderOp`, `SoftmaxOp`, `Conv2DForwardOp`, `TypeOfOp`, `SparsityOp`, `IsSymmetricOp`.

### Retire the 5×CSE loop in `DaphneIrExecutor.cpp`

The columnar branch ran CSE five times behind a TODO that said "CSE seems to eliminate only one row of dead code at a time... how to apply CSE until a fixpoint?" The observation was real: CSE defers dead-op erasure to the end of its walk and never revisits an op, so a dead chain of length N needs N passes to fully collapse. It's now a single `createCSEPass()`, because the canonicalizer that runs right before CSE already drives DCE to a fixpoint (its greedy driver erases dead ops immediately and re-queues their operands), so the dead chains are gone before CSE runs. Confirmed empirically: full suite byte-identical at `i < 5` vs `i < 1`, and `numDCE == 0` on every CSE run.

### Seed CSE in `buildCodegenPipeline`

Two nested-FuncOp CSE passes: 
- one after `LinalgElementwiseOpFusionPass` (fusion often exposes duplicate memref/tensor ops)
- one after the post-sparsification canonicalize. 
Both sit behind `use_mlir_codegen` / `use_mlir_hybrid_codegen`, so non-MLIR-codegen pipelines are untouched.

## Verification

`daphne-opt --cse` on IR with two identical `daphne.sumAll` calls on the same operand deduplicates them (`num-cse'd` 0 → 2). End-to-end, `sum(X) + sum(X)` with `X = fill(1.0, 4, 3)` shows two `daphne.sumAll` under `--explain parsing` and one under `--explain parsing_simplified`.

`test/codegen/purity_cse_syrk.mlir` runs `daphne-opt --cse` on two identical `syrk` ops and checks that only one survives. A case that depends on the new tag, since on the pre-`Pure` build both survive and the test fails.

Full suite via a small wrapper that filters two pre-existing aarch64-only crashes (#1011, #1012, neither of which reproduces on x86_64 CI): 2431 matched, 2318 passed, 113 failed. Byte-identical before and after this PR.

## Out of scope

Kept impure by design: `IncRefOp` / `DecRefOp` (ref counting; CSE must not delete them; see `DaphneIrExecutor.cpp:225-231`), `RandMatrixOp` / `SampleOp` / `NowOp` (non-deterministic), `VectorizedPipelineOp` (regional effects, TODO at `DaphneOps.td:1907`). Also skipped: `QrOp` / `SvdOp` (no kernel or lowering yet) and `EwAddOp` `Commutative` restoration (#449 / #351).

## On the commit range

This PR is stacked on #1010 (the kernel-compile OOM fix). #1010's branch lives on my fork and can't be a PR base upstream, so the first six commits here duplicate #1010's contents. Once #1010 merges I'll rebase and force-push; the duplicated commits drop out, leaving only the purity + CSE commits.

Refs #512.

